### PR TITLE
Fix/various axios interceptor bugs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     sourceType: 'module', // Allows for the use of imports
   },
   rules: {
-    '@typescript-eslint/interface-name-prefix': 'always',
+    '@typescript-eslint/interface-name-prefix': 'never',
     '@typescript-eslint/no-explicit-any': 'always',
     '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
     '@typescript-eslint/interface-name-prefix': ['error', 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     sourceType: 'module', // Allows for the use of imports
   },
   rules: {
-    '@typescript-eslint/interface-name-prefix': 'never',
+    '@typescript-eslint/interface-name-prefix': 'always',
     '@typescript-eslint/no-explicit-any': 'always',
     '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
     '@typescript-eslint/interface-name-prefix': ['error', 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,10 +10,8 @@ module.exports = {
     sourceType: 'module', // Allows for the use of imports
   },
   rules: {
-    '@typescript-eslint/interface-name-prefix': 'always',
     '@typescript-eslint/no-explicit-any': 'always',
     '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
-    '@typescript-eslint/interface-name-prefix': ['error', 'always'],
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/prefer-interface': 'off',

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
 
 import { legacyGetMapFromUrl, legacyGetMapWmsUrlFromParams, legacyGetMapFromParams } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
+import { registerAxiosCacheRetryInterceptors } from './utils/axiosInterceptors';
+
+registerAxiosCacheRetryInterceptors();
 
 export {
   LayersFactory,

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { GetMapParams, ApiType, PaginatedTiles } from 'src/layer/const';
 import { BBox } from 'src/bbox';
 import { Dataset } from 'src/layer/dataset';
-import { IRequestConfig } from 'src/utils/axiosInterceptors';
+import { RequestConfig } from 'src/utils/axiosInterceptors';
 
 export class AbstractLayer {
   public title: string | null = null;
@@ -20,7 +20,7 @@ export class AbstractLayer {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
-        const requestConfig: IRequestConfig = { responseType: 'blob', useCache: true };
+        const requestConfig: RequestConfig = { responseType: 'blob', useCache: true };
         const response = await axios.get(url, requestConfig);
         return response.data;
       default:

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { GetMapParams, ApiType, PaginatedTiles } from 'src/layer/const';
 import { BBox } from 'src/bbox';
 import { Dataset } from 'src/layer/dataset';
+import { IRequestConfig } from 'src/utils/axiosInterceptors';
 
 export class AbstractLayer {
   public title: string | null = null;
@@ -19,7 +20,8 @@ export class AbstractLayer {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
-        const response = await axios.get(url, { responseType: 'blob' });
+        const requestConfig: IRequestConfig = { responseType: 'blob', useCache: true };
+        const response = await axios.get(url, requestConfig);
         return response.data;
       default:
         const className = this.constructor.name;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -4,6 +4,7 @@ import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 import { getAuthToken } from 'src/auth';
 import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
+import { RequestConfig } from 'src/utils/axiosInterceptors';
 
 enum PreviewMode {
   DETAIL = 'DETAIL',
@@ -15,7 +16,6 @@ enum MosaickingOrder {
   LEAST_RECENT = 'leastRecent',
   LEAST_CC = 'leastCC',
 }
-
 export type ProcessingPayload = {
   input: {
     bounds: {
@@ -156,18 +156,16 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
   }
-
-  const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, {
+  const requestConfig: RequestConfig = {
     headers: {
       Authorization: 'Bearer ' + authToken,
       'Content-Type': 'application/json',
       Accept: '*/*',
     },
     responseType: 'blob',
-    params: {
-      useCache: true,
-      retries: 5,
-    },
-  });
+    useCache: true,
+    retries: 5,
+  };
+  const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;
 }

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -164,7 +164,6 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
     },
     responseType: 'blob',
     useCache: true,
-    retries: 5,
   };
   const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -4,7 +4,7 @@ import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 import { getAuthToken } from 'src/auth';
 import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-import { IRequestConfig } from 'src/utils/axiosInterceptors';
+import { RequestConfig } from 'src/utils/axiosInterceptors';
 
 enum PreviewMode {
   DETAIL = 'DETAIL',
@@ -156,7 +156,7 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
   }
-  const requestConfig: IRequestConfig = {
+  const requestConfig: RequestConfig = {
     headers: {
       Authorization: 'Bearer ' + authToken,
       'Content-Type': 'application/json',

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -4,7 +4,7 @@ import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 import { getAuthToken } from 'src/auth';
 import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-import { RequestConfig } from 'src/utils/axiosInterceptors';
+import { IRequestConfig } from 'src/utils/axiosInterceptors';
 
 enum PreviewMode {
   DETAIL = 'DETAIL',
@@ -156,7 +156,7 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
   }
-  const requestConfig: RequestConfig = {
+  const requestConfig: IRequestConfig = {
     headers: {
       Authorization: 'Bearer ' + authToken,
       'Content-Type': 'application/json',

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -89,7 +89,7 @@ const setCacheResponse = async (response: any): Promise<any> => {
 
     let cacheKey;
     if (response.config.method === 'get') {
-      cacheKey = generateCacheKey(response.config.url, stringify(response.config));
+      cacheKey = generateCacheKey(response.config.url, stringify(response.config.params));
     }
     if (response.config.method === 'post') {
       const body = response.config.data;

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -47,38 +47,37 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
   }
 
   const cachedResponse = await cache.match(cacheKey);
-  if (!hasCachedResponseExpired(cachedResponse)) {
+  if (!cachedResponse || !hasCachedResponseExpired(cachedResponse)) {
     return request;
   }
-  if (cachedResponse) {
-    request.adapter = async () => {
-      // response from cache api follows the same structure as the fetch api, hence this hack
-      // could be better if the caller handles the response (response.blob) instead of the caching function?
-      let responseData;
-      switch (request.responseType) {
-        case 'blob':
-          responseData = await cachedResponse.blob();
-          break;
-        case 'text':
-          responseData = await cachedResponse.text();
-          break;
-        case 'json':
-        case undefined:
-          responseData = await cachedResponse.json();
-          break;
-        default:
-          throw new Error('Unsupported response type: ' + request.responseType);
-      }
 
-      return Promise.resolve({
-        data: responseData,
-        headers: request.headers,
-        request: request,
-        config: request,
-        responseType: request.responseType,
-      });
-    };
-  }
+  request.adapter = async () => {
+    // response from cache api follows the same structure as the fetch api, hence this hack
+    // could be better if the caller handles the response (response.blob) instead of the caching function?
+    let responseData;
+    switch (request.responseType) {
+      case 'blob':
+        responseData = await cachedResponse.blob();
+        break;
+      case 'text':
+        responseData = await cachedResponse.text();
+        break;
+      case 'json':
+      case undefined:
+        responseData = await cachedResponse.json();
+        break;
+      default:
+        throw new Error('Unsupported response type: ' + request.responseType);
+    }
+
+    return Promise.resolve({
+      data: responseData,
+      headers: request.headers,
+      request: request,
+      config: request,
+      responseType: request.responseType,
+    });
+  };
 
   return request;
 };

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -1,7 +1,12 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 
 const SENTINEL_HUB_CACHE = 'sentinelhub-v1';
+const DELAY = 3000;
+export interface RequestConfig extends AxiosRequestConfig {
+  useCache?: boolean;
+  retries?: number;
+}
 
 export const registerAxiosCacheRetryInterceptors = (): any => {
   axios.interceptors.request.use(fetchCachedResponse, error => Promise.reject(error));
@@ -9,7 +14,7 @@ export const registerAxiosCacheRetryInterceptors = (): any => {
 };
 
 const fetchCachedResponse = async (request: any): Promise<any> => {
-  if (!(request.params && request.params.useCache)) {
+  if (!(request && request.useCache)) {
     return request;
   }
 
@@ -72,7 +77,7 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
 };
 
 const setCacheResponse = async (response: any): Promise<any> => {
-  if (response.config.params && response.config.params.useCache) {
+  if (response.config && response.config.useCache) {
     let cache;
     try {
       cache = await caches.open(SENTINEL_HUB_CACHE);
@@ -83,7 +88,7 @@ const setCacheResponse = async (response: any): Promise<any> => {
 
     let cacheKey;
     if (response.config.method === 'get') {
-      cacheKey = generateCacheKey(response.config.url, stringify(response.config.params));
+      cacheKey = generateCacheKey(response.config.url, stringify(response.config));
     }
     if (response.config.method === 'post') {
       const body = response.config.data;

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -4,7 +4,7 @@ import { stringify } from 'query-string';
 const SENTINEL_HUB_CACHE = 'sentinelhub-v1';
 const DELAY = 3000;
 const RETRIES = 5;
-export interface RequestConfig extends AxiosRequestConfig {
+export interface IRequestConfig extends AxiosRequestConfig {
   useCache?: boolean;
   retries?: number;
 }

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -156,7 +156,7 @@ const sha256 = async (message: any): Promise<any> => {
 
 const shouldRetry = (errorStatus: number): boolean => errorStatus >= 500 && errorStatus <= 599;
 
-const hasCachedResponseExpired = (response: Response) : boolean => {
+const hasCachedResponseExpired = (response: Response): boolean => {
   if (!response) {
     return true;
   }
@@ -165,7 +165,7 @@ const hasCachedResponseExpired = (response: Response) : boolean => {
   return expirationDate < now.getTime();
 };
 
-const findAndDeleteExpiredCachedItems = async () : Promise<void> => {
+const findAndDeleteExpiredCachedItems = async (): Promise<void> => {
   const cache = await caches.open(SENTINEL_HUB_CACHE);
   const cacheKeys = await cache.keys();
   cacheKeys.forEach(async key => {

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -95,11 +95,10 @@ const setCacheResponse = async (response: any): Promise<any> => {
 
     let cacheKey;
 
-    const expires = new Date();
-    expires.setSeconds(expires.getSeconds() + EXPIRES_IN_SECONDS);
+    const expiresMs = new Date().getTime() + EXPIRES_IN_SECONDS * 1000;
     response.headers = {
       ...response.headers,
-      [EXPIRY_HEADER_KEY]: expires.getTime(),
+      [EXPIRY_HEADER_KEY]: expiresMs,
     };
 
     if (response.config.method === 'get') {

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -47,10 +47,10 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
   }
 
   const cachedResponse = await cache.match(cacheKey);
+  if (!hasCachedResponseExpired(cachedResponse)) {
+    return request;
+  }
   if (cachedResponse) {
-    if (!hasCachedResponseExpired(cachedResponse)) {
-      return request;
-    }
     request.adapter = async () => {
       // response from cache api follows the same structure as the fetch api, hence this hack
       // could be better if the caller handles the response (response.blob) instead of the caching function?

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -6,7 +6,7 @@ const EXPIRY_HEADER_KEY = 'Cache_Expires';
 const EXPIRES_IN_SECONDS = 60 * 30;
 const DELAY = 3000;
 const RETRIES = 5;
-export interface IRequestConfig extends AxiosRequestConfig {
+export interface RequestConfig extends AxiosRequestConfig {
   useCache?: boolean;
   retries?: number;
 }

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -156,7 +156,7 @@ const sha256 = async (message: any): Promise<any> => {
 
 const shouldRetry = (errorStatus: number): boolean => errorStatus >= 500 && errorStatus <= 599;
 
-const hasCachedResponseExpired = (response: Response) => {
+const hasCachedResponseExpired = (response: Response) : boolean => {
   if (!response) {
     return true;
   }
@@ -165,7 +165,7 @@ const hasCachedResponseExpired = (response: Response) => {
   return expirationDate < now.getTime();
 };
 
-const findAndDeleteExpiredCachedItems = async () => {
+const findAndDeleteExpiredCachedItems = async () : Promise<void> => {
   const cache = await caches.open(SENTINEL_HUB_CACHE);
   const cacheKeys = await cache.keys();
   cacheKeys.forEach(async key => {


### PR DESCRIPTION
* remove `useCache` and `retries` from `request.config.params` and add `useCache` to `request.config`
* retries are now triggered depending on the error status (5xx)
* remove logging error when retries were exceeded
* add support for setting expiry on cache, and cleanup on library load
