### PR TITLE
Fix/cloud cover percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ We can always use layer to search for data availability:
   import { OrbitDirection } from 'sentinelhub-js';
 
   const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A');
-  const cloudCoveragePercent = 50;
-  const tilesS2L2A = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset, cloudCoverage);
+  const maxCloudCoverPercent = 50;
+  const tilesS2L2A = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset, maxCloudCoverPercent);
   const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(tilesS2L2A.tiles);
 
   const layerS1 = new S1GRDAWSEULayer(instanceId, 'LayerS1GRD');
@@ -149,7 +149,7 @@ We can always use layer to search for data availability:
   const tilesS1 = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset, orbitDirection);
   const flyoverIntervalsS1 = layerS1.findFlyoverIntervals(tilesS1.tiles);
 
-  const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate, cloudCoverage);
+  const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate, maxCloudCoverPercent);
 ```
 
 ## Backwards compatibility

--- a/README.md
+++ b/README.md
@@ -139,17 +139,19 @@ We can always use layer to search for data availability:
 ```typescript
   import { OrbitDirection } from 'sentinelhub-js';
 
-  const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A');
   const maxCloudCoverPercent = 50;
-  const tilesS2L2A = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset, maxCloudCoverPercent);
+  const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A', null, null, null, null, null, maxCloudCoverPercent);
+  const tilesS2L2A = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset);
   const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(tilesS2L2A.tiles);
+  const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate);
 
-  const layerS1 = new S1GRDAWSEULayer(instanceId, 'LayerS1GRD');
-  const orbitDirection = OrbitDirection.ASCENDING;
-  const tilesS1 = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset, orbitDirection);
+  const layerS1 = new S1GRDAWSEULayer(
+    instanceId, 'LayerS1GRD',
+    null, null, null, null, null, null, null, null,
+    true, BackscatterCoeff.GAMMA0_ELLIPSOID, OrbitDirection.ASCENDING
+  );
+  const tilesS1 = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset);
   const flyoverIntervalsS1 = layerS1.findFlyoverIntervals(tilesS1.tiles);
-
-  const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate, maxCloudCoverPercent);
 ```
 
 ## Backwards compatibility

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -37,6 +37,10 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     return this.dataset.shWmsEvalsource;
   }
 
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {};
+  }
+
   public getMapUrl(params: GetMapParams, api: ApiType): string {
     if (api !== ApiType.WMS) {
       throw new Error('Only WMS is supported on this layer');
@@ -49,6 +53,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       this.evalscript,
       this.evalscriptUrl,
       this.getEvalsource(),
+      this.getWmsGetMapUrlAdditionalParameters(),
     );
   }
 

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -52,7 +52,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     );
   }
 
-  protected getFindTilesAdditionalParameters(): Record<string, string> {
+  protected getFindTilesAdditionalParameters(): Record<string, any> {
     return {};
   }
 
@@ -108,24 +108,5 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       })),
       hasMore: response.data.hasMore,
     };
-  }
-
-  // This helper method is called by LayersFactory.makeLayers(). It constructs
-  // a layer based on layerInfo and other parameters. Subclasses can override it
-  // to use different constructor parameters based on layerInfo.
-  //
-  // A bit of TypeScript magic: since we want to construct a child class from the static
-  // method, we use the method outlined here: https://stackoverflow.com/a/51749145/593487
-  public static makeLayer<ChildLayer extends typeof AbstractSentinelHubV1OrV2Layer>(
-    this: ChildLayer,
-    layerInfo: any, // eslint-disable-line @typescript-eslint/no-unused-vars
-    instanceId: string,
-    layerId: string,
-    evalscript: string | null,
-    evalscriptUrl: string | null,
-    title: string | null,
-    description: string | null,
-  ): AbstractSentinelHubV1OrV2Layer {
-    return new this(instanceId, layerId, evalscript, evalscriptUrl, title, description);
   }
 }

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,5 +1,4 @@
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AbstractLayer } from 'src/layer/AbstractLayer';
 
 // same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
 export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {
@@ -35,32 +34,5 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     return {
       cloudCoverPercent: tile.cloudCoverPercent,
     };
-  }
-
-  // This helper method is called by LayersFactory.makeLayers(). It constructs
-  // a layer based on layerInfo and other parameters. Subclasses can override it
-  // to use different constructor parameters based on layerInfo.
-  //
-  // A bit of TypeScript magic: since we want to construct a child class from the static
-  // method, we use the method outlined here: https://stackoverflow.com/a/51749145/593487
-  public static makeLayer<ChildLayer extends typeof AbstractSentinelHubV1OrV2WithCCLayer>(
-    this: ChildLayer,
-    layerInfo: any, // eslint-disable-line @typescript-eslint/no-unused-vars
-    instanceId: string,
-    layerId: string,
-    evalscript: string | null,
-    evalscriptUrl: string | null,
-    title: string | null,
-    description: string | null,
-  ): AbstractLayer {
-    return new this(
-      instanceId,
-      layerId,
-      evalscript,
-      evalscriptUrl,
-      title,
-      description,
-      layerInfo.settings.maxCC,
-    );
   }
 }

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,0 +1,61 @@
+import { GetMapParams, ApiType } from 'src/layer/const';
+import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { AbstractLayer } from './AbstractLayer';
+
+// same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
+export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {
+  protected maxCloudCoverPercent: number;
+
+  public constructor(
+    instanceId: string,
+    layerId: string,
+    evalscript: string | null = null,
+    evalscriptUrl: string | null = null,
+    title: string | null = null,
+    description: string | null = null,
+    maxCloudCoverPercent: number | null = 100,
+  ) {
+    super(instanceId, layerId, evalscript, evalscriptUrl, title, description);
+    this.maxCloudCoverPercent = maxCloudCoverPercent;
+  }
+
+  public getMapUrl(params: GetMapParams, api: ApiType): string {
+    const getMapParams: GetMapParams = {
+      maxCloudCoverPercent: this.maxCloudCoverPercent,
+      ...params,
+    };
+    return super.getMapUrl(getMapParams, api);
+  }
+
+  protected getFindTilesAdditionalParameters(): Record<string, any> {
+    return {
+      maxcc: this.maxCloudCoverPercent / 100,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercent,
+    };
+  }
+
+  // This helper method is called by LayersFactory.makeLayers(). It constructs
+  // a layer based on layerInfo and other parameters. Subclasses can override it
+  // to use different constructor parameters based on layerInfo.
+  //
+  // A bit of TypeScript magic: since we want to construct a child class from the static
+  // method, we use the method outlined here: https://stackoverflow.com/a/51749145/593487
+  public static makeLayer<ChildLayer extends typeof AbstractSentinelHubV1OrV2WithCCLayer>(
+    this: ChildLayer,
+    layerInfo: any, // eslint-disable-line @typescript-eslint/no-unused-vars
+    instanceId: string,
+    layerId: string,
+    evalscript: string | null,
+    evalscriptUrl: string | null,
+    title: string | null,
+    description: string | null,
+  ): AbstractLayer {
+    return new this(instanceId, layerId, evalscript, evalscriptUrl, title, description, layerInfo.settings.maxCC);
+  }
+}

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,4 +1,3 @@
-import { GetMapParams, ApiType } from 'src/layer/const';
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AbstractLayer } from './AbstractLayer';
 
@@ -19,12 +18,10 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 
-  public getMapUrl(params: GetMapParams, api: ApiType): string {
-    const getMapParams: GetMapParams = {
-      maxCloudCoverPercent: this.maxCloudCoverPercent,
-      ...params,
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {
+      maxcc: this.maxCloudCoverPercent,
     };
-    return super.getMapUrl(getMapParams, api);
   }
 
   protected getFindTilesAdditionalParameters(): Record<string, any> {
@@ -56,6 +53,14 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     title: string | null,
     description: string | null,
   ): AbstractLayer {
-    return new this(instanceId, layerId, evalscript, evalscriptUrl, title, description, layerInfo.settings.maxCC);
+    return new this(
+      instanceId,
+      layerId,
+      evalscript,
+      evalscriptUrl,
+      title,
+      description,
+      layerInfo.settings.maxCC,
+    );
   }
 }

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,5 +1,5 @@
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AbstractLayer } from './AbstractLayer';
+import { AbstractLayer } from 'src/layer/AbstractLayer';
 
 // same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
 export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -100,13 +100,28 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
 
       // allow subclasses to update payload with their own parameters:
-      const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
+      const additionalDataFilterParams = this.getProcessingAPIAdditionalDataFilterParams();
+      const payload = createProcessingPayload(
+        this.dataset,
+        params,
+        this.evalscript,
+        this.dataProduct,
+        additionalDataFilterParams,
+      );
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
 
       return processingGetMap(this.dataset.shServiceHostname, updatedPayload);
     }
 
     return super.getMap(params, api);
+  }
+
+  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
+    return {};
+  }
+
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {};
   }
 
   public getMapUrl(params: GetMapParams, api: ApiType): string {
@@ -118,7 +133,15 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     }
     const baseUrl = `${this.dataset.shServiceHostname}ogc/wms/${this.instanceId}`;
     const evalsource = this.dataset.shWmsEvalsource;
-    return wmsGetMapUrl(baseUrl, this.layerId, params, this.evalscript, this.evalscriptUrl, evalsource);
+    return wmsGetMapUrl(
+      baseUrl,
+      this.layerId,
+      params,
+      this.evalscript,
+      this.evalscriptUrl,
+      evalsource,
+      this.getWmsGetMapUrlAdditionalParameters(),
+    );
   }
 
   public setEvalscript(evalscript: string): void {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -99,12 +99,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
       }
 
-      const payload = createProcessingPayload(
-        this.dataset,
-        params,
-        this.evalscript,
-        this.dataProduct,
-      );
+      const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
 

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -99,25 +99,19 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
       }
 
-      // allow subclasses to update payload with their own parameters:
-      const additionalDataFilterParams = this.getProcessingAPIAdditionalDataFilterParams();
       const payload = createProcessingPayload(
         this.dataset,
         params,
         this.evalscript,
         this.dataProduct,
-        additionalDataFilterParams,
       );
+      // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
 
       return processingGetMap(this.dataset.shServiceHostname, updatedPayload);
     }
 
     return super.getMap(params, api);
-  }
-
-  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
-    return {};
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -142,7 +142,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     toTime: Date,
     maxCount: number = 1,
     offset: number = 0,
-    maxCloudCoverage?: number | null,
+    maxCloudCoverPercent?: number | null,
     datasetParameters?: Record<string, any> | null,
   ): Promise<{ data: { tiles: any[]; hasMore: boolean } }> {
     if (!this.dataset.searchIndexUrl) {
@@ -161,10 +161,12 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         ],
       ],
     };
+    // Note: we are requesting maxCloudCoverage as a number between 0 and 1, but in
+    // the tiles we get cloudCoverPercentage (0..100).
     const payload: any = {
       clipping: bboxPolygon,
       maxcount: maxCount,
-      maxCloudCoverage: maxCloudCoverage ? maxCloudCoverage / 100 : null,
+      maxCloudCoverage: maxCloudCoverPercent ? maxCloudCoverPercent / 100 : null,
       timeFrom: fromTime.toISOString(),
       timeTo: toTime.toISOString(),
       offset: offset,

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -3,7 +3,7 @@ import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { ProcessingPayload } from './processing';
+import { ProcessingPayload } from 'src/layer/processing';
 
 type BYOCFindTilesDatasetParameters = {
   type: string;

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT5 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
 
-export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
+export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT5;
 }

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -3,4 +3,25 @@ import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinel
 
 export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT5;
+
+  public static makeLayer(
+    layerInfo: any,
+    instanceId: string,
+    layerId: string,
+    evalscript: string | null,
+    evalscriptUrl: string | null,
+    title: string | null,
+    description: string | null,
+  ): Landsat5EOCloudLayer {
+    const maxCloudCoverPercent = layerInfo.settings.maxCC;
+    return new Landsat5EOCloudLayer(
+      instanceId,
+      layerId,
+      evalscript,
+      evalscriptUrl,
+      title,
+      description,
+      maxCloudCoverPercent,
+    );
+  }
 }

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -3,4 +3,25 @@ import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinel
 
 export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT7;
+
+  public static makeLayer(
+    layerInfo: any,
+    instanceId: string,
+    layerId: string,
+    evalscript: string | null,
+    evalscriptUrl: string | null,
+    title: string | null,
+    description: string | null,
+  ): Landsat7EOCloudLayer {
+    const maxCloudCoverPercent = layerInfo.settings.maxCC;
+    return new Landsat7EOCloudLayer(
+      instanceId,
+      layerId,
+      evalscript,
+      evalscriptUrl,
+      title,
+      description,
+      maxCloudCoverPercent,
+    );
+  }
 }

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT7 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
 
-export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
+export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT7;
 }

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT8 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
 
-export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
+export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT8;
 }

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -3,4 +3,25 @@ import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinel
 
 export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT8;
+
+  public static makeLayer(
+    layerInfo: any,
+    instanceId: string,
+    layerId: string,
+    evalscript: string | null,
+    evalscriptUrl: string | null,
+    title: string | null,
+    description: string | null,
+  ): Landsat8EOCloudLayer {
+    const maxCloudCoverPercent = layerInfo.settings.maxCC;
+    return new Landsat8EOCloudLayer(
+      instanceId,
+      layerId,
+      evalscript,
+      evalscriptUrl,
+      title,
+      description,
+      maxCloudCoverPercent,
+    );
+  }
 }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -32,9 +32,9 @@ import { DEMLayer } from 'src/layer/DEMLayer';
 import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
 import { BYOCLayer } from 'src/layer/BYOCLayer';
 import { S1GRDEOCloudLayer } from 'src/layer/S1GRDEOCloudLayer';
-import { Landsat5EOCloudLayer } from './Landsat5EOCloudLayer';
-import { Landsat7EOCloudLayer } from './Landsat7EOCloudLayer';
-import { Landsat8EOCloudLayer } from './Landsat8EOCloudLayer';
+import { Landsat5EOCloudLayer } from 'src/layer/Landsat5EOCloudLayer';
+import { Landsat7EOCloudLayer } from 'src/layer/Landsat7EOCloudLayer';
+import { Landsat8EOCloudLayer } from 'src/layer/Landsat8EOCloudLayer';
 
 type GetCapabilitiesXml = {
   WMS_Capabilities: {

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -47,6 +47,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   protected orthorectify: boolean | null = false;
   protected backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
   protected resolution: Resolution | null = null;
+  protected orbitDirection: OrbitDirection | null = null;
 
   public constructor(
     instanceId: string | null,
@@ -61,6 +62,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     resolution: Resolution | null = null,
     orthorectify: boolean | null = false,
     backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID,
+    orbitDirection: OrbitDirection | null = null,
   ) {
     super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
     this.acquisitionMode = acquisitionMode;
@@ -68,29 +70,39 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     this.resolution = resolution;
     this.orthorectify = orthorectify;
     this.backscatterCoeff = backscatterCoeff;
+    this.orbitDirection = orbitDirection;
+  }
+
+  protected async updateLayerFromServiceIfNeeded(): Promise<void> {
+    if (this.polarization !== null && this.acquisitionMode !== null && this.resolution !== null) {
+      return;
+    }
+    if (this.instanceId === null || this.layerId === null) {
+      throw new Error(
+        "Parameters polarization, acquisitionMode and/or resolution are not set and can't be fetched from service because instanceId and layerId are not available",
+      );
+    }
+    const layerParams = await this.fetchLayerParamsFromSHServiceV3();
+
+    this.acquisitionMode = layerParams['acquisitionMode'];
+    this.polarization = layerParams['polarization'];
+    this.resolution = layerParams['resolution'];
+    this.backscatterCoeff = layerParams['backCoeff'];
+    this.orthorectify = layerParams['orthorectify'];
+    this.orbitDirection = layerParams['orbitDirection'] ? layerParams['orbitDirection'] : null;
   }
 
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    if (this.polarization === null || this.acquisitionMode === null || this.resolution === null) {
-      if (this.instanceId === null || this.layerId === null) {
-        throw new Error(
-          "Parameters polarization, acquisitionMode and/or resolution are not set and can't be fetched from service because instanceId and layerId are not available",
-        );
-      }
-      const layerParams = await this.fetchLayerParamsFromSHServiceV3();
+    await this.updateLayerFromServiceIfNeeded();
 
-      this.acquisitionMode = layerParams['acquisitionMode'];
-      this.polarization = layerParams['polarization'];
-      this.resolution = layerParams['resolution'];
-      this.backscatterCoeff = layerParams['backCoeff'];
-      this.orthorectify = layerParams['orthorectify'];
-
-      payload.input.data[0].dataFilter.acquisitionMode = this.acquisitionMode;
-      payload.input.data[0].dataFilter.polarization = this.polarization;
-      payload.input.data[0].dataFilter.resolution = this.resolution;
-      payload.input.data[0].processing.backCoeff = this.backscatterCoeff;
-      payload.input.data[0].processing.orthorectify = this.orthorectify;
+    payload.input.data[0].dataFilter.acquisitionMode = this.acquisitionMode;
+    payload.input.data[0].dataFilter.polarization = this.polarization;
+    payload.input.data[0].dataFilter.resolution = this.resolution;
+    if (this.orbitDirection !== null) {
+      payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
     }
+    payload.input.data[0].processing.backCoeff = this.backscatterCoeff;
+    payload.input.data[0].processing.orthorectify = this.orthorectify;
     return payload;
   }
 
@@ -100,13 +112,14 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    orbitDirection?: OrbitDirection,
   ): Promise<PaginatedTiles> {
+    await this.updateLayerFromServiceIfNeeded();
+
     const findTilesDatasetParameters: S1GRDFindTilesDatasetParameters = {
       type: this.dataset.shProcessingApiDatasourceAbbreviation,
       acquisitionMode: this.acquisitionMode,
       polarization: this.polarization,
-      orbitDirection: orbitDirection,
+      orbitDirection: this.orbitDirection,
       resolution: this.resolution,
     };
 

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,7 @@ import { BackscatterCoeff } from 'src/layer/const';
 import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
+import { AcquisitionMode, Polarization, Resolution, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -16,6 +16,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   protected orthorectify: boolean | null = false;
   protected backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
   protected resolution: Resolution | null = null;
+  protected orbitDirection: OrbitDirection | null = null;
 
   public constructor(
     instanceId: string | null,
@@ -26,6 +27,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     description: string | null = null,
     acquisitionMode: AcquisitionMode | null = null,
     polarization: Polarization | null = null,
+    orbitDirection: OrbitDirection | null = null,
   ) {
     super(instanceId, layerId, evalscript, evalscriptUrl, title, description);
     // it is not possible to determine these parameters by querying the service, because there
@@ -35,6 +37,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     }
     this.acquisitionMode = acquisitionMode;
     this.polarization = polarization;
+    this.orbitDirection = orbitDirection;
   }
 
   public static makeLayer(
@@ -96,10 +99,15 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   }
 
   protected getFindTilesAdditionalParameters(): Record<string, any> {
-    return {
+    const result = {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,
       polarization: this.polarization,
+      orbitDirection: this.orbitDirection,
     };
+    if (this.orbitDirection !== null) {
+      result.orbitDirection = this.orbitDirection;
+    }
+    return result;
   }
 }

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -103,7 +103,6 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,
       polarization: this.polarization,
-      orbitDirection: this.orbitDirection,
     };
     if (this.orbitDirection !== null) {
       result.orbitDirection = this.orbitDirection;

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -95,7 +95,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     );
   }
 
-  protected getFindTilesAdditionalParameters(): Record<string, string> {
+  protected getFindTilesAdditionalParameters(): Record<string, any> {
     return {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -2,6 +2,7 @@ import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S2L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from 'src/layer/processing';
 
 export class S2L1CLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L1C;
@@ -21,10 +22,9 @@ export class S2L1CLayer extends AbstractSentinelHubV3Layer {
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 
-  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
-    return {
-      maxCloudCoverage: this.maxCloudCoverPercent,
-    };
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    return payload;
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -5,6 +5,33 @@ import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer
 
 export class S2L1CLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L1C;
+  protected maxCloudCoverPercent: number;
+
+  public constructor(
+    instanceId: string | null,
+    layerId: string | null = null,
+    evalscript: string | null = null,
+    evalscriptUrl: string | null = null,
+    dataProduct: string | null = null,
+    title: string | null = null,
+    description: string | null = null,
+    maxCloudCoverPercent: number | null = 100,
+  ) {
+    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+    this.maxCloudCoverPercent = maxCloudCoverPercent;
+  }
+
+  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
+    return {
+      maxCloudCoverage: this.maxCloudCoverPercent,
+    };
+  }
+
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {
+      maxcc: this.maxCloudCoverPercent,
+    };
+  }
 
   public async findTiles(
     bbox: BBox,

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -39,9 +39,15 @@ export class S2L1CLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverPercent?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverPercent);
+    const response = await this.fetchTiles(
+      bbox,
+      fromTime,
+      toTime,
+      maxCount,
+      offset,
+      this.maxCloudCoverPercent,
+    );
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -12,9 +12,9 @@ export class S2L1CLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverage?: number,
+    maxCloudCoverPercent?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverage);
+    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverPercent);
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -2,6 +2,7 @@ import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S2L2A } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from 'src/layer/processing';
 
 export class S2L2ALayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L2A;
@@ -21,10 +22,9 @@ export class S2L2ALayer extends AbstractSentinelHubV3Layer {
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 
-  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
-    return {
-      maxCloudCoverage: this.maxCloudCoverPercent,
-    };
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    return payload;
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -5,6 +5,33 @@ import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer
 
 export class S2L2ALayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L2A;
+  protected maxCloudCoverPercent: number;
+
+  public constructor(
+    instanceId: string | null,
+    layerId: string | null = null,
+    evalscript: string | null = null,
+    evalscriptUrl: string | null = null,
+    dataProduct: string | null = null,
+    title: string | null = null,
+    description: string | null = null,
+    maxCloudCoverPercent: number | null = 100,
+  ) {
+    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+    this.maxCloudCoverPercent = maxCloudCoverPercent;
+  }
+
+  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
+    return {
+      maxCloudCoverage: this.maxCloudCoverPercent,
+    };
+  }
+
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {
+      maxcc: this.maxCloudCoverPercent,
+    };
+  }
 
   public async findTiles(
     bbox: BBox,

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -12,9 +12,9 @@ export class S2L2ALayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverage?: number,
+    maxCloudCoverPercent?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverage);
+    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverPercent);
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -39,9 +39,15 @@ export class S2L2ALayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverPercent?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset, maxCloudCoverPercent);
+    const response = await this.fetchTiles(
+      bbox,
+      fromTime,
+      toTime,
+      maxCount,
+      offset,
+      this.maxCloudCoverPercent,
+    );
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -3,6 +3,7 @@ import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { OrbitDirection } from 'src';
+import { ProcessingPayload } from 'src/layer/processing';
 
 type S3SLSTRFindTilesDatasetParameters = {
   type?: string;
@@ -34,10 +35,9 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     this.view = view;
   }
 
-  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
-    return {
-      maxCloudCoverage: this.maxCloudCoverPercent,
-    };
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    return payload;
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -52,14 +52,11 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverPercent?: number,
-    orbitDirection: OrbitDirection | null = OrbitDirection.DESCENDING,
-    view: 'NADIR' | 'OBLIQUE' = 'NADIR',
   ): Promise<PaginatedTiles> {
     const findTilesDatasetParameters: S3SLSTRFindTilesDatasetParameters = {
       type: this.dataset.shProcessingApiDatasourceAbbreviation,
-      orbitDirection: orbitDirection,
-      view: view,
+      orbitDirection: this.orbitDirection,
+      view: this.view,
     };
     const response = await this.fetchTiles(
       bbox,
@@ -67,7 +64,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
-      maxCloudCoverPercent,
+      this.maxCloudCoverPercent,
       findTilesDatasetParameters,
     );
     return {

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -19,7 +19,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    maxCloudCoverage?: number,
+    maxCloudCoverPercent?: number,
     orbitDirection: OrbitDirection | null = OrbitDirection.DESCENDING,
     view: 'NADIR' | 'OBLIQUE' = 'NADIR',
   ): Promise<PaginatedTiles> {
@@ -34,7 +34,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
-      maxCloudCoverage,
+      maxCloudCoverPercent,
       findTilesDatasetParameters,
     );
     return {

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -12,6 +12,39 @@ type S3SLSTRFindTilesDatasetParameters = {
 
 export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3SLSTR;
+  protected maxCloudCoverPercent: number;
+  protected orbitDirection: OrbitDirection | null;
+  protected view: 'NADIR' | 'OBLIQUE';
+
+  public constructor(
+    instanceId: string | null,
+    layerId: string | null = null,
+    evalscript: string | null = null,
+    evalscriptUrl: string | null = null,
+    dataProduct: string | null = null,
+    title: string | null = null,
+    description: string | null = null,
+    maxCloudCoverPercent: number | null = 100,
+    orbitDirection: OrbitDirection | null = null,
+    view: 'NADIR' | 'OBLIQUE' = 'NADIR',
+  ) {
+    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+    this.maxCloudCoverPercent = maxCloudCoverPercent;
+    this.orbitDirection = orbitDirection;
+    this.view = view;
+  }
+
+  protected getProcessingAPIAdditionalDataFilterParams(): Record<string, any> {
+    return {
+      maxCloudCoverage: this.maxCloudCoverPercent,
+    };
+  }
+
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {
+      maxcc: this.maxCloudCoverPercent,
+    };
+  }
 
   public async findTiles(
     bbox: BBox,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -24,7 +24,7 @@ export enum ProductType {
 type S5PL2FindTilesDatasetParameters = {
   type: string;
   productType: ProductType;
-  minQa?: number;
+  // minQa?: number;
 };
 
 export class S5PL2Layer extends AbstractSentinelHubV3Layer {
@@ -46,9 +46,6 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     minQa: number | null = null,
   ) {
     super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
-    if (productType === null) {
-      throw new Error('Parameter productType must be specified!');
-    }
     this.productType = productType;
     this.maxCloudCoverPercent = maxCloudCoverPercent;
     this.minQa = minQa;
@@ -71,10 +68,13 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
+    if (this.productType === null) {
+      throw new Error('Parameter productType must be specified!');
+    }
     const findTilesDatasetParameters: S5PL2FindTilesDatasetParameters = {
       type: this.dataset.shProcessingApiDatasourceAbbreviation,
       productType: this.productType,
-      minQa: this.minQa,
+      // minQa: this.minQa,
     };
     const response = await this.fetchTiles(
       bbox,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -2,6 +2,7 @@ import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from 'src/layer/processing';
 
 /*
   S-5P is a bit special in that we need to supply productType when searching
@@ -23,10 +24,45 @@ export enum ProductType {
 type S5PL2FindTilesDatasetParameters = {
   type: string;
   productType: ProductType;
+  minQa?: number;
 };
 
 export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S5PL2;
+  protected productType: ProductType;
+  protected maxCloudCoverPercent: number;
+  protected minQa: number | null;
+
+  public constructor(
+    instanceId: string | null,
+    layerId: string | null = null,
+    evalscript: string | null = null,
+    evalscriptUrl: string | null = null,
+    dataProduct: string | null = null,
+    title: string | null = null,
+    description: string | null = null,
+    productType: ProductType | null = null,
+    maxCloudCoverPercent: number | null = 100,
+    minQa: number | null = null,
+  ) {
+    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+    if (productType === null) {
+      throw new Error('Parameter productType must be specified!');
+    }
+    this.productType = productType;
+    this.maxCloudCoverPercent = maxCloudCoverPercent;
+    this.minQa = minQa;
+  }
+
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    if (this.minQa !== null) {
+      payload.input.data[0].processing.minQa = this.minQa;
+    }
+    // note that productType is not present among the parameters:
+    // https://docs.sentinel-hub.com/api/latest/reference/#operation/process
+    return payload;
+  }
 
   public async findTiles(
     bbox: BBox,
@@ -34,11 +70,11 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
-    productType?: ProductType,
   ): Promise<PaginatedTiles> {
     const findTilesDatasetParameters: S5PL2FindTilesDatasetParameters = {
       type: this.dataset.shProcessingApiDatasourceAbbreviation,
-      productType: productType,
+      productType: this.productType,
+      minQa: this.minQa,
     };
     const response = await this.fetchTiles(
       bbox,
@@ -46,7 +82,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
-      null,
+      this.maxCloudCoverPercent,
       findTilesDatasetParameters,
     );
     return {

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -11,7 +11,7 @@ export type GetMapParams = {
   width?: number;
   height?: number;
   // optional additional parameters:
-  maxCCPercent?: number;
+  maxCloudCoverPercent?: number;
   preview?: number;
   geometry?: string;
   quality?: number;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -11,7 +11,6 @@ export type GetMapParams = {
   width?: number;
   height?: number;
   // optional additional parameters:
-  maxCloudCoverPercent?: number;
   preview?: number;
   geometry?: string;
   quality?: number;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -33,7 +33,6 @@ export type ProcessingPayload = {
             from: string;
             to: string;
           };
-          maxCloudCoverage: number;
           previewMode?: PreviewMode;
           mosaickingOrder?: MosaickingOrder;
           [key: string]: any;
@@ -68,6 +67,7 @@ export function createProcessingPayload(
   params: GetMapParams,
   evalscript: string | null = null,
   dataProduct: string | null = null,
+  additionalDataFilterParams: Record<string, any>,
 ): ProcessingPayload {
   const { bbox } = params;
 
@@ -87,7 +87,7 @@ export function createProcessingPayload(
               to: params.toTime.toISOString(),
             },
             mosaickingOrder: MosaickingOrder.MOST_RECENT,
-            maxCloudCoverage: params.maxCloudCoverPercent, // maximum allowable cloud coverage in percent
+            ...additionalDataFilterParams,
           },
           processing: {},
           type: dataset.shProcessingApiDatasourceAbbreviation,

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -67,7 +67,6 @@ export function createProcessingPayload(
   params: GetMapParams,
   evalscript: string | null = null,
   dataProduct: string | null = null,
-  additionalDataFilterParams: Record<string, any>,
 ): ProcessingPayload {
   const { bbox } = params;
 
@@ -87,7 +86,6 @@ export function createProcessingPayload(
               to: params.toTime.toISOString(),
             },
             mosaickingOrder: MosaickingOrder.MOST_RECENT,
-            ...additionalDataFilterParams,
           },
           processing: {},
           type: dataset.shProcessingApiDatasourceAbbreviation,

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -87,7 +87,7 @@ export function createProcessingPayload(
               to: params.toTime.toISOString(),
             },
             mosaickingOrder: MosaickingOrder.MOST_RECENT,
-            maxCloudCoverage: params.maxCCPercent, // maximum allowable cloud coverage in percent
+            maxCloudCoverage: params.maxCloudCoverPercent, // maximum allowable cloud coverage in percent
           },
           processing: {},
           type: dataset.shProcessingApiDatasourceAbbreviation,

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -88,7 +88,7 @@ export function wmsGetMapUrl(
 
   queryParams.time = `${params.fromTime.toISOString()}/${params.toTime.toISOString()}`;
 
-  if (params.maxCloudCoverPercent) {
+  if (params.maxCloudCoverPercent !== undefined) {
     queryParams.maxcc = params.maxCloudCoverPercent;
   }
 

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -88,8 +88,8 @@ export function wmsGetMapUrl(
 
   queryParams.time = `${params.fromTime.toISOString()}/${params.toTime.toISOString()}`;
 
-  if (params.maxCCPercent) {
-    queryParams.maxcc = params.maxCCPercent;
+  if (params.maxCloudCoverPercent) {
+    queryParams.maxcc = params.maxCloudCoverPercent;
   }
 
   if (params.width && params.height) {

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -53,6 +53,7 @@ export function wmsGetMapUrl(
   evalscript: string | null = null,
   evalscriptUrl: string | null = null,
   evalsource: string | null = null,
+  additionalParameters: Record<string, any> = {},
 ): string {
   const queryParams: OgcGetMapOptions = {
     version: OGC_SERVICES_IMPLEMENTED_VERSIONS[ServiceType.WMS],
@@ -69,6 +70,7 @@ export function wmsGetMapUrl(
     transparent: true,
     gain: undefined,
     gamma: undefined,
+    ...additionalParameters,
   };
 
   if (layers === null) {
@@ -87,10 +89,6 @@ export function wmsGetMapUrl(
   }
 
   queryParams.time = `${params.fromTime.toISOString()}/${params.toTime.toISOString()}`;
-
-  if (params.maxCloudCoverPercent !== undefined) {
-    queryParams.maxcc = params.maxCloudCoverPercent;
-  }
 
   if (params.width && params.height) {
     queryParams.width = params.width;

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -146,7 +146,7 @@ function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegac
   }
 
   if (params.maxcc) {
-    getMapParams.maxCCPercent = parseInt(params.maxcc);
+    getMapParams.maxCloudCoverPercent = parseInt(params.maxcc);
   }
   if (params.preview) {
     getMapParams.preview = previewFromParams(params);

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -145,9 +145,12 @@ function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegac
     getMapParams.height = height;
   }
 
-  if (params.maxcc) {
-    getMapParams.maxCloudCoverPercent = parseInt(params.maxcc);
-  }
+  // Instead of dealing with maxCC at this point, we pass it through as an unknown parameter. In the
+  // future, it should be used to instantiate the layers instead.
+  // if (params.maxcc) {
+  //   getMapParams.maxCloudCoverPercent = parseInt(params.maxcc);
+  // }
+
   if (params.preview) {
     getMapParams.preview = previewFromParams(params);
   }
@@ -196,7 +199,7 @@ function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegac
     'srs',
     'srsname',
     'time',
-    'maxcc',
+    //'maxcc',
   ];
   const getMapParamsObjectKeys = Object.keys(getMapParams);
   let unknown: Record<string, string> = {};

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -50,7 +50,7 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCCPercent: 50,
+    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -77,7 +77,7 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -128,7 +128,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -50,7 +50,6 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -77,7 +76,6 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -128,7 +126,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -198,7 +198,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };
@@ -227,7 +227,7 @@ export const findTilesAuth = () => {
       new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -213,7 +213,8 @@ export const WmsGetMap = () => {
 };
 
 export const S2FindTiles = () => {
-  const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const maxCloudCoverPercent = 60;
+  const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId, null, null, null, null, null, maxCloudCoverPercent);
   const bbox = new BBox(CRS_EPSG4326, 11.9, 12.34, 42.05, 42.19);
   const containerEl = document.createElement('pre');
 
@@ -227,8 +228,7 @@ export const S2FindTiles = () => {
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      60,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };
@@ -253,7 +253,6 @@ export const S1GRDFindTiles = () => {
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
       0,
-      'ASCENDING',
     );
 
     renderTilesList(containerEl, data.tiles);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -50,7 +50,7 @@ export const S2GetMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCCPercent: 50,
+    maxCloudCoverPercent: 50,
   };
   const imageUrl = layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -79,7 +79,7 @@ export const S2GetMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -132,7 +132,7 @@ export const S2GetMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -50,7 +50,6 @@ export const S2GetMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCloudCoverPercent: 50,
   };
   const imageUrl = layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -79,7 +78,6 @@ export const S2GetMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -132,7 +130,6 @@ export const S2GetMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -34,7 +34,8 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = "<h2>GetMapUrl (WMS)</h2>";
   wrapperEl.insertAdjacentElement("beforeend", img);
 
-  const layer = new Landsat5EOCloudLayer(instanceId, layerId);
+  const maxCloudCoverPercent = 0;
+  const layer = new Landsat5EOCloudLayer(instanceId, layerId, null, null, null, null, maxCloudCoverPercent);
 
   const getMapParams = {
     bbox: bbox,
@@ -69,6 +70,7 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
+      maxCloudCoverPercent: 0,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -89,7 +91,6 @@ export const getMapWMSLayersFactory = () => {
 
   const perform = async () => {
     const layer = (await LayersFactory.makeLayers(`${DATASET_EOCLOUD_LANDSAT5.shServiceHostname}v1/wms/${instanceId}`, (lId, datasetId) => (layerId === lId)))[0];
-
     const getMapParams = {
       bbox: bbox,
       fromTime: new Date(Date.UTC(2010, 11 - 1, 22, 0, 0, 0)),
@@ -97,6 +98,7 @@ export const getMapWMSLayersFactory = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
+      maxCloudCoverPercent: 0,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -123,7 +125,6 @@ export const getMapWMSEvalscript = () => {
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
     );
-    console.log("aaaaaaaaaaaaaaaaaaa", layer)
 
     const getMapParams = {
       bbox: bbox,

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -157,8 +157,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      OrbitDirection.ASCENDING,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -5,7 +5,6 @@ import {
   MimeTypes,
   ApiType,
   DATASET_EOCLOUD_LANDSAT5,
-  OrbitDirection,
   LayersFactory,
 } from '../dist/sentinelHub.esm';
 
@@ -70,7 +69,6 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 0,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -98,7 +96,6 @@ export const getMapWMSLayersFactory = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 0,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -133,7 +130,6 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -132,7 +132,7 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -5,7 +5,6 @@ import {
   MimeTypes,
   ApiType,
   DATASET_EOCLOUD_LANDSAT5,
-  OrbitDirection,
   LayersFactory,
 } from '../dist/sentinelHub.esm';
 
@@ -131,7 +130,6 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -155,8 +155,7 @@ export const findTiles = () => {
       new Date(Date.UTC(1990, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      OrbitDirection.ASCENDING,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -131,7 +131,7 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -5,7 +5,6 @@ import {
   MimeTypes,
   ApiType,
   DATASET_EOCLOUD_LANDSAT8,
-  OrbitDirection,
   LayersFactory,
 } from '../dist/sentinelHub.esm';
 
@@ -131,7 +130,6 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -131,7 +131,7 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -155,8 +155,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      OrbitDirection.ASCENDING,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -125,7 +125,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -178,7 +178,7 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -238,8 +238,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),
       new Date(Date.UTC(2020, 2 - 1, 2, 23, 59, 59)),
       5,
-      null,
-      null,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -125,7 +125,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -178,7 +177,6 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -135,7 +135,6 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -146,7 +146,17 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S1GRDEOCloudLayer(instanceId, layerId, null, null, null, null, AcquisitionMode.IW, Polarization.DV, Resolution.HIGH);
+  const layer = new S1GRDEOCloudLayer(
+    instanceId,
+    layerId,
+    null,
+    null,
+    null,
+    null,
+    AcquisitionMode.IW,
+    Polarization.DV,
+    OrbitDirection.ASCENDING,
+  );
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -135,7 +135,7 @@ export const getMapWMSEvalscript = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -160,7 +160,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -213,7 +213,7 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -273,8 +273,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      OrbitDirection.ASCENDING,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -160,7 +160,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -213,7 +212,6 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -183,7 +183,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -43,7 +43,6 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -71,7 +70,6 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -123,7 +121,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -43,7 +43,7 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCCPercent: 50,
+    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -71,7 +71,7 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -123,7 +123,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -45,7 +45,6 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -73,7 +72,6 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -125,7 +123,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -44,7 +44,7 @@ export const getMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    maxCCPercent: 50,
+    maxCloudCoverPercent: 50,
   };
   const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -72,7 +72,7 @@ export const getMapWMS = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
@@ -124,7 +124,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -8,6 +8,7 @@ import {
   BBox,
   MimeTypes,
   ApiType,
+  OrbitDirection,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -170,7 +171,8 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S3SLSTRLayer(instanceId, layerId);
+  const layer = new S3SLSTRLayer(instanceId, layerId, null, null, null, null, null,
+     60, OrbitDirection.DESCENDING, 'OBLIQUE');
   const bbox = new BBox(CRS_EPSG4326, 11.9, 12.34, 42.05, 42.19);
   const containerEl = document.createElement('pre');
 
@@ -184,10 +186,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,
-      null,
-      60,
-      "DESCENDING",
-      "OBLIQUE",
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -157,7 +157,7 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -207,7 +207,7 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCCPercent: 100,
+      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -265,8 +265,7 @@ export const findTiles = () => {
       new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),
       new Date(Date.UTC(2020, 2 - 1, 2, 23, 59, 59)),
       5,
-      null,
-      null,
+      0,
     );
     renderTilesList(containerEl, data.tiles);
   };

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -252,7 +252,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S5PL2Layer(instanceId, layerId);
+  const layer = new S5PL2Layer(instanceId, layerId, null, null, null, null, null, "SO2");
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -157,7 +157,6 @@ export const getMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
@@ -207,7 +206,6 @@ export const getMapProcessingWithoutInstance = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
-      maxCloudCoverPercent: 100,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);


### PR DESCRIPTION
Note: this PR is against #19's branch.

This PR makes use of various parameters (like `maxCloudCoverPercent`) more consistent across the datasets:
- all the relevant parameters are specified when instantiating the layer
- `findTiles()` has the same parameters across all datasets (though the layer itself will supply others as needed)
- all cloud cover (internal) variables are now named consistently: `cloudCoverPercent` (if value) or `maxCloudCoverPercent` (if limit)

Also:
- makeLayer() was moved from `AbstractSentinelHubV1OrV2WithCCLayer` directly to `LandsatXEOCloudLayer` (X ∈  {5, 7, 8}) because I couldn't make TypeScript "magic" work so that it would create appropriate child class instance