### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,5 +1,5 @@
 name: Lint
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -99,7 +99,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   }
 
   protected getFindTilesAdditionalParameters(): Record<string, any> {
-    const result = {
+    const result: Record<string, any> = {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,
       polarization: this.polarization,


### PR DESCRIPTION
This PR fixes the reason for failing tests.

Interestingly, the tests in branch for #21 were failing for `pull_request`, but not for `push` event - I assume the reason was that in first case they were being run against the code as if it were merged with `master` (which is where the bug was). This PR thus re-enables running of tests on `pull_request` events, since it sounds like a good feature to have.