### PR TITLE
Feature/public layer properties

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -79,4 +79,6 @@ export class AbstractLayer {
     }
     return flyoverIntervals;
   }
+
+  public async updateLayerFromServiceIfNeeded(): Promise<void> {}
 }

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -2,7 +2,7 @@ import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1O
 
 // same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
 export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {
-  protected maxCloudCoverPercent: number;
+  public maxCloudCoverPercent: number;
 
   public constructor(
     instanceId: string,

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -73,7 +73,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     this.orbitDirection = orbitDirection;
   }
 
-  protected async updateLayerFromServiceIfNeeded(): Promise<void> {
+  public async updateLayerFromServiceIfNeeded(): Promise<void> {
     if (this.polarization !== null && this.acquisitionMode !== null && this.resolution !== null) {
       return;
     }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -42,12 +42,12 @@ type S1GRDFindTilesDatasetParameters = {
 export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_AWSEU_S1GRD;
 
-  protected acquisitionMode: AcquisitionMode;
-  protected polarization: Polarization;
-  protected orthorectify: boolean | null = false;
-  protected backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
-  protected resolution: Resolution | null = null;
-  protected orbitDirection: OrbitDirection | null = null;
+  public acquisitionMode: AcquisitionMode;
+  public polarization: Polarization;
+  public resolution: Resolution | null = null;
+  public orbitDirection: OrbitDirection | null = null;
+  public orthorectify: boolean | null = false;
+  public backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
 
   public constructor(
     instanceId: string | null,

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -11,12 +11,12 @@ import { AcquisitionMode, Polarization, Resolution, OrbitDirection } from 'src/l
 export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   public readonly dataset = DATASET_EOCLOUD_S1GRD;
 
-  protected acquisitionMode: AcquisitionMode;
-  protected polarization: Polarization;
-  protected orthorectify: boolean | null = false;
-  protected backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
-  protected resolution: Resolution | null = null;
-  protected orbitDirection: OrbitDirection | null = null;
+  public acquisitionMode: AcquisitionMode;
+  public polarization: Polarization;
+  public resolution: Resolution | null = null;
+  public orbitDirection: OrbitDirection | null = null;
+  public orthorectify: boolean | null = false;
+  public backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
 
   public constructor(
     instanceId: string | null,

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -6,7 +6,7 @@ import { ProcessingPayload } from 'src/layer/processing';
 
 export class S2L1CLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L1C;
-  protected maxCloudCoverPercent: number;
+  public maxCloudCoverPercent: number;
 
   public constructor(
     instanceId: string | null,

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -6,7 +6,7 @@ import { ProcessingPayload } from 'src/layer/processing';
 
 export class S2L2ALayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S2L2A;
-  protected maxCloudCoverPercent: number;
+  public maxCloudCoverPercent: number;
 
   public constructor(
     instanceId: string | null,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -13,7 +13,7 @@ type S3SLSTRFindTilesDatasetParameters = {
 
 export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3SLSTR;
-  protected maxCloudCoverPercent: number;
+  public maxCloudCoverPercent: number;
   protected orbitDirection: OrbitDirection | null;
   protected view: 'NADIR' | 'OBLIQUE';
 

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -14,8 +14,8 @@ type S3SLSTRFindTilesDatasetParameters = {
 export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3SLSTR;
   public maxCloudCoverPercent: number;
-  protected orbitDirection: OrbitDirection | null;
-  protected view: 'NADIR' | 'OBLIQUE';
+  public orbitDirection: OrbitDirection | null;
+  public view: 'NADIR' | 'OBLIQUE';
 
   public constructor(
     instanceId: string | null,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -30,7 +30,7 @@ type S5PL2FindTilesDatasetParameters = {
 export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S5PL2;
   protected productType: ProductType;
-  protected maxCloudCoverPercent: number;
+  public maxCloudCoverPercent: number;
   protected minQa: number | null;
 
   public constructor(

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -29,9 +29,9 @@ type S5PL2FindTilesDatasetParameters = {
 
 export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S5PL2;
-  protected productType: ProductType;
+  public productType: ProductType;
   public maxCloudCoverPercent: number;
-  protected minQa: number | null;
+  public minQa: number | null;
 
   public constructor(
     instanceId: string | null,


### PR DESCRIPTION
EO Browser needs to have access to layer properties (such as `acquisitionMode`, `polarization`,... for Sentinel 1) for filtering the layers.