### PR TITLE
Feature/find flyovers coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ We can always use layer to search for data availability:
 
   const maxCloudCoverPercent = 50;
   const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A', null, null, null, null, null, maxCloudCoverPercent);
-  const tilesS2L2A = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(tilesS2L2A.tiles);
+  const { tiles, hasMore } = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset);
+  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(bbox, tiles);
   const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate);
 
   const layerS1 = new S1GRDAWSEULayer(
@@ -150,8 +150,8 @@ We can always use layer to search for data availability:
     null, null, null, null, null, null, null, null,
     true, BackscatterCoeff.GAMMA0_ELLIPSOID, OrbitDirection.ASCENDING
   );
-  const tilesS1 = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoverIntervalsS1 = layerS1.findFlyoverIntervals(tilesS1.tiles);
+  const { tiles: tilesS1 } = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset);
+  const flyoverIntervalsS1 = layerS1.findFlyoverIntervals(bbox, tilesS1);
 ```
 
 ## Backwards compatibility

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ We can always use layer to search for data availability:
   const maxCloudCoverPercent = 50;
   const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A', null, null, null, null, null, maxCloudCoverPercent);
   const { tiles, hasMore } = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(bbox, tiles);
+  const flyoversS2L2A = layerS2L2A.findFlyovers(bbox, tiles);
   const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate);
 
   const layerS1 = new S1GRDAWSEULayer(
@@ -151,7 +151,7 @@ We can always use layer to search for data availability:
     true, BackscatterCoeff.GAMMA0_ELLIPSOID, OrbitDirection.ASCENDING
   );
   const { tiles: tilesS1 } = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoverIntervalsS1 = layerS1.findFlyoverIntervals(bbox, tilesS1);
+  const flyoversS1 = layerS1.findFlyovers(bbox, tilesS1);
 ```
 
 ## Backwards compatibility

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ We can always use layer to search for data availability:
   const maxCloudCoverPercent = 50;
   const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A', null, null, null, null, null, maxCloudCoverPercent);
   const { tiles, hasMore } = layerS2L2A.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoversS2L2A = layerS2L2A.findFlyovers(bbox, tiles);
+  const flyoversS2L2A = layerS2L2A.findFlyovers(bbox, fromDate, toDate);
   const dates = layerS2L2A.findDatesUTC(bbox, fromDate, toDate);
 
   const layerS1 = new S1GRDAWSEULayer(
@@ -151,7 +151,7 @@ We can always use layer to search for data availability:
     true, BackscatterCoeff.GAMMA0_ELLIPSOID, OrbitDirection.ASCENDING
   );
   const { tiles: tilesS1 } = layerS1.findTiles(bbox, fromDate, toDate, maxCount, offset);
-  const flyoversS1 = layerS1.findFlyovers(bbox, tilesS1);
+  const flyoversS1 = layerS1.findFlyovers(bbox, fromDate, toDate);
 ```
 
 ## Backwards compatibility

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -110,7 +110,7 @@ async function run() {
 
   // get tiles and flyover intervals for S2 L2A layer
   const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
-  const tilesS2L2A = await layerS2L2A.findTiles(
+  const { tiles: tilesS2L2A, hasMore } = await layerS2L2A.findTiles(
     getMapParams.bbox,
     getMapParams.fromTime,
     getMapParams.toTime,
@@ -119,11 +119,12 @@ async function run() {
     100,
   );
   printOut('tiles for S2 L2A:', tilesS2L2A);
-  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(tilesS2L2A.tiles);
+  printOut('hasMore:', hasMore);
+  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(bbox, tilesS2L2A);
   printOut('flyover intervals for S2 L2A:', flyoverIntervalsS2L2A);
 
   // get tiles and flyover intervals for S1 GRD Layer
-  const tilesS1GRD = await layerS1.findTiles(
+  const { tiles: tilesS1GRD, hasMoreS1 } = await layerS1.findTiles(
     getMapParams.bbox,
     getMapParams.fromTime,
     getMapParams.toTime,
@@ -132,7 +133,8 @@ async function run() {
     OrbitDirection.ASCENDING,
   );
   printOut('tiles for S1 GRD:', tilesS1GRD);
-  const flyoverIntervalsS1GRD = layerS1.findFlyoverIntervals(tilesS1GRD.tiles);
+  printOut('hasMore for S1:', hasMoreS1);
+  const flyoverIntervalsS1GRD = layerS1.findFlyoverIntervals(bbox, tilesS1GRD);
   printOut('flyover intervals for S1 GRD:', flyoverIntervalsS1GRD);
 
   // finally, display the image:

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -116,25 +116,37 @@ async function run() {
     getMapParams.toTime,
     20,
     0,
-    100,
   );
   printOut('tiles for S2 L2A:', tilesS2L2A);
   printOut('hasMore:', hasMore);
-  const flyoversS2L2A = layerS2L2A.findFlyovers(bbox, tilesS2L2A);
+
+  const flyoversS2L2A = await layerS2L2A.findFlyovers(
+    getMapParams.bbox,
+    getMapParams.fromTime,
+    getMapParams.toTime,
+    10,
+    50,
+  );
   printOut('flyovers for S2 L2A:', flyoversS2L2A);
 
   // get tiles and flyover intervals for S1 GRD Layer
-  const { tiles: tilesS1GRD, hasMoreS1 } = await layerS1.findTiles(
+  const { tiles: tilesS1GRD, hasMore: hasMoreS1 } = await layerS1.findTiles(
     getMapParams.bbox,
     getMapParams.fromTime,
     getMapParams.toTime,
     10,
     0,
-    OrbitDirection.ASCENDING,
   );
   printOut('tiles for S1 GRD:', tilesS1GRD);
   printOut('hasMore for S1:', hasMoreS1);
-  const flyoversS1GRD = layerS1.findFlyovers(bbox, tilesS1GRD);
+
+  const flyoversS1GRD = await layerS1.findFlyovers(
+    getMapParams.bbox,
+    getMapParams.fromTime,
+    getMapParams.toTime,
+    10,
+    50,
+  );
   printOut('flyovers for S1 GRD:', flyoversS1GRD);
 
   // finally, display the image:

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -120,8 +120,8 @@ async function run() {
   );
   printOut('tiles for S2 L2A:', tilesS2L2A);
   printOut('hasMore:', hasMore);
-  const flyoverIntervalsS2L2A = layerS2L2A.findFlyoverIntervals(bbox, tilesS2L2A);
-  printOut('flyover intervals for S2 L2A:', flyoverIntervalsS2L2A);
+  const flyoversS2L2A = layerS2L2A.findFlyovers(bbox, tilesS2L2A);
+  printOut('flyovers for S2 L2A:', flyoversS2L2A);
 
   // get tiles and flyover intervals for S1 GRD Layer
   const { tiles: tilesS1GRD, hasMoreS1 } = await layerS1.findTiles(
@@ -134,8 +134,8 @@ async function run() {
   );
   printOut('tiles for S1 GRD:', tilesS1GRD);
   printOut('hasMore for S1:', hasMoreS1);
-  const flyoverIntervalsS1GRD = layerS1.findFlyoverIntervals(bbox, tilesS1GRD);
-  printOut('flyover intervals for S1 GRD:', flyoverIntervalsS1GRD);
+  const flyoversS1GRD = layerS1.findFlyovers(bbox, tilesS1GRD);
+  printOut('flyovers for S1 GRD:', flyoversS1GRD);
 
   // finally, display the image:
   const imageUrl = await layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2114,10 +2114,55 @@
         }
       }
     },
+    "@turf/area": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
+      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      }
+    },
     "@turf/helpers": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
       "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+    },
+    "@turf/intersect": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
+      "integrity": "sha512-SeAJG/zPRRTeyK2OifkPoyLq60q8tv8prpPIH3R8ZhyF4MdLOnMv5MURaQ6kQd+3UTDrL+pYm6rqbPvln1zqIw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "martinez-polygon-clipping": "^0.4.3"
+      }
+    },
+    "@turf/invariant": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "requires": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "@turf/meta": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "requires": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "@turf/union": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.3.tgz",
+      "integrity": "sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "martinez-polygon-clipping": "^0.4.3"
+      }
     },
     "@types/babel__core": {
       "version": "7.1.5",
@@ -10218,6 +10263,15 @@
         "unquote": "^1.1.0"
       }
     },
+    "martinez-polygon-clipping": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
+      "integrity": "sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==",
+      "requires": {
+        "splaytree": "^0.1.4",
+        "tinyqueue": "^1.2.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -13456,6 +13510,11 @@
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
       "dev": true
     },
+    "splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
+    },
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -14045,6 +14104,11 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "dev": true,
       "optional": true
+    },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,13 +2155,19 @@
       }
     },
     "@turf/union": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.3.tgz",
-      "integrity": "sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        }
       }
     },
     "@types/babel__core": {
@@ -14276,6 +14282,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@turf/area": "^6.0.1",
     "@turf/helpers": "^6.1.4",
     "@turf/intersect": "^6.1.3",
-    "@turf/union": "^6.0.3",
+    "@turf/union": "^5.1.5",
     "@types/xml2js": "^0.4.4",
     "axios": "^0.18.1",
     "query-string": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "devDependencies": {
     "@babel/core": "^7.8.3",
     "@storybook/html": "^5.3.3",
+    "@types/jest": "^25.1.3",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
-    "@types/jest": "^25.1.2",
     "babel-loader": "^8.0.6",
     "dotenv": "^8.2.0",
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "module": "dist/sentinelHub.esm.js",
   "browser": "dist/sentinelHub.umd.js",
   "dependencies": {
+    "@turf/area": "^6.0.1",
     "@turf/helpers": "^6.1.4",
+    "@turf/intersect": "^6.1.3",
+    "@turf/union": "^6.0.3",
     "@types/xml2js": "^0.4.4",
     "axios": "^0.18.1",
     "query-string": "^6.4.2",

--- a/src/customTypings/@turf/union/index.d.ts
+++ b/src/customTypings/@turf/union/index.d.ts
@@ -1,0 +1,7 @@
+declare module '@turf/union' {
+  import { MultiPolygon, Polygon } from '@turf/helpers';
+  export default function union(
+    poly1: Polygon | MultiPolygon,
+    poly2: Polygon | MultiPolygon,
+  ): Polygon | MultiPolygon;
+}

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -9,6 +9,7 @@ import area from '@turf/area';
 import union from '@turf/union'; // @turf/union is missing types definitions, we supply them separately
 
 import { Polygon, MultiPolygon } from '@turf/helpers';
+import { CRS_EPSG4326 } from 'src/crs';
 
 export class AbstractLayer {
   public title: string | null = null;
@@ -58,6 +59,10 @@ export class AbstractLayer {
   ): Promise<FlyoverInterval[]> {
     if (!this.dataset || !this.dataset.orbitTimeMinutes) {
       throw new Error('Orbit time is needed for grouping tiles into flyovers.');
+    }
+
+    if (bbox.crs !== CRS_EPSG4326) {
+      throw new Error('Currently, only EPSG:4326 in findFlyovers');
     }
 
     let tiles: Tile[] = [];

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -6,7 +6,7 @@ import { Dataset } from 'src/layer/dataset';
 import { RequestConfig } from 'src/utils/axiosInterceptors';
 import intersect from '@turf/intersect';
 import area from '@turf/area';
-import union from '@turf/union';  // @turf/union is missing types definitions, we supply them separately
+import union from '@turf/union'; // @turf/union is missing types definitions, we supply them separately
 
 import { Polygon, MultiPolygon } from '@turf/helpers';
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -4,6 +4,11 @@ import { GetMapParams, ApiType, Tile, PaginatedTiles, FlyoverInterval } from 'sr
 import { BBox } from 'src/bbox';
 import { Dataset } from 'src/layer/dataset';
 import { RequestConfig } from 'src/utils/axiosInterceptors';
+import intersect from '@turf/intersect';
+import area from '@turf/area';
+import union from '@turf/union';  // @turf/union is missing types definitions, we supply them separately
+
+import { Polygon, MultiPolygon } from '@turf/helpers';
 
 export class AbstractLayer {
   public title: string | null = null;
@@ -44,7 +49,7 @@ export class AbstractLayer {
     throw new Error('Not implemented yet');
   }
 
-  public findFlyoverIntervals(tiles: Tile[]): FlyoverInterval[] {
+  public findFlyoverIntervals(bbox: BBox, tiles: Tile[]): FlyoverInterval[] {
     if (!this.dataset || !this.dataset.orbitTimeMinutes) {
       throw new Error('Orbit time is needed for grouping tiles into flyovers.');
     }
@@ -53,31 +58,64 @@ export class AbstractLayer {
     let orbitTimeMS = this.dataset.orbitTimeMinutes * 60 * 1000;
     let flyoverIntervals: FlyoverInterval[] = [];
 
-    let j = 0;
-    for (let i = 0; i < tiles.length; i++) {
-      if (i === 0) {
-        flyoverIntervals[j] = {
-          fromTime: tiles[i].sensingTime,
-          toTime: tiles[i].sensingTime,
+    let flyoverIndex = 0;
+    let currentFlyoverGeometry = null;
+    for (let tileIndex = 0; tileIndex < tiles.length; tileIndex++) {
+      if (tileIndex === 0) {
+        flyoverIntervals[flyoverIndex] = {
+          fromTime: tiles[tileIndex].sensingTime,
+          toTime: tiles[tileIndex].sensingTime,
+          coveragePercent: 0,
         };
+        currentFlyoverGeometry = tiles[tileIndex].geometry;
         continue;
       }
 
-      const prevDateMS = tiles[i - 1].sensingTime.getTime();
-      const currDateMS = tiles[i].sensingTime.getTime();
+      const prevDateMS = tiles[tileIndex - 1].sensingTime.getTime();
+      const currDateMS = tiles[tileIndex].sensingTime.getTime();
       const diffMS = Math.abs(prevDateMS - currDateMS);
 
       if (diffMS < orbitTimeMS) {
-        flyoverIntervals[j].toTime = tiles[i].sensingTime;
+        flyoverIntervals[flyoverIndex].toTime = tiles[tileIndex].sensingTime;
+        currentFlyoverGeometry = union(currentFlyoverGeometry, tiles[tileIndex].geometry);
       } else {
-        j++;
-        flyoverIntervals[j] = {
-          fromTime: tiles[i].sensingTime,
-          toTime: tiles[i].sensingTime,
+        flyoverIntervals[flyoverIndex].coveragePercent = this.calculateCoveragePercent(
+          bbox,
+          currentFlyoverGeometry,
+        );
+        flyoverIndex++;
+        flyoverIntervals[flyoverIndex] = {
+          fromTime: tiles[tileIndex].sensingTime,
+          toTime: tiles[tileIndex].sensingTime,
+          coveragePercent: 0,
         };
+        currentFlyoverGeometry = tiles[tileIndex].geometry;
       }
     }
+    if (flyoverIntervals.length > 0) {
+      flyoverIntervals[flyoverIndex].coveragePercent = this.calculateCoveragePercent(
+        bbox,
+        currentFlyoverGeometry,
+      );
+    }
     return flyoverIntervals;
+  }
+
+  private calculateCoveragePercent(bbox: BBox, flyoverGeometry: Polygon | MultiPolygon): number {
+    const bboxGeometry: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [bbox.minX, bbox.minY],
+          [bbox.maxX, bbox.minY],
+          [bbox.maxX, bbox.maxY],
+          [bbox.minX, bbox.maxY],
+          [bbox.minX, bbox.minY],
+        ],
+      ],
+    };
+    const bboxedFlyoverGeometry = intersect(bboxGeometry, flyoverGeometry);
+    return (area(bboxedFlyoverGeometry) / area(bboxGeometry)) * 100;
   }
 
   public async updateLayerFromServiceIfNeeded(): Promise<void> {}

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -49,7 +49,7 @@ export class AbstractLayer {
     throw new Error('Not implemented yet');
   }
 
-  public findFlyoverIntervals(bbox: BBox, tiles: Tile[]): FlyoverInterval[] {
+  public findFlyovers(bbox: BBox, tiles: Tile[]): FlyoverInterval[] {
     if (!this.dataset || !this.dataset.orbitTimeMinutes) {
       throw new Error('Orbit time is needed for grouping tiles into flyovers.');
     }

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -62,6 +62,7 @@ export type PaginatedTiles = {
 export type FlyoverInterval = {
   fromTime: Date;
   toTime: Date;
+  coveragePercent: number;
 };
 
 export type MimeType =

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -1,6 +1,7 @@
 import {
   S1GRDEOCloudLayer,
   CRS_EPSG3857,
+  CRS_EPSG4326,
   BBox,
   MimeTypes,
   ApiType,
@@ -23,6 +24,7 @@ if (!process.env.EOC_S1GRDIW_LAYER_ID) {
 const instanceId = process.env.EOC_INSTANCE_ID;
 const layerId = process.env.EOC_S1GRDIW_LAYER_ID;
 const bbox = new BBox(CRS_EPSG3857, 1487158.82, 5322463.15, 1565430.34, 5400734.67);
+const bbox4326 = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
 
 export default {
   title: 'Sentinel 1 GRD IW - EOCloud',
@@ -144,7 +146,7 @@ export const getMapWMSEvalscript = () => {
   return wrapperEl;
 };
 
-export const findTiles = () => {
+export const findTilesEPSG3857 = () => {
   const layer = new S1GRDEOCloudLayer(
     instanceId,
     layerId,
@@ -159,12 +161,46 @@ export const findTiles = () => {
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = "<h2>findTiles</h2>";
+  wrapperEl.innerHTML = "<h2>findTiles - BBox in EPSG:3857</h2>";
   wrapperEl.insertAdjacentElement("beforeend", containerEl);
 
   const perform = async () => {
     const data = await layer.findTiles(
       bbox,
+      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+      5,
+      null,
+      OrbitDirection.ASCENDING,
+    );
+    renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findTilesEPSG4326 = () => {
+  const layer = new S1GRDEOCloudLayer(
+    instanceId,
+    layerId,
+    null,
+    null,
+    null,
+    null,
+    AcquisitionMode.IW,
+    Polarization.DV,
+    OrbitDirection.ASCENDING,
+  );
+  const containerEl = document.createElement('pre');
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findTiles - BBox in EPSG:4326</h2>";
+  wrapperEl.insertAdjacentElement("beforeend", containerEl);
+
+  const perform = async () => {
+    const data = await layer.findTiles(
+      bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
       5,

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -308,7 +308,7 @@ export const findFlyovers = () => {
       0,
     );
 
-    const flyovers = layer.findFlyoverIntervals(bbox, tiles);
+    const flyovers = layer.findFlyovers(bbox, tiles);
     flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
 
     // prepare an image to show that the number makes sense:

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -300,15 +300,13 @@ export const findFlyovers = () => {
     await setAuthTokenWithOAuthCredentials();
     const fromTime = new Date(Date.UTC(2020, 1 - 1, 15, 0, 0, 0));
     const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59));
-    const { tiles } = await layer.findTiles(
+    const flyovers = await layer.findFlyovers(
       bbox,
       fromTime,
       toTime,
+      20,
       50,
-      0,
     );
-
-    const flyovers = layer.findFlyovers(bbox, tiles);
     flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
 
     // prepare an image to show that the number makes sense:

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -266,6 +266,7 @@ export const findTiles = () => {
   wrapperEl.insertAdjacentElement("beforeend", containerEl);
 
   const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
     const data = await layer.findTiles(
       bbox,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
@@ -274,6 +275,53 @@ export const findTiles = () => {
       0,
     );
     renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findFlyovers = () => {
+  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const bbox = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const fromTime = new Date(Date.UTC(2020, 1 - 1, 15, 0, 0, 0));
+    const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59));
+    const { tiles } = await layer.findTiles(
+      bbox,
+      fromTime,
+      toTime,
+      50,
+      0,
+    );
+
+    const flyovers = layer.findFlyoverIntervals(bbox, tiles);
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});
 

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -256,9 +256,35 @@ export const getMapProcessingFromLayer = () => {
   return wrapperEl;
 };
 
-export const findTiles = () => {
+export const findTilesEPSG3857 = () => {
   const layer = new S1GRDAWSEULayer(instanceId, layerId);
-  const bbox = new BBox(CRS_EPSG4326, 11.9, 12.34, 42.05, 42.19);
+  const bbox = new BBox(CRS_EPSG3857, 1487158.82, 5322463.15, 1565430.34, 5400734.67);
+  const bbox4326 = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
+  const containerEl = document.createElement('pre');
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findTiles</h2>";
+  wrapperEl.insertAdjacentElement("beforeend", containerEl);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const data = await layer.findTiles(
+      bbox,
+      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+      5,
+      0,
+    );
+    renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findTilesEPSG4326 = () => {
+  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const bbox = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es2016",
     "moduleResolution": "node",
     "typeRoots": [
-      "src/customTypings/@types/union"
+      "src/customTypings/@types/union",
+      "node_modules/@types"
     ],
     "esModuleInterop": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     "outDir": "./dist",
     "target": "es2016",
     "moduleResolution": "node",
+    "typeRoots": [
+      "src/customTypings/@types/union"
+    ],
     "esModuleInterop": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
This PR implements calculation of coverage in `findFlyovers()` (previously known as `findFlyoverIntervals()`). I had reservations about whether this should be implemented inside this function or outside (for performance reasons), but it would complicate interface a bit, so I decided to add it in.

`@turf/union` didn't have TypeScript types definitions ready, so I had to come up with my own. Not an expert here, would appreciate feedback.

**EDIT**: The interface for `findFlyovers()` is now changed so that it fetches tiles itself, thus avoiding possible user mistakes (ignoring `hasMore`). 
