### PR TITLE
Cleanup: bbox should know how to convert itself to GeoJSON to avoid code duplication

### DIFF
--- a/src/bbox.ts
+++ b/src/bbox.ts
@@ -20,4 +20,22 @@ export class BBox {
     this.minY = minY;
     this.maxY = maxY;
   }
+
+  // Note that Turf's Polygon type (which is basically what we are returning) doesn't
+  // allow 'crs' property, so we must return type :any.
+  public toGeoJSON(): any {
+    return {
+      type: 'Polygon',
+      crs: { type: 'name', properties: { name: this.crs.urn } },
+      coordinates: [
+        [
+          [this.minX, this.minY],
+          [this.maxX, this.minY],
+          [this.maxX, this.maxY],
+          [this.minX, this.maxY],
+          [this.minX, this.minY],
+        ],
+      ],
+    };
+  }
 }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -133,18 +133,7 @@ export class AbstractLayer {
   }
 
   private calculateCoveragePercent(bbox: BBox, flyoverGeometry: Polygon | MultiPolygon): number {
-    const bboxGeometry: Polygon = {
-      type: 'Polygon',
-      coordinates: [
-        [
-          [bbox.minX, bbox.minY],
-          [bbox.maxX, bbox.minY],
-          [bbox.maxX, bbox.maxY],
-          [bbox.minX, bbox.maxY],
-          [bbox.minX, bbox.minY],
-        ],
-      ],
-    };
+    const bboxGeometry: Polygon = bbox.toGeoJSON();
     const bboxedFlyoverGeometry = intersect(bboxGeometry, flyoverGeometry);
     return (area(bboxedFlyoverGeometry) / area(bboxGeometry)) * 100;
   }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -76,20 +76,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     if (!this.dataset.searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');
     }
-    const bboxPolygon = {
-      type: 'Polygon',
-      crs: { type: 'name', properties: { name: bbox.crs.urn } },
-      coordinates: [
-        [
-          [bbox.minX, bbox.minY],
-          [bbox.maxX, bbox.minY],
-          [bbox.maxX, bbox.maxY],
-          [bbox.minX, bbox.maxY],
-          [bbox.minX, bbox.minY],
-        ],
-      ],
-    };
-    const payload = bboxPolygon;
+    const payload = bbox.toGeoJSON();
     const params = {
       expand: 'true',
       timefrom: fromTime.toISOString(),

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -160,19 +160,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!this.dataset.searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');
     }
-    const bboxPolygon = {
-      type: 'Polygon',
-      crs: { type: 'name', properties: { name: bbox.crs.urn } },
-      coordinates: [
-        [
-          [bbox.minX, bbox.maxY],
-          [bbox.maxX, bbox.maxY],
-          [bbox.maxX, bbox.minY],
-          [bbox.minX, bbox.minY],
-          [bbox.minX, bbox.maxY],
-        ],
-      ],
-    };
+    const bboxPolygon = bbox.toGeoJSON();
     // Note: we are requesting maxCloudCoverage as a number between 0 and 1, but in
     // the tiles we get cloudCoverPercentage (0..100).
     const payload: any = {


### PR DESCRIPTION
Code cleanup.

`BBox` instance `toGeoJSON()`'s result had to be defined as `:any`, because turf's `Polygon` doesn't allow `crs` to be specified, and we need it when specifying payload for Sentinel Hub Processing API.