### PR TITLE
Return meta.averageCloudCoverPercent from findFlyovers()

### DIFF
--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -63,6 +63,7 @@ export type FlyoverInterval = {
   fromTime: Date;
   toTime: Date;
   coveragePercent: number;
+  meta: Record<string, any>;
 };
 
 export type MimeType =

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -259,6 +259,52 @@ export const S1GRDFindTiles = () => {
   return wrapperEl;
 };
 
+export const findFlyovers = () => {
+  const layer = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const bbox = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
+    const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59));
+    const flyovers = await layer.findFlyovers(
+      bbox,
+      fromTime,
+      toTime,
+      20,
+      50,
+    );
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+
 function renderTilesList(containerEl, list) {
   list.forEach(tile => {
     const ul = document.createElement('ul');


### PR DESCRIPTION
In some cases it is beneficial to know the cloud cover percentage for flyovers (for datasets that support it).

Note that "average" is calculated very imprecisely - it is just the average value of the CC of the tiles that intersect the bounding box, no matter how big the intersection is. This can be improved in the future if needed.