### PR TITLE
Upgraded turf/union to v6 - node example throws exception otherwise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,19 +2155,13 @@
       }
     },
     "@turf/union": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.3.tgz",
+      "integrity": "sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        }
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "martinez-polygon-clipping": "^0.4.3"
       }
     },
     "@types/babel__core": {
@@ -14282,11 +14276,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@turf/area": "^6.0.1",
     "@turf/helpers": "^6.1.4",
     "@turf/intersect": "^6.1.3",
-    "@turf/union": "^5.1.5",
+    "@turf/union": "^6.0.3",
     "@types/xml2js": "^0.4.4",
     "axios": "^0.18.1",
     "query-string": "^6.4.2",


### PR DESCRIPTION
Turf.union is sometimes throwing an exception along the lines:
```
EOBTimelapsePanel.js:193 TypeError: Cannot read property 'type' of undefined
    at Ie.read (jsts.min.js:1)
    at Ne.read (jsts.min.js:1)
    at union (main.es.js:32)
    at S2L2ALayer.<anonymous> (sentinelHub.esm.js:440)
    at Generator.next (<anonymous>)
    at fulfilled (sentinelHub.esm.js:68)
```
The cause is this line:
```
currentFlyoverGeometry = union(currentFlyoverGeometry, tiles[tileIndex].geometry);
```

This PR upgrades to 6.0.3 - hopefully this will solve this error.