### PR TITLE
Fix return type, as union() returns a feature

### DIFF
--- a/src/customTypings/@turf/union/index.d.ts
+++ b/src/customTypings/@turf/union/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@turf/union' {
-  import { MultiPolygon, Polygon } from '@turf/helpers';
+  import { MultiPolygon, Polygon, Feature } from '@turf/helpers';
   export default function union(
     poly1: Polygon | MultiPolygon,
     poly2: Polygon | MultiPolygon,
-  ): Polygon | MultiPolygon;
+  ): Feature<Polygon | MultiPolygon>;
 }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -113,7 +113,7 @@ export class AbstractLayer {
 
       if (diffMS < orbitTimeMS) {
         flyoverIntervals[flyoverIndex].toTime = tiles[tileIndex].sensingTime;
-        currentFlyoverGeometry = union(currentFlyoverGeometry, tiles[tileIndex].geometry);
+        currentFlyoverGeometry = union(currentFlyoverGeometry, tiles[tileIndex].geometry).geometry;
         sumCloudCoverPercent =
           sumCloudCoverPercent !== undefined
             ? sumCloudCoverPercent + tiles[tileIndex].meta.cloudCoverPercent


### PR DESCRIPTION
Typing for turf union was incorrect, as it returns a geojson feature  and not a polygon or multipolygon