### PR TITLE
Fix/find flyovers errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2128,40 +2128,12 @@
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
       "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
     },
-    "@turf/intersect": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
-      "integrity": "sha512-SeAJG/zPRRTeyK2OifkPoyLq60q8tv8prpPIH3R8ZhyF4MdLOnMv5MURaQ6kQd+3UTDrL+pYm6rqbPvln1zqIw==",
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
-      }
-    },
-    "@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
-      "requires": {
-        "@turf/helpers": "6.x"
-      }
-    },
     "@turf/meta": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
       "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
       "requires": {
         "@turf/helpers": "6.x"
-      }
-    },
-    "@turf/union": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.3.tgz",
-      "integrity": "sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==",
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
       }
     },
     "@types/babel__core": {
@@ -10263,15 +10235,6 @@
         "unquote": "^1.1.0"
       }
     },
-    "martinez-polygon-clipping": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
-      "integrity": "sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==",
-      "requires": {
-        "splaytree": "^0.1.4",
-        "tinyqueue": "^1.2.0"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11398,6 +11361,21 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3"
+      }
+    },
+    "polygon-clipping": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.14.3.tgz",
+      "integrity": "sha512-bIaMFYIsHOShMN0JZsvkfk66S7gKMQMlYUpV7LIx+WOBYvJT09eCgoAv2JCDNj6SofA4+o5tlmV76zzUiG4aBQ==",
+      "requires": {
+        "splaytree": "^3.0.1"
+      },
+      "dependencies": {
+        "splaytree": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.0.1.tgz",
+          "integrity": "sha512-WvQIHRDXLSVn72xjlIG/WGhv/4QO3m+iY2TpVdFRaXd1+/vkNlpkpw1QaNH5taghF9eWXDHWMWnzXyicR8d6ig=="
+        }
       }
     },
     "popper.js": {
@@ -13510,11 +13488,6 @@
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
       "dev": true
     },
-    "splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
-    },
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -14104,11 +14077,6 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "dev": true,
       "optional": true
-    },
-    "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
   "dependencies": {
     "@turf/area": "^6.0.1",
     "@turf/helpers": "^6.1.4",
-    "@turf/intersect": "^6.1.3",
-    "@turf/union": "^6.0.3",
     "@types/xml2js": "^0.4.4",
     "axios": "^0.18.1",
+    "polygon-clipping": "^0.14.3",
     "query-string": "^6.4.2",
     "xml2js": "^0.4.19"
   },

--- a/src/customTypings/@turf/union/index.d.ts
+++ b/src/customTypings/@turf/union/index.d.ts
@@ -1,7 +1,0 @@
-declare module '@turf/union' {
-  import { MultiPolygon, Polygon, Feature } from '@turf/helpers';
-  export default function union(
-    poly1: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon,
-    poly2: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon,
-  ): Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon;
-}

--- a/src/customTypings/@turf/union/index.d.ts
+++ b/src/customTypings/@turf/union/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@turf/union' {
-  import { MultiPolygon, Polygon } from '@turf/helpers';
+  import { MultiPolygon, Polygon, Feature } from '@turf/helpers';
   export default function union(
-    poly1: Polygon | MultiPolygon,
-    poly2: Polygon | MultiPolygon,
-  ): Polygon | MultiPolygon;
+    poly1: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon,
+    poly2: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon,
+  ): Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon;
 }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -88,7 +88,10 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
 
     const url = `${this.dataset.searchIndexUrl}?${stringify(params, { sort: false })}`;
     const response = await axios.post(url, payload, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-CRS': 'EPSG:4326',
+      },
     });
 
     const responseTiles: any[] = response.data.tiles;

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -29,10 +29,9 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercent,
+      cloudCoverPercent: tile.cloudCoverPercentage,
     };
   }
 }

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -6,6 +6,7 @@ import {
   ApiType,
   DATASET_EOCLOUD_LANDSAT5,
   LayersFactory,
+  CRS_EPSG4326,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.EOC_INSTANCE_ID) {
@@ -156,6 +157,51 @@ export const findTiles = () => {
       0,
     );
     renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findFlyovers = () => {
+  const layer = new Landsat5EOCloudLayer(instanceId, layerId);
+  const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const fromTime = new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
+
+  const perform = async () => {
+    const flyovers = await layer.findFlyovers(
+      bbox4326,
+      fromTime,
+      toTime,
+      20,
+      50,
+    );
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});
 

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -6,6 +6,7 @@ import {
   ApiType,
   DATASET_EOCLOUD_LANDSAT5,
   LayersFactory,
+  CRS_EPSG4326,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.EOC_INSTANCE_ID) {
@@ -156,6 +157,51 @@ export const findTiles = () => {
       0,
     );
     renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findFlyovers = () => {
+  const layer = new Landsat7EOCloudLayer(instanceId, layerId);
+  const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const fromTime = new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
+
+  const perform = async () => {
+    const flyovers = await layer.findFlyovers(
+      bbox4326,
+      fromTime,
+      toTime,
+      20,
+      50,
+    );
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});
 

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -6,6 +6,7 @@ import {
   ApiType,
   DATASET_EOCLOUD_LANDSAT8,
   LayersFactory,
+  CRS_EPSG4326,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.EOC_INSTANCE_ID) {
@@ -156,6 +157,52 @@ export const findTiles = () => {
       0,
     );
     renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+
+export const findFlyovers = () => {
+  const layer = new Landsat8EOCloudLayer(instanceId, layerId);
+  const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const fromTime = new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
+
+  const perform = async () => {
+    const flyovers = await layer.findFlyovers(
+      bbox4326,
+      fromTime,
+      toTime,
+      20,
+      50,
+    );
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});
 

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -231,6 +231,7 @@ export const findTiles = () => {
   wrapperEl.insertAdjacentElement("beforeend", containerEl);
 
   const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
     const data = await layer.findTiles(
       bbox,
       new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -227,7 +227,6 @@ export const findFlyovers = () => {
   wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
 
   const perform = async () => {
-    console.log({layerId})
     const layer = (await LayersFactory.makeLayers(`${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`, (lId, datasetId) => (layerId === lId)))[0];
 
     const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -214,6 +214,50 @@ export const findTilesEPSG4326 = () => {
   return wrapperEl;
 };
 
+export const findFlyovers = () => {
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = "<h2>findFlyovers</h2>";
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement("beforeend", img);
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement("beforeend", flyoversContainerEl);
+
+  const perform = async () => {
+    console.log({layerId})
+    const layer = (await LayersFactory.makeLayers(`${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`, (lId, datasetId) => (layerId === lId)))[0];
+
+    const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
+    const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59));
+    const flyovers = await layer.findFlyovers(
+      bbox4326,
+      fromTime,
+      toTime,
+      20,
+      50,
+    );
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true)
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
 function renderTilesList(containerEl, list) {
   list.forEach(tile => {
     const ul = document.createElement('ul');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,6 @@
     "outDir": "./dist",
     "target": "es2016",
     "moduleResolution": "node",
-    "typeRoots": [
-      "src/customTypings/@types/union",
-      "node_modules/@types"
-    ],
     "esModuleInterop": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
- uses [polygon-clipping](https://github.com/mfogel/polygon-clipping) instead of Turf union/intersect due to numerous bugs (invalid intersection calculation, sometimes hangs)
- the tiles are now fetched on-the-go, as we are calculating the flyovers (less memory consumption)
- improved robustness (better error handling)
