### PR TITLE
Use Moment.js for all findTiles/findFlyovers times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10534,6 +10534,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@turf/helpers": "^6.1.4",
     "@types/xml2js": "^0.4.4",
     "axios": "^0.18.1",
+    "moment": "^2.24.0",
     "polygon-clipping": "^0.14.3",
     "query-string": "^6.4.2",
     "xml2js": "^0.4.19"

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Moment } from 'moment';
 
 import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval } from 'src/layer/const';
 import { BBox } from 'src/bbox';
@@ -40,8 +41,8 @@ export class AbstractLayer {
 
   public async findTiles(
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
-    fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
+    fromTime: Moment, // eslint-disable-line @typescript-eslint/no-unused-vars
+    toTime: Moment, // eslint-disable-line @typescript-eslint/no-unused-vars
     maxCount: number = 50, // eslint-disable-line @typescript-eslint/no-unused-vars
     offset: number = 0, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<PaginatedTiles> {
@@ -50,8 +51,8 @@ export class AbstractLayer {
 
   public async findFlyovers(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxFindTilesRequests: number = 50,
     tilesPerRequest: number = 50,
   ): Promise<FlyoverInterval[]> {
@@ -62,7 +63,7 @@ export class AbstractLayer {
       throw new Error('Currently, only EPSG:4326 in findFlyovers');
     }
 
-    const orbitTimeMS = this.dataset.orbitTimeMinutes * 60 * 1000;
+    const orbitTimeS = this.dataset.orbitTimeMinutes * 60;
     const bboxGeometry: Geom = this.roundCoordinates([
       [
         [bbox.minX, bbox.minY],
@@ -109,10 +110,10 @@ export class AbstractLayer {
         }
 
         // append the tile to flyovers:
-        const prevDateMS = flyovers[flyoverIndex].fromTime.getTime();
-        const currDateMS = tiles[tileIndex].sensingTime.getTime();
-        const diffMS = Math.abs(prevDateMS - currDateMS);
-        if (diffMS > orbitTimeMS) {
+        const prevDateS = flyovers[flyoverIndex].fromTime.unix();
+        const currDateS = tiles[tileIndex].sensingTime.unix();
+        const diffS = Math.abs(prevDateS - currDateS);
+        if (diffS > orbitTimeS) {
           // finish the old flyover:
           try {
             flyovers[flyoverIndex].coveragePercent = this.calculateCoveragePercent(

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { stringify } from 'query-string';
+import moment, { Moment } from 'moment';
 
 import { BBox } from 'src/bbox';
 import { GetMapParams, ApiType, PaginatedTiles } from 'src/layer/const';
@@ -68,8 +69,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount: number = 50,
     offset: number = 0,
   ): Promise<PaginatedTiles> {
@@ -98,7 +99,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     return {
       tiles: responseTiles.map(tile => ({
         geometry: tile.tileDrawRegionGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: this.extractFindTilesMeta(tile),
       })),
       hasMore: response.data.hasMore,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import moment, { Moment } from 'moment';
 
 import { getAuthToken, isAuthTokenSet } from 'src/auth';
 import { BBox } from 'src/bbox';
@@ -150,8 +151,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -159,7 +160,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: {},
       })),
       hasMore: response.data.hasMore,
@@ -168,8 +169,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected fetchTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount: number = 1,
     offset: number = 0,
     maxCloudCoverPercent?: number | null,

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,3 +1,5 @@
+import moment, { Moment } from 'moment';
+
 import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
@@ -22,8 +24,8 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -38,7 +40,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: {
           cloudCoverPercent: tile.cloudCoverPercentage,
         },

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -1,4 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
+import moment, { Moment } from 'moment';
+
 import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
@@ -51,8 +53,8 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -78,7 +80,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       tiles: response.data.tiles.map(tile => {
         return {
           geometry: tile.dataGeometry,
-          sensingTime: tile.sensingTime,
+          sensingTime: moment.utc(tile.sensingTime),
           meta: {
             cloudCoverPercent: tile.cloudCoverPercentage,
           },

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -1,3 +1,5 @@
+import moment, { Moment } from 'moment';
+
 import { BBox } from 'src/bbox';
 import { BackscatterCoeff, PaginatedTiles } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -108,8 +110,8 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -135,7 +137,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: {
           orbitDirection: tile.orbitDirection,
           polarization: tile.polarization,

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,3 +1,5 @@
+import moment, { Moment } from 'moment';
+
 import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S3OLCI } from 'src/layer/dataset';
@@ -8,8 +10,8 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -17,7 +19,7 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: {},
       })),
       hasMore: response.data.hasMore,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -4,6 +4,7 @@ import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { OrbitDirection } from 'src';
 import { ProcessingPayload } from 'src/layer/processing';
+import moment, { Moment } from 'moment';
 
 type S3SLSTRFindTilesDatasetParameters = {
   type?: string;
@@ -48,8 +49,8 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -70,7 +71,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
-        sensingTime: new Date(tile.sensingTime),
+        sensingTime: moment.utc(tile.sensingTime),
         meta: {
           cloudCoverPercent: tile.cloudCoverPercentage,
           orbitDirection: tile.orbitDirection,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -3,6 +3,7 @@ import { PaginatedTiles } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
+import moment, { Moment } from 'moment';
 
 /*
   S-5P is a bit special in that we need to supply productType when searching
@@ -63,8 +64,8 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
 
   public async findTiles(
     bbox: BBox,
-    fromTime: Date,
-    toTime: Date,
+    fromTime: Moment,
+    toTime: Moment,
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
@@ -89,7 +90,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
       tiles: response.data.tiles.map(tile => {
         return {
           geometry: tile.tileDrawRegionGeometry,
-          sensingTime: tile.sensingTime,
+          sensingTime: moment.utc(tile.sensingTime),
           meta: {},
         };
       }),

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -1,5 +1,7 @@
-import { BBox } from 'src/bbox';
+import { Moment } from 'moment';
 import { Polygon, MultiPolygon } from '@turf/helpers';
+
+import { BBox } from 'src/bbox';
 
 export type GetMapParams = {
   bbox: BBox;
@@ -50,7 +52,7 @@ export enum BackscatterCoeff {
 
 export type Tile = {
   geometry: Polygon | MultiPolygon;
-  sensingTime: Date;
+  sensingTime: Moment;
   meta: Record<string, any>;
 };
 
@@ -60,8 +62,8 @@ export type PaginatedTiles = {
 };
 
 export type FlyoverInterval = {
-  fromTime: Date;
-  toTime: Date;
+  fromTime: Moment;
+  toTime: Moment;
   coveragePercent: number;
   meta: Record<string, any>;
 };


### PR DESCRIPTION
Instead of battling with the JS `Date` timezones, this PR includes Moment.js. Unfortunately this makes the library a bit bigger - we might revisit this decision in near future.

Note that this change only applies to `findTiles()` and `findFlyovers()`.