### PR TITLE
Lock S3SLSTR to DESCENDING (other images are blank)

### DIFF
--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -26,12 +26,12 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     title: string | null = null,
     description: string | null = null,
     maxCloudCoverPercent: number | null = 100,
-    orbitDirection: OrbitDirection | null = null,
     view: 'NADIR' | 'OBLIQUE' = 'NADIR',
   ) {
     super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
     this.maxCloudCoverPercent = maxCloudCoverPercent;
-    this.orbitDirection = orbitDirection;
+    // images that are not DESCENDING are blank, so we can hardcode this:
+    this.orbitDirection = OrbitDirection.DESCENDING;
     this.view = view;
   }
 

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -168,8 +168,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S3SLSTRLayer(instanceId, layerId, null, null, null, null, null,
-     60, OrbitDirection.DESCENDING, 'OBLIQUE');
+  const layer = new S3SLSTRLayer(instanceId, layerId, null, null, null, null, null, 60, 'NADIR');
   const bbox = new BBox(CRS_EPSG4326, 11.9, 12.34, 42.05, 42.19);
   const containerEl = document.createElement('pre');
 


### PR DESCRIPTION
It looks like ASCENDING images are empty for S3SLSTR (will investigate further). As a temporary fix, we enforce descending `orbitDirection`.