### PR TITLE
Specify orbitDirection with S-3 SLSTR to avoid blank images

### DIFF
--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -32,13 +32,14 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   ) {
     super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
     this.maxCloudCoverPercent = maxCloudCoverPercent;
-    // images that are not DESCENDING are blank, so we can hardcode this:
+    // images that are not DESCENDING appear empty:
     this.orbitDirection = OrbitDirection.DESCENDING;
     this.view = view;
   }
 
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
     return payload;
   }
 

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -108,7 +108,7 @@ export const getMapProcessing = () => {
     const getMapParams = {
       bbox: bbox4326,
       fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 12, 23, 59, 59)),
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,


### PR DESCRIPTION
The images with S-3 SLSTR appear empty when orbit direction is ASC, so we need to specify this parameter when using Processing API.