### PR TITLE
Fix/named parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 dist/
+doc/
 # dependencies
 node_modules
 .env

--- a/README.md
+++ b/README.md
@@ -35,36 +35,57 @@ $ npm install @sentinel-hub/sentinelhub-js
 
 ## Layers
 
-The core data structure is `Layer`, which corresponds to a _layer_ as returned by OGC WMS GetCapabilities request. If the URL matches one of the Sentinel Hub service URLs, additional capabilities are unlocked.
-
-Basic (WMS-capable) `Layer` can be initialized like this:
+The core data structure is `Layer`, which corresponds to a _layer_ as returned by OGC WMS GetCapabilities request. Basic (WMS-capable) `Layer` can be initialized like this:
 
 ```javascript
   import { WmsLayer } from '@sentinel-hub/sentinelhub-js';
 
-  const layer = new WmsLayer('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', '<layer-id>', 'Title', 'Description');
+  const layer = new WmsLayer({
+    url: 'https://services.sentinel-hub.com/ogc/wms/<your-instance-id>',
+    layerId: '<layer-id>',
+  });
 ```
 
-Such layer would only allow WMS requests. However, `Layer` is also a superclass for multiple dataset-specific subclasses (like `S1GRDAWSEULayer` - Sentinel-1 GRD data on AWS eu-central-1 Sentinel Hub endpoint) which can be instantiated with their own specific parameters and thus unlock additional powers.
+Such layer would only allow WMS requests. However, `Layer` is also a superclass for multiple dataset-specific subclasses (like `S1GRDAWSEULayer` - Sentinel-1 GRD data on AWS eu-central-1 Sentinel Hub endpoint) which can be instantiated with their own specific parameters and thus have additional capabilities.
 
 When it comes to Sentinel Hub layers, there are four ways to determine their content:
 
-- by `layerId`: ID of the layer, as used by OGC WMS and SentinelHub Configurator
+- by `instanceId` and `layerId`: ID of the layer, as used by OGC WMS and SentinelHub Configurator
 - by `evalscript`: custom (javascript) code that will be executed by the service per each pixel and will calculate the (usually RGB/RGBA) values
 - by `evalscriptUrl`: the URL from which the evalscript can be downloaded from
-- by `dataProduct`: the structure which contains an ID of a pre-existing product
+- by `dataProduct`: the ID of a pre-existing data product
 
 ```javascript
   import { S1GRDAWSEULayer } from '@sentinel-hub/sentinelhub-js';
 
   let layerS1;
-  layerS1 = new S1GRDAWSEULayer(instanceId, '<layer-id>', null, null, null, 'Title', 'Description');
-  layerS1 = new S1GRDAWSEULayer(null, null, myEvalscript, null, null, 'Title', 'Description', 'IW', 'DV', 'HIGH');
-  layerS1 = new S1GRDAWSEULayer(null, null, null, myEvalscriptUrl, null, 'Title', 'Description', 'IW', 'DV', 'HIGH');
-  layerS1 = new S1GRDAWSEULayer(null, null, null, null, '<data-product-id>', 'Title', 'Description', 'EW', 'DH', 'MEDIUM');
+  layerS1 = new S1GRDAWSEULayer({
+    instanceId: '<my-instance-id>',
+    layerId: '<layer-id>',
+  );
+  layerS1 = new S1GRDAWSEULayer({
+    evalscript: myEvalscript,
+    title: 'Title',
+    description: 'Description',
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+  });
+  layerS1 = new S1GRDAWSEULayer({
+    evalscriptUrl: myEvalscriptUrl,
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+  });
+  layerS1 = new S1GRDAWSEULayer({
+    dataProduct: '<data-product-id>',
+    acquisitionMode: AcquisitionMode.EW,
+    polarization: Polarization.DH,
+    resolution: Resolution.MEDIUM,
+  });
 ```
 
-It is also possible to create layers as they are defined in Sentinel Hub configuration instance:
+It is also possible to create layers by importing their definitions from the Sentinel Hub configuration instance:
 
 ```javascript
   import { LayersFactory } from '@sentinel-hub/sentinelhub-js';
@@ -103,23 +124,32 @@ The process of getting the authentication token is described in [Authentication 
 
 ## Fetching images
 
-Maps which correspond to these layers can be fetched via different protocols like WMS and Processing. Not all of the protocols can be used in all cases; for example, Processing can only render layers for which it has access to the `evalscript` and for which evalscript version 3 is used.
+Maps which correspond to these layers can be fetched via different protocols like WMS and Processing. Not all of the protocols can be used in all cases; for example, Processing can only render layers for which it has `evalscript` available and for which evalscript version 3 is used.
 
 ```javascript
   import { BBox, CRS_EPSG4326, MimeTypes, ApiType } from '@sentinel-hub/sentinelhub-js';
 
   const bbox = new BBox(CRS_EPSG4326, 18, 20, 20, 22);
-  const getMapParams = {
+  const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
+  const imageBlob = await layer.getMap({
     bbox: bbox,
-    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
-    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    fromTime: fromTime,
+    toTime: toTime,
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-  };
-
-  const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-  const imageBlob2 = await layer.getMap(getMapParams, ApiType.PROCESSING);
+    api: ApiType.WMS,
+  });
+  const imageBlob2 = await layer.getMap({
+    bbox: bbox,
+    fromTime: fromTime,
+    toTime: toTime,
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG,
+    api: ApiType.PROCESSING,
+  });
 ```
 
 Note that both of the images above should be _exactly_ the same.
@@ -127,8 +157,16 @@ Note that both of the images above should be _exactly_ the same.
 In some cases we can retrieve just the image URL instead of a blob:
 
 ```javascript
-  const imageUrl = await layer.getMapUrl(getMapParams, ApiType.WMS);
-  const imageUrl2 = await layer.getMapUrl(getMapParams, ApiType.PROCESSING); // exception thrown - Processing API does not support HTTP GET method
+  const imageBlob = await layer.getMapUrl({
+    bbox: bbox,
+    fromTime: fromTime,
+    toTime: toTime,
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG,
+    api: ApiType.WMS,
+  });
+  // for ApiType.PROCESSING, exception would be thrown - Processing API does not support HTTP GET method
 ```
 
 It is also possible to determine whether a layer supports a specific ApiType:
@@ -148,17 +186,22 @@ We can always use layer to search for data availability:
 ```typescript
   import { OrbitDirection } from '@sentinel-hub/sentinelhub-js';
 
-  const maxCloudCoverPercent = 50;
-  const layerS2L2A = new S2L2ALayer(instanceId, 'S2L2A', null, null, null, null, null, maxCloudCoverPercent);
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: '<my-instance-id>',
+    layerId: 'LAYER_S2L2A',
+    maxCloudCoverPercent: 50,
+  });
   const { tiles, hasMore } = await layerS2L2A.findTiles(bbox, fromTime, toTime, maxCount, offset);
   const flyoversS2L2A = await layerS2L2A.findFlyovers(bbox, fromTime, toTime);
   const datesS2L2A = await layerS2L2A.findDates(bbox, fromTime, toTime);
 
-  const layerS1 = new S1GRDAWSEULayer(
-    instanceId, 'LayerS1GRD',
-    null, null, null, null, null, null, null, null,
-    true, BackscatterCoeff.GAMMA0_ELLIPSOID, OrbitDirection.ASCENDING
-  );
+  const layerS1 = new S1GRDAWSEULayer({
+    instanceId: '<my-instance-id>',
+    layerId: 'LAYER_S1GRD',
+    orthorectify: true,
+    backscatterCoeff: BackscatterCoeff.GAMMA0_ELLIPSOID,
+    orbitDirection: OrbitDirection.ASCENDING,
+  });
   const { tiles: tilesS1 } = await layerS1.findTiles(bbox, fromTime, toTime, maxCount, offset);
   const flyoversS1 = await layerS1.findFlyovers(bbox, fromTime, toTime);
   const datesS1 = await layerS1.findDates(bbox, fromTime, toTime);

--- a/README.md
+++ b/README.md
@@ -130,26 +130,17 @@ Maps which correspond to these layers can be fetched via different protocols lik
   import { BBox, CRS_EPSG4326, MimeTypes, ApiType } from '@sentinel-hub/sentinelhub-js';
 
   const bbox = new BBox(CRS_EPSG4326, 18, 20, 20, 22);
-  const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
-  const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
-  const imageBlob = await layer.getMap({
+  const getMapParams = {
     bbox: bbox,
-    fromTime: fromTime,
-    toTime: toTime,
+    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
-    api: ApiType.WMS,
-  });
-  const imageBlob2 = await layer.getMap({
-    bbox: bbox,
-    fromTime: fromTime,
-    toTime: toTime,
-    width: 512,
-    height: 512,
-    format: MimeTypes.JPEG,
-    api: ApiType.PROCESSING,
-  });
+  };
+
+  const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+  const imageBlob2 = await layer.getMap(getMapParams, ApiType.PROCESSING);
 ```
 
 Note that both of the images above should be _exactly_ the same.
@@ -157,16 +148,8 @@ Note that both of the images above should be _exactly_ the same.
 In some cases we can retrieve just the image URL instead of a blob:
 
 ```javascript
-  const imageBlob = await layer.getMapUrl({
-    bbox: bbox,
-    fromTime: fromTime,
-    toTime: toTime,
-    width: 512,
-    height: 512,
-    format: MimeTypes.JPEG,
-    api: ApiType.WMS,
-  });
-  // for ApiType.PROCESSING, exception would be thrown - Processing API does not support HTTP GET method
+  const imageUrl = await layer.getMapUrl(getMapParams, ApiType.WMS);
+  const imageUrl2 = await layer.getMapUrl(getMapParams, ApiType.PROCESSING); // exception thrown - Processing API does not support HTTP GET method
 ```
 
 It is also possible to determine whether a layer supports a specific ApiType:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The core data structure is `Layer`, which corresponds to a _layer_ as returned b
   import { WmsLayer } from '@sentinel-hub/sentinelhub-js';
 
   const layer = new WmsLayer({
-    url: 'https://services.sentinel-hub.com/ogc/wms/<your-instance-id>',
+    baseUrl: 'https://services.sentinel-hub.com/ogc/wms/<your-instance-id>',
     layerId: '<layer-id>',
   });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2248,6 +2248,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "13.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
@@ -3552,6 +3558,15 @@
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
         "lodash": "^4.17.11"
+      }
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -7460,6 +7475,26 @@
         "pify": "^4.0.1"
       }
     },
+    "handlebars": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -9843,6 +9878,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10164,6 +10205,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
@@ -10234,6 +10281,12 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
+    },
+    "marked": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -10988,6 +11041,24 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
           "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+          "dev": true
+        }
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
       }
@@ -14308,6 +14379,51 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.16.11.tgz",
+      "integrity": "sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "3.0.3",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.2",
+        "highlight.js": "^9.17.1",
+        "lodash": "^4.17.15",
+        "marked": "^0.8.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "^0.7.2",
+        "typescript": "3.7.x"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.18.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+          "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.7.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz",
+      "integrity": "sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.8",
+        "underscore": "^1.9.1"
+      }
+    },
     "typescript": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
@@ -14337,6 +14453,12 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+      "dev": true
     },
     "unfetch": {
       "version": "4.1.0",
@@ -15004,6 +15126,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
       "node_modules",
       "."
     ],
-    "testRegex": "/__tests__/.*\\.(ts|tsx|js)$"
+    "testRegex": "/__tests__/.*\\.(ts|tsx|js)$",
+    "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
   },
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-typescript2": "^0.20.1",
     "ts-jest": "^25.2.0",
+    "typedoc": "^0.16.11",
     "typescript": "^3.5.1"
   },
   "scripts": {
@@ -41,7 +42,8 @@
     "lint": "eslint --max-warnings 0 --ext .ts,js src/",
     "prettier": "prettier --write \"{src,example,stories}/**/*.{ts,js}\"",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "build-doc": "typedoc --excludePrivate --excludeProtected --out doc/ src/"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes } from 'src/layer/const';
+import { ApiType, MimeTypes, OrbitDirection } from 'src/layer/const';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
 import {
@@ -39,7 +39,7 @@ import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
 import { BYOCLayer } from 'src/layer/BYOCLayer';
 
 import { legacyGetMapFromUrl, legacyGetMapWmsUrlFromParams, legacyGetMapFromParams } from 'src/legacyCompat';
-import { AcquisitionMode, Polarization, Resolution, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
+import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 
 registerAxiosCacheRetryInterceptors();

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { S1GRDAWSEULayer } from 'src/layer/S1GRDAWSEULayer';
 import { S1GRDEOCloudLayer } from 'src/layer/S1GRDEOCloudLayer';
 import { S2L2ALayer } from 'src/layer/S2L2ALayer';
 import { S2L1CLayer } from 'src/layer/S2L1CLayer';
-import { S3SLSTRLayer } from 'src/layer/S3SLSTRLayer';
+import { S3SLSTRLayer, S3SLSTRView } from 'src/layer/S3SLSTRLayer';
 import { S3OLCILayer } from 'src/layer/S3OLCILayer';
 import { S5PL2Layer } from 'src/layer/S5PL2Layer';
 import { EnvisatMerisEOCloudLayer } from 'src/layer/EnvisatMerisEOCloudLayer';
@@ -93,6 +93,7 @@ export {
   Polarization,
   Resolution,
   OrbitDirection,
+  S3SLSTRView,
   BBox,
   // legacy:
   legacyGetMapFromUrl,

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -10,12 +10,17 @@ import { union, intersection, Geom } from 'polygon-clipping';
 
 import { CRS_EPSG4326 } from 'src/crs';
 
+interface ConstructorParameters {
+  title?: string | null;
+  description?: string | null;
+}
+
 export class AbstractLayer {
   public title: string | null = null;
   public description: string | null = null;
   public readonly dataset: Dataset | null = null;
 
-  public constructor(title: string | null = null, description: string | null = null) {
+  public constructor({ title = null, description = null }: ConstructorParameters) {
     this.title = title;
     this.description = description;
   }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -7,6 +7,15 @@ import { GetMapParams, ApiType, PaginatedTiles } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  title?: string | null;
+  description?: string | null;
+}
+
 // this class provides any SHv1- or SHv2-specific (EO Cloud) functionality to the subclasses:
 export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   protected instanceId: string;
@@ -14,15 +23,15 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
 
-  public constructor(
-    instanceId: string,
-    layerId: string,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-  ) {
-    super(title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    title = null,
+    description = null,
+  }: ConstructorParameters) {
+    super({ title, description });
     if (!layerId || !instanceId) {
       throw new Error('Parameters instanceId and layerId must be specified!');
     }

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,19 +1,29 @@
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  title?: string | null;
+  description?: string | null;
+  maxCloudCoverPercent?: number | null;
+}
+
 // same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
 export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {
   public maxCloudCoverPercent: number;
 
-  public constructor(
-    instanceId: string,
-    layerId: string,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    maxCloudCoverPercent: number | null = 100,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    title = null,
+    description = null,
+    maxCloudCoverPercent = 100,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, title, description });
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -9,6 +9,16 @@ import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+}
+
 // this class provides any SHv3-specific functionality to the subclasses:
 export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected instanceId: string | null;
@@ -17,16 +27,16 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected evalscriptUrl: string | null;
   protected dataProduct: string | null;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-  ) {
-    super(title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+  }: ConstructorParameters) {
+    super({ title, description });
     if (layerId === null && evalscript === null && evalscriptUrl === null && dataProduct === null) {
       throw new Error(
         'At least one of these parameters (layerId, evalscript, evalscriptUrl, dataProduct) must be specified!',

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -37,9 +37,14 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     description = null,
   }: ConstructorParameters) {
     super({ title, description });
-    if (layerId === null && evalscript === null && evalscriptUrl === null && dataProduct === null) {
+    if (
+      (layerId === null || instanceId === null) &&
+      evalscript === null &&
+      evalscriptUrl === null &&
+      dataProduct === null
+    ) {
       throw new Error(
-        'At least one of these parameters (layerId, evalscript, evalscriptUrl, dataProduct) must be specified!',
+        'At least one of these parameters (instanceId + layerId, evalscript, evalscriptUrl, dataProduct) must be specified!',
       );
     }
     this.instanceId = instanceId;

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -4,21 +4,32 @@ import { BBox } from 'src/bbox';
 import { PaginatedTiles } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+  maxCloudCoverPercent?: number | null;
+}
+
 // same as AbstractSentinelHubV3Layer, but with maxCloudCoverPercent (for layers which support it)
 export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer {
   public maxCloudCoverPercent: number;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    maxCloudCoverPercent: number | null = 100,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+    maxCloudCoverPercent = 100,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -7,6 +7,17 @@ import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+  collectionId?: string | null;
+}
+
 type BYOCFindTilesDatasetParameters = {
   type: string;
   collectionId: string;
@@ -16,17 +27,17 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_BYOC;
   protected collectionId: string;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    collectionId: string | null = null,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+    collectionId = null,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.collectionId = collectionId;
   }
 

--- a/src/layer/EnvisatMerisEOCloudLayer.ts
+++ b/src/layer/EnvisatMerisEOCloudLayer.ts
@@ -14,6 +14,13 @@ export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     title: string | null,
     description: string | null,
   ): EnvisatMerisEOCloudLayer {
-    return new EnvisatMerisEOCloudLayer(instanceId, layerId, evalscript, evalscriptUrl, title, description);
+    return new EnvisatMerisEOCloudLayer({
+      instanceId,
+      layerId,
+      evalscript,
+      evalscriptUrl,
+      title,
+      description,
+    });
   }
 }

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -14,7 +14,7 @@ export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
     description: string | null,
   ): Landsat5EOCloudLayer {
     const maxCloudCoverPercent = layerInfo.settings.maxCC;
-    return new Landsat5EOCloudLayer(
+    return new Landsat5EOCloudLayer({
       instanceId,
       layerId,
       evalscript,
@@ -22,6 +22,6 @@ export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       title,
       description,
       maxCloudCoverPercent,
-    );
+    });
   }
 }

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -14,7 +14,7 @@ export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
     description: string | null,
   ): Landsat7EOCloudLayer {
     const maxCloudCoverPercent = layerInfo.settings.maxCC;
-    return new Landsat7EOCloudLayer(
+    return new Landsat7EOCloudLayer({
       instanceId,
       layerId,
       evalscript,
@@ -22,6 +22,6 @@ export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       title,
       description,
       maxCloudCoverPercent,
-    );
+    });
   }
 }

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -14,7 +14,7 @@ export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
     description: string | null,
   ): Landsat8EOCloudLayer {
     const maxCloudCoverPercent = layerInfo.settings.maxCC;
-    return new Landsat8EOCloudLayer(
+    return new Landsat8EOCloudLayer({
       instanceId,
       layerId,
       evalscript,
@@ -22,6 +22,6 @@ export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       title,
       description,
       maxCloudCoverPercent,
-    );
+    });
   }
 }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -226,7 +226,7 @@ export class LayersFactory {
 
     return filteredLayersInfos.map(({ layerId, dataset, title, description }) => {
       if (!dataset) {
-        return new WmsLayer(baseUrl, layerId, title, description);
+        return new WmsLayer({ baseUrl, layerId, title, description });
       }
 
       const SHLayerClass = LayersFactory.LAYER_FROM_DATASET_V3[dataset.id];
@@ -300,7 +300,7 @@ export class LayersFactory {
       filterLayers === null ? layersInfos : layersInfos.filter(l => filterLayers(l.layerId, l.dataset));
 
     return filteredLayersInfos.map(
-      ({ layerId, title, description }) => new WmsLayer(baseUrl, layerId, title, description),
+      ({ layerId, title, description }) => new WmsLayer({ baseUrl, layerId, title, description }),
     );
   }
 }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -233,15 +233,15 @@ export class LayersFactory {
       if (!SHLayerClass) {
         throw new Error(`Dataset ${dataset.id} is not defined in LayersFactory.LAYER_FROM_DATASET`);
       }
-      return new SHLayerClass(
-        LayersFactory.parseSHInstanceId(baseUrl),
+      return new SHLayerClass({
+        instanceId: LayersFactory.parseSHInstanceId(baseUrl),
         layerId,
-        null,
-        null,
-        null,
+        evalscript: null,
+        evalscriptUrl: null,
+        dataProduct: null,
         title,
         description,
-      );
+      });
     });
   }
 

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -33,6 +33,22 @@ export enum Resolution {
   MEDIUM = 'MEDIUM',
 }
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+  acquisitionMode?: AcquisitionMode | null;
+  polarization?: Polarization | null;
+  resolution?: Resolution | null;
+  orthorectify?: boolean | null;
+  backscatterCoeff?: BackscatterCoeff | null;
+  orbitDirection?: OrbitDirection | null;
+}
+
 type S1GRDFindTilesDatasetParameters = {
   type: string;
   acquisitionMode: AcquisitionMode;
@@ -51,22 +67,22 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   public orthorectify: boolean | null = false;
   public backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    acquisitionMode: AcquisitionMode | null = null,
-    polarization: Polarization | null = null,
-    resolution: Resolution | null = null,
-    orthorectify: boolean | null = false,
-    backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID,
-    orbitDirection: OrbitDirection | null = null,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+    acquisitionMode = null,
+    polarization = null,
+    resolution = null,
+    orthorectify = false,
+    backscatterCoeff = BackscatterCoeff.GAMMA0_ELLIPSOID,
+    orbitDirection = null,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.acquisitionMode = acquisitionMode;
     this.polarization = polarization;
     this.resolution = resolution;

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { BackscatterCoeff, PaginatedTiles } from 'src/layer/const';
+import { BackscatterCoeff, PaginatedTiles, OrbitDirection } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
 
@@ -21,11 +21,6 @@ export enum Polarization {
   SH = 'SH',
   DH = 'DH',
   SV = 'SV',
-}
-
-export enum OrbitDirection {
-  ASCENDING = 'ASCENDING',
-  DESCENDING = 'DESCENDING',
 }
 
 export enum Resolution {

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -1,35 +1,43 @@
-import { BackscatterCoeff } from 'src/layer/const';
 import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AcquisitionMode, Polarization, Resolution, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
+import { AcquisitionMode, Polarization, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
 */
+
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  title?: string | null;
+  description?: string | null;
+  acquisitionMode?: AcquisitionMode | null;
+  polarization?: Polarization | null;
+  orbitDirection?: OrbitDirection | null;
+}
 
 export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   public readonly dataset = DATASET_EOCLOUD_S1GRD;
 
   public acquisitionMode: AcquisitionMode;
   public polarization: Polarization;
-  public resolution: Resolution | null = null;
   public orbitDirection: OrbitDirection | null = null;
-  public orthorectify: boolean | null = false;
-  public backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    acquisitionMode: AcquisitionMode | null = null,
-    polarization: Polarization | null = null,
-    orbitDirection: OrbitDirection | null = null,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    title = null,
+    description = null,
+    acquisitionMode = null,
+    polarization = null,
+    orbitDirection = null,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, title, description });
     // it is not possible to determine these parameters by querying the service, because there
     // is no endpoint which would return them:
     if ((evalscript || evalscriptUrl) && (!acquisitionMode || !polarization)) {
@@ -67,7 +75,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
       default:
         throw new Error(`Unknown datasourceName (${layerInfo.settings.datasourceName})`);
     }
-    return new S1GRDEOCloudLayer(
+    return new S1GRDEOCloudLayer({
       instanceId,
       layerId,
       evalscript,
@@ -76,7 +84,8 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
       description,
       acquisitionMode,
       polarization,
-    );
+      orbitDirection: null,
+    });
   }
 
   protected getEvalsource(): string {

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -1,7 +1,8 @@
 import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AcquisitionMode, Polarization, OrbitDirection } from 'src/layer/S1GRDAWSEULayer';
+import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
+import { OrbitDirection } from 'src/layer/const';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,10 +1,9 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { OrbitDirection } from 'src';
 import { ProcessingPayload } from 'src/layer/processing';
 
 interface ConstructorParameters {

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -7,6 +7,18 @@ import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer
 import { OrbitDirection } from 'src';
 import { ProcessingPayload } from 'src/layer/processing';
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+  maxCloudCoverPercent?: number | null;
+  view?: 'NADIR' | 'OBLIQUE';
+}
+
 type S3SLSTRFindTilesDatasetParameters = {
   type?: string;
   orbitDirection?: OrbitDirection;
@@ -19,18 +31,18 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   public orbitDirection: OrbitDirection | null;
   public view: 'NADIR' | 'OBLIQUE';
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    maxCloudCoverPercent: number | null = 100,
-    view: 'NADIR' | 'OBLIQUE' = 'NADIR',
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+    maxCloudCoverPercent = 100,
+    view = 'NADIR',
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.maxCloudCoverPercent = maxCloudCoverPercent;
     // images that are not DESCENDING appear empty:
     this.orbitDirection = OrbitDirection.DESCENDING;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -15,20 +15,25 @@ interface ConstructorParameters {
   title?: string | null;
   description?: string | null;
   maxCloudCoverPercent?: number | null;
-  view?: 'NADIR' | 'OBLIQUE';
+  view?: S3SLSTRView | null;
+}
+
+export enum S3SLSTRView {
+  NADIR = 'NADIR',
+  OBLIQUE = 'OBLIQUE',
 }
 
 type S3SLSTRFindTilesDatasetParameters = {
   type?: string;
   orbitDirection?: OrbitDirection;
-  view: 'NADIR' | 'OBLIQUE';
+  view: S3SLSTRView;
 };
 
 export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3SLSTR;
   public maxCloudCoverPercent: number;
   public orbitDirection: OrbitDirection | null;
-  public view: 'NADIR' | 'OBLIQUE';
+  public view: S3SLSTRView;
 
   public constructor({
     instanceId = null,
@@ -39,7 +44,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     title = null,
     description = null,
     maxCloudCoverPercent = 100,
-    view = 'NADIR',
+    view = S3SLSTRView.NADIR,
   }: ConstructorParameters) {
     super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.maxCloudCoverPercent = maxCloudCoverPercent;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -52,6 +52,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
+    payload.input.data[0].processing.view = this.view;
     return payload;
   }
 

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -23,6 +23,19 @@ export enum ProductType {
   CH4 = 'CH4',
 }
 
+interface ConstructorParameters {
+  instanceId?: string | null;
+  layerId?: string | null;
+  evalscript?: string | null;
+  evalscriptUrl?: string | null;
+  dataProduct?: string | null;
+  title?: string | null;
+  description?: string | null;
+  productType?: ProductType | null;
+  maxCloudCoverPercent?: number | null;
+  minQa?: number | null;
+}
+
 type S5PL2FindTilesDatasetParameters = {
   type: string;
   productType: ProductType;
@@ -35,19 +48,19 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   public maxCloudCoverPercent: number;
   public minQa: number | null;
 
-  public constructor(
-    instanceId: string | null,
-    layerId: string | null = null,
-    evalscript: string | null = null,
-    evalscriptUrl: string | null = null,
-    dataProduct: string | null = null,
-    title: string | null = null,
-    description: string | null = null,
-    productType: ProductType | null = null,
-    maxCloudCoverPercent: number | null = 100,
-    minQa: number | null = null,
-  ) {
-    super(instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description);
+  public constructor({
+    instanceId = null,
+    layerId = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    dataProduct = null,
+    title = null,
+    description = null,
+    productType = null,
+    maxCloudCoverPercent = 100,
+    minQa = null,
+  }: ConstructorParameters) {
+    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.productType = productType;
     this.maxCloudCoverPercent = maxCloudCoverPercent;
     this.minQa = minQa;

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -2,6 +2,13 @@ import { GetMapParams, ApiType } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 
+interface ConstructorParameters {
+  baseUrl?: string;
+  layerId?: string;
+  title?: string | null;
+  description?: string | null;
+}
+
 export class WmsLayer extends AbstractLayer {
   // The URL of the WMS service, for example: "https://services.sentinel-hub.com/ogc/wms/<instance-id>/"
   protected baseUrl: string;
@@ -13,7 +20,7 @@ export class WmsLayer extends AbstractLayer {
     title: string | null = null,
     description: string | null = null,
   ) {
-    super(title, description);
+    super({ title, description });
     this.baseUrl = baseUrl;
     this.layerId = layerId;
   }

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -14,12 +14,7 @@ export class WmsLayer extends AbstractLayer {
   protected baseUrl: string;
   protected layerId: string;
 
-  public constructor(
-    baseUrl: string,
-    layerId: string,
-    title: string | null = null,
-    description: string | null = null,
-  ) {
+  public constructor({ baseUrl, layerId, title = null, description = null }: ConstructorParameters) {
     super({ title, description });
     this.baseUrl = baseUrl;
     this.layerId = layerId;

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -28,18 +28,13 @@ test.each([
     const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
     const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
     const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
-    const layer = new S1GRDAWSEULayer(
-      'INSTANCE_ID',
-      'LAYER_ID',
-      null,
-      null,
-      null,
-      null,
-      null,
-      AcquisitionMode.IW,
-      Polarization.DV,
-      Resolution.HIGH,
-    );
+    const layer = new S1GRDAWSEULayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    });
 
     // mock a single-tile response:
     axios.post.mockReset();

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -6,10 +6,10 @@ import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmsLayer } from 'src';
 test('WmsLayer.getMapUrl returns an URL', () => {
   const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
   const layerId = 'PROBAV_S1_TOA_333M';
-  const layer = new WmsLayer(
-    'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
+  const layer = new WmsLayer({
+    baseUrl: 'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
     layerId,
-  );
+  });
 
   const getMapParams = {
     bbox: bbox,
@@ -41,10 +41,10 @@ test('WmsLayer.getMapUrl returns an URL', () => {
 test('WmsLayer.getMap makes an appropriate request', () => {
   const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
   const layerId = 'PROBAV_S1_TOA_333M';
-  const layer = new WmsLayer(
-    'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
+  const layer = new WmsLayer({
+    baseUrl: 'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
     layerId,
-  );
+  });
 
   const getMapParams = {
     bbox: bbox,

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -43,6 +43,11 @@ export enum ApiType {
   PROCESSING = 'processing',
 }
 
+export enum OrbitDirection {
+  ASCENDING = 'ASCENDING',
+  DESCENDING = 'DESCENDING',
+}
+
 export enum BackscatterCoeff {
   BETA0 = 'BETA0',
   GAMMA0_ELLIPSOID = 'GAMMA0_ELLIPSOID',

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -22,7 +22,7 @@ export async function legacyGetMapFromUrl(
 
 export function legacyGetMapWmsUrlFromParams(baseUrl: string, wmsParams: Record<string, any>): string {
   const { layers, getMapParams } = parseLegacyWmsGetMapParams(wmsParams);
-  const layer = new WmsLayer(baseUrl, layers);
+  const layer = new WmsLayer({ baseUrl, layerId: layers });
   return layer.getMapUrl(getMapParams, ApiType.WMS);
 }
 
@@ -39,7 +39,7 @@ export async function legacyGetMapFromParams(
   let layer;
   switch (api) {
     case ApiType.WMS:
-      layer = new WmsLayer(baseUrl, layers);
+      layer = new WmsLayer({ baseUrl, layerId: layers });
       return layer.getMap(getMapParams, api);
 
     case ApiType.PROCESSING:

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -34,7 +34,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new BYOCLayer(instanceId, layerId);
+  const layer = new BYOCLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -60,7 +60,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new BYOCLayer(instanceId, layerId);
+    const layer = new BYOCLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -94,10 +94,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new BYOCLayer(
+    const layer = new BYOCLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -110,7 +110,7 @@ export const getMapProcessing = () => {
         return [sample.IR/255, sample.G/255, sample.B/255];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -144,7 +144,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new BYOCLayer(instanceId, layerId);
+    const layer = new BYOCLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -166,16 +166,11 @@ export const findTiles = () => {
   if (!process.env.BYOC_COLLECTION_ID) {
     throw new Error('BYOC_COLLECTION_ID environment variable is not defined!');
   }
-  const layer = new BYOCLayer(
+  const layer = new BYOCLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    null,
-    process.env.BYOC_COLLECTION_ID,
-  );
+    collectionId: process.env.BYOC_COLLECTION_ID,
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -210,7 +205,7 @@ export const findTilesAuth = () => {
 
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
-    const layer = new BYOCLayer(instanceId, layerId);
+    const layer = new BYOCLayer({ instanceId, layerId });
 
     const data = await layer.findTiles(
       bbox,
@@ -230,16 +225,11 @@ export const findDates = () => {
   if (!process.env.BYOC_COLLECTION_ID) {
     throw new Error('BYOC_COLLECTION_ID environment variable is not defined!');
   }
-  const layer = new BYOCLayer(
+  const layer = new BYOCLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    null,
-    process.env.BYOC_COLLECTION_ID,
-  );
+    collectionId: process.env.BYOC_COLLECTION_ID,
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findDates (with collectionId)</h2>';
@@ -284,7 +274,7 @@ export const findDatesAuth = () => {
   if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
     return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
   }
-  const layer = new BYOCLayer(instanceId, layerId);
+  const layer = new BYOCLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findDates (without collectionId)</h2>';

--- a/stories/envisatmeris.eocloud.stories.js
+++ b/stories/envisatmeris.eocloud.stories.js
@@ -37,7 +37,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new EnvisatMerisEOCloudLayer(instanceId, layerId);
+  const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -63,7 +63,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new EnvisatMerisEOCloudLayer(instanceId, layerId);
+    const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -124,13 +124,13 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new EnvisatMerisEOCloudLayer(
+    const layer = new EnvisatMerisEOCloudLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -149,7 +149,7 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new EnvisatMerisEOCloudLayer(instanceId, layerId);
+  const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -172,7 +172,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new EnvisatMerisEOCloudLayer(instanceId, layerId);
+  const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -211,7 +211,7 @@ export const findFlyovers = () => {
 
 export const findDatesEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
-  const layer = new EnvisatMerisEOCloudLayer(instanceId, layerId);
+  const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent} </h2>`;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -40,7 +40,7 @@ export const S2GetMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS) for Sentinel-2 L2A</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const layerS2L2A = new S2L2ALayer({ instanceId, layerId: s2l2aLayerId });
 
   const getMapParams = {
     bbox: bbox4326,
@@ -67,7 +67,7 @@ export const S2GetMapWMS = () => {
 
   // getMap is async:
   const perform = async () => {
-    const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+    const layerS2L2A = new S2L2ALayer({ instanceId, layerId: s2l2aLayerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -102,10 +102,10 @@ export const S2GetMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layerS2L2A = new S2L2ALayer(
+    const layerS2L2A = new S2L2ALayer({
       instanceId,
-      s2l2aLayerId,
-      `
+      layerId: s2l2aLayerId,
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -118,7 +118,7 @@ export const S2GetMapProcessing = () => {
         return [2.5 * sample.B04, 2.5 * sample.B03, 2.5 * sample.B02];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -153,7 +153,7 @@ export const S1GetMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(instanceId, s1grdLayerId);
+    const layer = new S1GRDAWSEULayer({ instanceId, layerId: s1grdLayerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -182,10 +182,10 @@ export const WmsGetMap = () => {
 
   // getMap is async:
   const perform = async () => {
-    const layer = new WmsLayer(
-      'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
-      'PROBAV_S1_TOA_333M',
-    );
+    const layer = new WmsLayer({
+      baseUrl: 'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows',
+      layerId: 'PROBAV_S1_TOA_333M',
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -205,16 +205,11 @@ export const WmsGetMap = () => {
 
 export const S2FindTiles = () => {
   const maxCloudCoverPercent = 60;
-  const layerS2L2A = new S2L2ALayer(
+  const layerS2L2A = new S2L2ALayer({
     instanceId,
-    s2l2aLayerId,
-    null,
-    null,
-    null,
-    null,
-    null,
+    layerId: s2l2aLayerId,
     maxCloudCoverPercent,
-  );
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -237,7 +232,7 @@ export const S2FindTiles = () => {
 };
 
 export const S1GRDFindTiles = () => {
-  const layerS1 = new S1GRDAWSEULayer(instanceId, s1grdLayerId);
+  const layerS1 = new S1GRDAWSEULayer({ instanceId, layerId: s1grdLayerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -262,7 +257,7 @@ export const S1GRDFindTiles = () => {
 };
 
 export const S2FindFlyovers = () => {
-  const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const layerS2L2A = new S2L2ALayer({ instanceId, layerId: s2l2aLayerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers for Sentinel-2 L2A</h2>';

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -38,7 +38,7 @@ export const getMapURL = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const maxCloudCoverPercent = 0;
-  const layer = new Landsat5EOCloudLayer(instanceId, layerId, null, null, null, null, maxCloudCoverPercent);
+  const layer = new Landsat5EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const getMapParams = {
     bbox: bbox,
@@ -64,7 +64,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat5EOCloudLayer(instanceId, layerId);
+    const layer = new Landsat5EOCloudLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -124,13 +124,13 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat5EOCloudLayer(
+    const layer = new Landsat5EOCloudLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -149,7 +149,7 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new Landsat5EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat5EOCloudLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -172,7 +172,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new Landsat5EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat5EOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -211,7 +211,7 @@ export const findFlyovers = () => {
 
 export const findDatesEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
-  const layer = new Landsat5EOCloudLayer(instanceId, layerId, null, null, null, null, maxCloudCoverPercent);
+  const layer = new Landsat5EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -37,7 +37,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new Landsat7EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat7EOCloudLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -63,7 +63,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat7EOCloudLayer(instanceId, layerId);
+    const layer = new Landsat7EOCloudLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -124,13 +124,13 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat7EOCloudLayer(
+    const layer = new Landsat7EOCloudLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -149,7 +149,7 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new Landsat7EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat7EOCloudLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -172,7 +172,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new Landsat7EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat7EOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -211,7 +211,7 @@ export const findFlyovers = () => {
 
 export const findDatesEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
-  const layer = new Landsat7EOCloudLayer(instanceId, layerId, null, null, null, null, maxCloudCoverPercent);
+  const layer = new Landsat7EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/landsat8.aws.stories.js
+++ b/stories/landsat8.aws.stories.js
@@ -37,7 +37,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new Landsat8AWSLayer(instanceId, layerId);
+  const layer = new Landsat8AWSLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -63,7 +63,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat8AWSLayer(instanceId, layerId);
+    const layer = new Landsat8AWSLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -124,13 +124,13 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat8AWSLayer(
+    const layer = new Landsat8AWSLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -149,7 +149,7 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new Landsat8AWSLayer(instanceId, layerId);
+  const layer = new Landsat8AWSLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -172,7 +172,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new Landsat8AWSLayer(instanceId, layerId);
+  const layer = new Landsat8AWSLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -211,7 +211,7 @@ export const findFlyovers = () => {
 
 export const findDates = () => {
   const maxCloudCoverPercent = 40;
-  const layer = new Landsat8AWSLayer(instanceId, layerId, null, null, null, null, null, maxCloudCoverPercent);
+  const layer = new Landsat8AWSLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates for Landsat 8 on AWS; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -37,7 +37,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new Landsat8EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat8EOCloudLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -63,7 +63,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat8EOCloudLayer(instanceId, layerId);
+    const layer = new Landsat8EOCloudLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -124,13 +124,13 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new Landsat8EOCloudLayer(
+    const layer = new Landsat8EOCloudLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * B04, 1.5 * B03, 0.5 * B02];
       `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -149,7 +149,7 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTiles = () => {
-  const layer = new Landsat8EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat8EOCloudLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -172,7 +172,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new Landsat8EOCloudLayer(instanceId, layerId);
+  const layer = new Landsat8EOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -211,7 +211,7 @@ export const findFlyovers = () => {
 
 export const findDatesEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
-  const layer = new Landsat8EOCloudLayer(instanceId, layerId, null, null, null, null, maxCloudCoverPercent);
+  const layer = new Landsat8EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -38,7 +38,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox3857,
@@ -64,7 +64,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S1GRDAWSEULayer(instanceId, layerId);
+    const layer = new S1GRDAWSEULayer({ instanceId, layerId });
     const getMapParams = {
       bbox: bbox3857,
       fromTime: new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),
@@ -97,10 +97,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(
+    const layer = new S1GRDAWSEULayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -113,7 +113,7 @@ export const getMapProcessing = () => {
         return [2.5 * sample.HH, 2.5 * sample.HH, 2.5 * sample.HH];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -147,30 +147,24 @@ export const getMapProcessingWithoutInstance = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(
-      null,
-      null,
-      `
-      //VERSION=3
-      function setup() {
-        return {
-          input: ["HH"],
-          output: { bands: 3 }
-        };
-      }
+    const layer = new S1GRDAWSEULayer({
+      evalscript: `
+        //VERSION=3
+        function setup() {
+          return {
+            input: ["HH"],
+            output: { bands: 3 }
+          };
+        }
 
-      function evaluatePixel(sample) {
-        return [2.5 * sample.HH, 2.5 * sample.HH, 2.5 * sample.HH];
-      }
-    `,
-      null,
-      null,
-      null,
-      null,
-      AcquisitionMode.EW,
-      Polarization.DH,
-      Resolution.MEDIUM,
-    );
+        function evaluatePixel(sample) {
+          return [2.5 * sample.HH, 2.5 * sample.HH, 2.5 * sample.HH];
+        }
+      `,
+      acquisitionMode: AcquisitionMode.EW,
+      polarization: Polarization.DH,
+      resolution: Resolution.MEDIUM,
+    });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -204,7 +198,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(instanceId, layerId);
+    const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -223,7 +217,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -247,7 +241,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -285,7 +279,7 @@ export const findFlyovers = () => {
 };
 
 export const findDates = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
   const bbox4326 = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
 
   const wrapperEl = document.createElement('div');

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -107,10 +107,12 @@ export const getMapWMSLayersFactory = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(
-      `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
-      (lId, datasetId) => layerId === lId,
-    ))[0];
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+      )
+    )[0];
 
     const getMapParams = {
       bbox: bbox,
@@ -236,10 +238,12 @@ export const findFlyovers = () => {
   wrapperEl.insertAdjacentElement('beforeend', flyoversContainerEl);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(
-      `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
-      (lId, datasetId) => layerId === lId,
-    ))[0];
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+      )
+    )[0];
 
     const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
     const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59));
@@ -365,10 +369,12 @@ export const supportsProcessingAPI = () => {
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(
-      `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
-      (lId, datasetId) => layerId === lId,
-    ))[0];
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_EOCLOUD_S1GRD.shServiceHostname}v1/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+      )
+    )[0];
     const supportsProcessingAPI = layer.supportsApiType(ApiType.PROCESSING);
     containerEl.innerHTML = JSON.stringify(supportsProcessingAPI, null, true);
   };

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -41,17 +41,13 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S1GRDEOCloudLayer(
+  const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    Resolution.HIGH,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+  });
 
   const getMapParams = {
     bbox: bbox,
@@ -77,17 +73,13 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S1GRDEOCloudLayer(
+    const layer = new S1GRDEOCloudLayer({
       instanceId,
       layerId,
-      null,
-      null,
-      null,
-      null,
-      AcquisitionMode.IW,
-      Polarization.DV,
-      Resolution.HIGH,
-    );
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -146,19 +138,16 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S1GRDEOCloudLayer(
+    const layer = new S1GRDEOCloudLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
         return [2.5 * VV, 1.5 * VV, 0.5 * VV];
       `,
-      null,
-      null,
-      null,
-      AcquisitionMode.IW,
-      Polarization.DV,
-      Resolution.HIGH,
-    );
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -177,17 +166,13 @@ export const getMapWMSEvalscript = () => {
 };
 
 export const findTilesEPSG3857 = () => {
-  const layer = new S1GRDEOCloudLayer(
+  const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    OrbitDirection.ASCENDING,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: OrbitDirection.ASCENDING,
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -210,17 +195,13 @@ export const findTilesEPSG3857 = () => {
 };
 
 export const findTilesEPSG4326 = () => {
-  const layer = new S1GRDEOCloudLayer(
+  const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    OrbitDirection.ASCENDING,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: OrbitDirection.ASCENDING,
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -283,17 +264,13 @@ export const findFlyovers = () => {
 };
 
 export const findDatesEPSG4326 = () => {
-  const layer = new S1GRDEOCloudLayer(
+  const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    OrbitDirection.ASCENDING,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: OrbitDirection.ASCENDING,
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:4326</h2>';
@@ -335,17 +312,13 @@ export const findDatesEPSG4326 = () => {
 };
 
 export const findDatesEPSG3857 = () => {
-  const layer = new S1GRDEOCloudLayer(
+  const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    OrbitDirection.ASCENDING,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: OrbitDirection.ASCENDING,
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:3857</h2>';

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -11,7 +11,6 @@ import {
   OrbitDirection,
   AcquisitionMode,
   Polarization,
-  Resolution,
   LayersFactory,
 } from '../dist/sentinelHub.esm';
 
@@ -46,7 +45,7 @@ export const getMapURL = () => {
     layerId,
     acquisitionMode: AcquisitionMode.IW,
     polarization: Polarization.DV,
-    resolution: Resolution.HIGH,
+    orbitDirection: OrbitDirection.ASCENDING,
   });
 
   const getMapParams = {
@@ -78,7 +77,7 @@ export const getMapWMS = () => {
       layerId,
       acquisitionMode: AcquisitionMode.IW,
       polarization: Polarization.DV,
-      resolution: Resolution.HIGH,
+      orbitDirection: OrbitDirection.ASCENDING,
     });
 
     const getMapParams = {
@@ -148,7 +147,7 @@ export const getMapWMSEvalscript = () => {
       `,
       acquisitionMode: AcquisitionMode.IW,
       polarization: Polarization.DV,
-      resolution: Resolution.HIGH,
+      orbitDirection: OrbitDirection.ASCENDING,
     });
 
     const getMapParams = {
@@ -173,7 +172,7 @@ export const findTilesEPSG3857 = () => {
     layerId,
     acquisitionMode: AcquisitionMode.IW,
     polarization: Polarization.DV,
-    resolution: OrbitDirection.ASCENDING,
+    orbitDirection: OrbitDirection.ASCENDING,
   });
   const containerEl = document.createElement('pre');
 
@@ -202,7 +201,7 @@ export const findTilesEPSG4326 = () => {
     layerId,
     acquisitionMode: AcquisitionMode.IW,
     polarization: Polarization.DV,
-    resolution: OrbitDirection.ASCENDING,
+    orbitDirection: OrbitDirection.ASCENDING,
   });
   const containerEl = document.createElement('pre');
 
@@ -273,7 +272,7 @@ export const findDatesEPSG4326 = () => {
     layerId,
     acquisitionMode: AcquisitionMode.IW,
     polarization: Polarization.DV,
-    resolution: OrbitDirection.ASCENDING,
+    orbitDirection: OrbitDirection.ASCENDING,
   });
 
   const wrapperEl = document.createElement('div');
@@ -321,7 +320,7 @@ export const findDatesEPSG3857 = () => {
     layerId,
     acquisitionMode: AcquisitionMode.IW,
     polarization: Polarization.DV,
-    resolution: OrbitDirection.ASCENDING,
+    orbitDirection: OrbitDirection.ASCENDING,
   });
 
   const wrapperEl = document.createElement('div');

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -42,7 +42,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox3857,
@@ -68,7 +68,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S1GRDAWSEULayer(instanceId, layerId);
+    const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -133,10 +133,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(
+    const layer = new S1GRDAWSEULayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -149,7 +149,7 @@ export const getMapProcessing = () => {
         return [2.5 * sample.VV, 2.5 * sample.VV, 2.5 * sample.VV];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -183,10 +183,8 @@ export const getMapProcessingWithoutInstance = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(
-      null,
-      null,
-      `
+    const layer = new S1GRDAWSEULayer({
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -199,14 +197,10 @@ export const getMapProcessingWithoutInstance = () => {
         return [2.5 * sample.VV, 2.5 * sample.VV, 2.5 * sample.VV];
       }
     `,
-      null,
-      null,
-      null,
-      null,
-      AcquisitionMode.IW,
-      Polarization.DV,
-      Resolution.HIGH,
-    );
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -240,7 +234,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S1GRDAWSEULayer(instanceId, layerId);
+    const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox3857,
@@ -259,7 +253,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTilesEPSG3857 = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const containerEl = document.createElement('pre');
 
@@ -284,7 +278,7 @@ export const findTilesEPSG3857 = () => {
 };
 
 export const findTilesEPSG4326 = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const containerEl = document.createElement('pre');
 
@@ -309,7 +303,7 @@ export const findTilesEPSG4326 = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S1GRDAWSEULayer(instanceId, layerId);
+  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -347,21 +341,13 @@ export const findFlyovers = () => {
 };
 
 export const findDatesEPSG4326 = () => {
-  const layer = new S1GRDAWSEULayer(
+  const layer = new S1GRDAWSEULayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    null,
-    AcquisitionMode.IW,
-    Polarization.DV,
-    null,
-    null,
-    null,
-    OrbitDirection.DESCENDING,
-  );
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    orbitDirection: OrbitDirection.DESCENDING,
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:4326</h2>';

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -96,10 +96,12 @@ export const getMapWMSLayersFactory = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(
-      `${DATASET_AWSEU_S1GRD.shServiceHostname}ogc/wms/${instanceId}`,
-      (lId, datasetId) => layerId === lId,
-    ))[0];
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_AWSEU_S1GRD.shServiceHostname}ogc/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+      )
+    )[0];
 
     const getMapParams = {
       bbox: bbox3857,
@@ -397,10 +399,12 @@ export const supportsProcessingAPI = () => {
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(
-      `${DATASET_AWSEU_S1GRD.shServiceHostname}ogc/wms/${instanceId}`,
-      (lId, datasetId) => layerId === lId,
-    ))[0];
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_AWSEU_S1GRD.shServiceHostname}ogc/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+      )
+    )[0];
     const supportsProcessingAPI = layer.supportsApiType(ApiType.PROCESSING);
     containerEl.innerHTML = JSON.stringify(supportsProcessingAPI, null, true);
   };

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -54,7 +54,7 @@ export const GetMapWMS = () => {
 
   // getMap is async:
   const perform = async () => {
-    const layerS2L1C = new S2L1CLayer({ instanceId, layerId: layerId });
+    const layerS2L1C = new S2L1CLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -11,7 +11,7 @@ if (!process.env.S2L1C_LAYER_ID) {
 }
 
 const instanceId = process.env.INSTANCE_ID;
-const s2l1cLayerId = process.env.S2L1C_LAYER_ID;
+const layerId = process.env.S2L1C_LAYER_ID;
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.2, 12.7, 43);
 
 export default {
@@ -27,7 +27,7 @@ export const GetMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS) for Sentinel-2 L2A</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layerS2L1C = new S2L1CLayer(instanceId, s2l1cLayerId);
+  const layerS2L1C = new S2L1CLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox4326,
@@ -54,7 +54,7 @@ export const GetMapWMS = () => {
 
   // getMap is async:
   const perform = async () => {
-    const layerS2L1C = new S2L1CLayer(instanceId, s2l1cLayerId);
+    const layerS2L1C = new S2L1CLayer({ instanceId, layerId: layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -89,10 +89,10 @@ export const GetMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layerS2L1C = new S2L1CLayer(
+    const layerS2L1C = new S2L1CLayer({
       instanceId,
-      s2l1cLayerId,
-      `
+      layerId,
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -105,7 +105,7 @@ export const GetMapProcessing = () => {
         return [2.5 * sample.B04, 2.5 * sample.B03, 2.5 * sample.B02];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -124,13 +124,14 @@ export const GetMapProcessing = () => {
 };
 
 export const GetMapWMSMaxCC20vs60 = () => {
-  const layerS2L1C20 = new S2L1CLayer(instanceId, s2l1cLayerId, null, null, null, null, null, 20);
-  const layerS2L1C60 = new S2L1CLayer(instanceId, s2l1cLayerId, null, null, null, null, null, 100);
+  const layerS2L1C20 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 20 });
+  const layerS2L1C60 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 100 });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `
   <h2>GetMap: maxCC=20 vs maxCC=60</h2>
   <p>top left part of left image should be white (cc of the tile is above 20)</p>
+  <p>TODO: this story doesn't work because there is no data for S-2 in 2014 available; should be fixed.</p>
   `;
 
   const img20 = document.createElement('img');
@@ -170,16 +171,11 @@ export const GetMapWMSMaxCC20vs60 = () => {
 
 export const FindTiles = () => {
   const maxCloudCoverPercent = 60;
-  const layerS2L1C = new S2L1CLayer(
+  const layerS2L1C = new S2L1CLayer({
     instanceId,
-    s2l1cLayerId,
-    null,
-    null,
-    null,
-    null,
-    null,
+    layerId,
     maxCloudCoverPercent,
-  );
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -202,7 +198,7 @@ export const FindTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S2L1CLayer(instanceId, s2l1cLayerId);
+  const layer = new S2L1CLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -241,16 +237,11 @@ export const findFlyovers = () => {
 
 export const findDates = () => {
   const maxCloudCoverPercent = 60;
-  const layerS2L1C = new S2L1CLayer(
+  const layerS2L1C = new S2L1CLayer({
     instanceId,
-    s2l1cLayerId,
-    null,
-    null,
-    null,
-    null,
-    null,
+    layerId,
     maxCloudCoverPercent,
-  );
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -125,7 +125,7 @@ export const GetMapProcessing = () => {
 
 export const GetMapWMSMaxCC20vs60 = () => {
   const layerS2L1C20 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 20 });
-  const layerS2L1C60 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 100 });
+  const layerS2L1C60 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -11,7 +11,7 @@ if (!process.env.S2L2A_LAYER_ID) {
 }
 
 const instanceId = process.env.INSTANCE_ID;
-const s2l2aLayerId = process.env.S2L2A_LAYER_ID;
+const layerId = process.env.S2L2A_LAYER_ID;
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
 
 export default {
@@ -27,7 +27,7 @@ export const GetMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS) for Sentinel-2 L2A</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const layerS2L2A = new S2L2ALayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox4326,
@@ -54,7 +54,7 @@ export const GetMapWMS = () => {
 
   // getMap is async:
   const perform = async () => {
-    const layerS2L2A = new S2L2ALayer(instanceId, s2l2aLayerId);
+    const layerS2L2A = new S2L2ALayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -89,10 +89,10 @@ export const GetMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layerS2L2A = new S2L2ALayer(
+    const layerS2L2A = new S2L2ALayer({
       instanceId,
-      s2l2aLayerId,
-      `
+      layerId,
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -105,7 +105,7 @@ export const GetMapProcessing = () => {
         return [2.5 * sample.B04, 2.5 * sample.B03, 2.5 * sample.B02];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -124,13 +124,14 @@ export const GetMapProcessing = () => {
 };
 
 export const GetMapWMSMaxCC20vs60 = () => {
-  const layerS2L2A20 = new S2L2ALayer(instanceId, s2l2aLayerId, null, null, null, null, null, 20);
-  const layerS2L2A60 = new S2L2ALayer(instanceId, s2l2aLayerId, null, null, null, null, null, 60);
+  const layerS2L2A20 = new S2L2ALayer({ instanceId, layerId, maxCloudCoverPercent: 20 });
+  const layerS2L2A60 = new S2L2ALayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `
   <h2>GetMap: maxCC=20 vs maxCC=60</h2>
   <p>top left part of left image should be white (cc of the tile is above 20)</p>
+  <p>TODO: this story doesn't work because there is no data for S-2 in 2014 available; should be fixed.</p>
   `;
 
   const img20 = document.createElement('img');
@@ -170,16 +171,11 @@ export const GetMapWMSMaxCC20vs60 = () => {
 
 export const FindTiles = () => {
   const maxCloudCoverPercent = 60;
-  const layerS2L2A = new S2L2ALayer(
+  const layerS2L2A = new S2L2ALayer({
     instanceId,
-    s2l2aLayerId,
-    null,
-    null,
-    null,
-    null,
-    null,
+    layerId,
     maxCloudCoverPercent,
-  );
+  });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -202,7 +198,7 @@ export const FindTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S2L2ALayer(instanceId, s2l2aLayerId);
+  const layer = new S2L2ALayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -241,16 +237,11 @@ export const findFlyovers = () => {
 
 export const findDates = () => {
   const maxCloudCoverPercent = 60;
-  const layerS2L2A = new S2L2ALayer(
+  const layerS2L2A = new S2L2ALayer({
     instanceId,
-    s2l2aLayerId,
-    null,
-    null,
-    null,
-    null,
-    null,
+    layerId,
     maxCloudCoverPercent,
-  );
+  });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findDates for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -35,7 +35,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S3OLCILayer(instanceId, layerId);
+  const layer = new S3OLCILayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox4326,
@@ -61,7 +61,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S3OLCILayer(instanceId, layerId);
+    const layer = new S3OLCILayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -95,10 +95,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S3OLCILayer(
+    const layer = new S3OLCILayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -111,7 +111,7 @@ export const getMapProcessing = () => {
         return [2.5 * sample.B08, 2.5 * sample.B06, 2.5 * sample.B04];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -145,7 +145,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S3OLCILayer(instanceId, layerId);
+    const layer = new S3OLCILayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -164,7 +164,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S3OLCILayer(instanceId, layerId);
+  const layer = new S3OLCILayer({ instanceId, layerId });
 
   const containerEl = document.createElement('pre');
 
@@ -231,7 +231,7 @@ export const findFlyoversLinearRingError = () => {
 };
 
 export const findDates = () => {
-  const layer = new S3OLCILayer(instanceId, layerId);
+  const layer = new S3OLCILayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML =

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -1,6 +1,6 @@
 import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { S3SLSTRLayer, CRS_EPSG4326, BBox, MimeTypes, ApiType } from '../dist/sentinelHub.esm';
+import { S3SLSTRLayer, CRS_EPSG4326, BBox, MimeTypes, ApiType, S3SLSTRView } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -157,12 +157,11 @@ export const getMapProcessingFromLayer = () => {
 
 export const findTiles = () => {
   const maxCloudCoverPercent = 60;
-  const view = 'NADIR';
   const layer = new S3SLSTRLayer({
     instanceId,
     layerId,
     maxCloudCoverPercent,
-    view,
+    view: S3SLSTRView.NADIR,
   });
 
   const containerEl = document.createElement('pre');

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -186,7 +186,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S3SLSTRLayer({ instanceId, layerId, maxCloudCoverPercent: 60, view: 'NADIR' });
+  const layer = new S3SLSTRLayer({ instanceId, layerId, maxCloudCoverPercent: 60, view: S3SLSTRView.NADIR });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -27,7 +27,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S3SLSTRLayer(instanceId, layerId);
+  const layer = new S3SLSTRLayer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox4326,
@@ -53,7 +53,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S3SLSTRLayer(instanceId, layerId);
+    const layer = new S3SLSTRLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -87,10 +87,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S3SLSTRLayer(
+    const layer = new S3SLSTRLayer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -103,7 +103,7 @@ export const getMapProcessing = () => {
         return [1.1 * sample.S3, 1.1 * sample.S2, 1.1 * sample.S1];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -137,7 +137,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S3SLSTRLayer(instanceId, layerId);
+    const layer = new S3SLSTRLayer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox4326,
@@ -158,17 +158,12 @@ export const getMapProcessingFromLayer = () => {
 export const findTiles = () => {
   const maxCloudCoverPercent = 60;
   const view = 'NADIR';
-  const layer = new S3SLSTRLayer(
+  const layer = new S3SLSTRLayer({
     instanceId,
     layerId,
-    null,
-    null,
-    null,
-    null,
-    null,
     maxCloudCoverPercent,
     view,
-  );
+  });
 
   const containerEl = document.createElement('pre');
 
@@ -192,7 +187,7 @@ export const findTiles = () => {
 };
 
 export const findFlyovers = () => {
-  const layer = new S3SLSTRLayer(instanceId, layerId, null, null, null, null, null, 60, 'NADIR');
+  const layer = new S3SLSTRLayer({ instanceId, layerId, maxCloudCoverPercent: 60, view: 'NADIR' });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
@@ -230,7 +225,7 @@ export const findFlyovers = () => {
 };
 
 export const findDates = () => {
-  const layer = new S3SLSTRLayer(instanceId, layerId);
+  const layer = new S3SLSTRLayer({ instanceId, layerId });
   const specialBBox4326 = new BBox(CRS_EPSG4326, 10, 40, 14, 44);
 
   const fromTime = new Date(Date.UTC(2018, 1 - 1, 1, 0, 0, 0));

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -34,7 +34,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new S5PL2Layer(instanceId, layerId);
+  const layer = new S5PL2Layer({ instanceId, layerId });
 
   const getMapParams = {
     bbox: bbox,
@@ -60,7 +60,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S5PL2Layer(instanceId, layerId);
+    const layer = new S5PL2Layer({ instanceId, layerId });
     const getMapParams = {
       bbox: bbox,
       fromTime: new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),
@@ -87,10 +87,10 @@ export const getMapWMSEvalscript = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = new S5PL2Layer(
+    const layer = new S5PL2Layer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       var val = CLOUD_BASE_PRESSURE;
       var minVal = 10000.0;
       var maxVal = 110000.0;
@@ -99,7 +99,7 @@ export const getMapWMSEvalscript = () => {
       var colors = [[0, 0, 0.5], [0, 0, 1], [0, 1, 1], [1, 1, 0], [1, 0, 0], [0.5, 0, 0]];
       return colorBlend(val, limits, colors);
       `,
-    );
+    });
     const getMapParams = {
       bbox: bbox,
       fromTime: new Date(Date.UTC(2020, 2 - 1, 2, 0, 0, 0)),
@@ -132,10 +132,10 @@ export const getMapProcessing = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S5PL2Layer(
+    const layer = new S5PL2Layer({
       instanceId,
       layerId,
-      `
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -148,7 +148,7 @@ export const getMapProcessing = () => {
         return [2.5 * sample.CO, 2.5 * sample.CO, 2.5 * sample.CO];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -182,10 +182,8 @@ export const getMapProcessingWithoutInstance = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S5PL2Layer(
-      null,
-      null,
-      `
+    const layer = new S5PL2Layer({
+      evalscript: `
       //VERSION=3
       function setup() {
         return {
@@ -198,7 +196,7 @@ export const getMapProcessingWithoutInstance = () => {
         return [2.5 * sample.CO, 2.5 * sample.CO, 2.5 * sample.CO];
       }
     `,
-    );
+    });
 
     const getMapParams = {
       bbox: bbox,
@@ -232,7 +230,7 @@ export const getMapProcessingFromLayer = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
-    const layer = new S5PL2Layer(instanceId, layerId);
+    const layer = new S5PL2Layer({ instanceId, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -251,7 +249,7 @@ export const getMapProcessingFromLayer = () => {
 };
 
 export const findTiles = () => {
-  const layer = new S5PL2Layer(instanceId, layerId, null, null, null, null, null, 'SO2');
+  const layer = new S5PL2Layer({ instanceId, layerId, productType: 'SO2' });
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
@@ -274,7 +272,7 @@ export const findTiles = () => {
 };
 
 export const findDates = () => {
-  const layer = new S5PL2Layer(instanceId, layerId, null, null, null, null, null, 'NO2', 60);
+  const layer = new S5PL2Layer({ instanceId, layerId, productType: 'NO2', maxCloudCoverPercent: 60 });
 
   const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
   const toTime = new Date(Date.UTC(2020, 2 - 1, 1, 23, 59, 59));


### PR DESCRIPTION
This PR changes the way layers are instantiated - instead of normal paramaters, "named" parameters are used (JS doesn't have support for real named parameters, so they are really objects). 

I wanted to make sure that the users will be able to find the list of available parameters for each of the classes, so I have also installed `typedoc`. Please run `npm run build-doc` and explore resulting `doc/index.html` - I would appreciate some feedback.

Apart from that, a small bug was fixed along the way (S-3 SLSTR view was not being passed to Processing API). 

Two of the stories did not work (wrong dates) so I added a notice about that.