### PR TITLE
Support findDates() on WmsLayer

### DIFF
--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -51,6 +51,7 @@ type GetCapabilitiesXml = {
                 Title: string[];
                 Abstract: string[];
                 Style: any[]; // Depending on the service, it can be an array of strings or an array of objects
+                Dimension?: any[];
               },
             ];
           },
@@ -119,7 +120,7 @@ export class LayersFactory {
     [DATASET_EOCLOUD_ENVISAT_MERIS.id]: EnvisatMerisEOCloudLayer,
   };
 
-  private static async fetchGetCapabilitiesXml(
+  public static async fetchGetCapabilitiesXml(
     baseUrl: string,
     forceFetch = false,
   ): Promise<GetCapabilitiesXml> {

--- a/stories/wms.probav.stories.js
+++ b/stories/wms.probav.stories.js
@@ -1,0 +1,203 @@
+import { renderTilesList } from './storiesUtils';
+
+import {
+  WmsLayer,
+  CRS_EPSG3857,
+  CRS_EPSG4326,
+  BBox,
+  MimeTypes,
+  ApiType,
+  LayersFactory,
+} from '../dist/sentinelHub.esm';
+
+const baseUrl = 'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows';
+const layerId = 'PROBAV_S5_TOA_100M';
+const bbox = new BBox(CRS_EPSG3857, 1487158.82, 5322463.15, 1565430.34, 5400734.67);
+const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+export default {
+  title: 'WMS - ProbaV',
+};
+
+export const getMapURL = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const layer = new WmsLayer({ baseUrl, layerId });
+
+  const getMapParams = {
+    bbox: bbox,
+    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG,
+  };
+  const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
+  img.src = imageUrl;
+
+  return wrapperEl;
+};
+
+export const getMapWMS = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap with WMS</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const layer = new WmsLayer({ baseUrl, layerId });
+
+    const getMapParams = {
+      bbox: bbox,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const getMapWmsLayersFactory = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap with WMS</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const layer = (await LayersFactory.makeLayers(baseUrl, (lId, datasetId) => layerId === lId))[0];
+
+    const getMapParams = {
+      bbox: bbox,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findTilesNotImplemented = () => {
+  const layer = new WmsLayer({ baseUrl, layerId });
+  const containerEl = document.createElement('pre');
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>findTiles</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', containerEl);
+
+  const perform = async () => {
+    const data = await layer.findTiles(
+      bbox,
+      new Date(Date.UTC(2000, 1 - 1, 1, 0, 0, 0)),
+      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+      5,
+      0,
+    );
+    renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findFlyoversNotImplemented = () => {
+  const layer = new WmsLayer({ baseUrl, layerId });
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>findFlyovers</h2>';
+
+  const flyoversContainerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement('beforeend', flyoversContainerEl);
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
+
+  const perform = async () => {
+    const flyovers = await layer.findFlyovers(bbox4326, fromTime, toTime, 50, 50);
+    flyoversContainerEl.innerHTML = JSON.stringify(flyovers, null, true);
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: fromTime,
+      toTime: toTime,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const findDates = () => {
+  const layer = new WmsLayer({ baseUrl, layerId });
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>findDates for ProbaV</h2>`;
+
+  const containerEl = document.createElement('pre');
+  wrapperEl.insertAdjacentElement('beforeend', containerEl);
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
+
+  const perform = async () => {
+    const dates = await layer.findDates(bbox, fromTime, toTime);
+    containerEl.innerHTML = JSON.stringify(dates, null, true);
+
+    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
+    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
+
+    // prepare an image to show that the number makes sense:
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: resDateStartOfDay,
+      toTime: resDateEndOfDay,
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};


### PR DESCRIPTION
This PR implements `findDates()` for WMS (tested on Proba-V). Since we only need to support a small subset of [specification](http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#dims). Note that WmsLayer's `findDates()` throws an exception whenever it encounters (as yet) unsupported format.