### PR TITLE
Fix/gibs

### DIFF
--- a/example/node/index.js
+++ b/example/node/index.js
@@ -70,8 +70,6 @@ async function run() {
   const s2l2aLayerId = process.env.S2L2A_LAYER_ID;
   const s1grdLayerId = process.env.S1GRDIW_LAYER_ID;
 
-  printOut('JSON GetCapabilities', await LayersFactory.fetchGetCapabilitiesJson(baseUrl));
-
   // get the list of all of the layers:
   const layers = await LayersFactory.makeLayers(baseUrl);
   printOut(`Layers:`, layers);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "prettier --write \"{src,example,stories}/**/*.{ts,js}\"",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "build-doc": "typedoc --excludePrivate --excludeProtected --out doc/ src/"
+    "build-doc": "typedoc --excludePrivate --excludeProtected --excludeNotExported --exclude '**/*__*' --out doc/ src/"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -4,7 +4,7 @@ import { BBox } from 'src/bbox';
 import { GetMapParams, ApiType } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
-import { LayersFactory } from 'src/layer/LayersFactory';
+import { fetchGetCapabilitiesXml } from './utils';
 
 interface ConstructorParameters {
   baseUrl?: string;
@@ -38,7 +38,7 @@ export class WmsLayer extends AbstractLayer {
     // any additional
   ): Promise<Date[]> {
     // http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#dims
-    const capabilities = await LayersFactory.fetchGetCapabilitiesXml(this.baseUrl);
+    const capabilities = await fetchGetCapabilitiesXml(this.baseUrl);
     const layer = capabilities.WMS_Capabilities.Capability[0].Layer[0].Layer.find(
       layerInfo => this.layerId === layerInfo.Name[0],
     );

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -56,14 +56,27 @@ export class WmsLayer extends AbstractLayer {
     if (timeDimension['$'].units !== 'ISO8601') {
       throw new Error('Layer time information is not in ISO8601 format, parsing not supported');
     }
-    const times = timeDimension['_'];
-    if (!times.includes(',')) {
-      throw new Error(
-        'Currently only time lists of length > 1 are supported (valid time values separated by comma)',
-      );
-    }
 
-    const result = times.split(',').map((t: string) => moment.utc(t).toDate());
+    let result = [];
+    const times = timeDimension['_'].split(',');
+    for (let i = 0; i < times.length; i++) {
+      const timeParts = times[i].split('/');
+      switch (timeParts.length) {
+        case 1:
+          result.push(moment.utc(timeParts[0]).toDate());
+          break;
+        case 3:
+          const [fromTime, toTime, interval] = timeParts;
+          const intervalDuration = moment.duration(interval);
+          const toTimeMoment = moment.utc(toTime);
+          for (let t = moment.utc(fromTime); t.isSameOrBefore(toTimeMoment); t.add(intervalDuration)) {
+            result.push(t.toDate());
+          }
+          break;
+        default:
+          throw new Error('Unable to parse time information');
+      }
+    }
     return result;
   }
 }

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -28,9 +28,9 @@ test('WmsLayer.getMapUrl returns an URL', () => {
     request: 'GetMap',
     format: 'image/jpeg',
     layers: layerId,
-    crs: 'EPSG:4326',
+    srs: 'EPSG:4326',
     bbox: '19,20,20,21',
-    time: '2020-01-10T00:00:00.000Z/2020-01-10T23:59:59.000Z',
+    time: '2020-01-10T00:00:00Z/2020-01-10T23:59:59Z',
     width: '512',
     height: '512',
   });
@@ -68,9 +68,9 @@ test('WmsLayer.getMap makes an appropriate request', () => {
     request: 'GetMap',
     format: 'image/jpeg',
     layers: layerId,
-    crs: 'EPSG:4326',
+    srs: 'EPSG:4326',
     bbox: '19,20,20,21',
-    time: '2020-01-10T00:00:00.000Z/2020-01-10T23:59:59.000Z',
+    time: '2020-01-10T00:00:00Z/2020-01-10T23:59:59Z',
     width: '512',
     height: '512',
   });

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -2,9 +2,14 @@ import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from 'src/bbox';
 
+/**
+ * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).
+ */
 export type GetMapParams = {
   bbox: BBox;
+  /** Start of the time interval for which the images are fetched. If null, only `toTime` parameter will be used. */
   fromTime: Date | null;
+  /** End of the time interval for which the images are fetched. If `fromTime` is null, only this parameter will be used to set time. */
   toTime: Date;
   format: MimeType;
   resx?: string; // either resx + resy or width + height must be specified

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -4,7 +4,7 @@ import { BBox } from 'src/bbox';
 
 export type GetMapParams = {
   bbox: BBox;
-  fromTime: Date;
+  fromTime: Date | null;
   toTime: Date;
   format: MimeType;
   resx?: string; // either resx + resy or width + height must be specified

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -1,8 +1,33 @@
 import axios, { AxiosResponse } from 'axios';
+import { stringify } from 'query-string';
+import { parseStringPromise } from 'xml2js';
 
 import { getAuthToken, isAuthTokenSet } from 'src/auth';
 
 let fetchCache: Record<string, Promise<AxiosResponse>> = {};
+
+export type GetCapabilitiesXml = {
+  WMS_Capabilities: {
+    Service: [];
+    Capability: [
+      {
+        Layer: [
+          {
+            Layer: [
+              {
+                Name: string[];
+                Title: string[];
+                Abstract: string[];
+                Style: any[]; // Depending on the service, it can be an array of strings or an array of objects
+                Dimension?: any[];
+              },
+            ];
+          },
+        ];
+      },
+    ];
+  };
+};
 
 export function fetchCached(
   url: string,
@@ -21,4 +46,38 @@ export function fetchCached(
   }
   fetchCache[url] = axios.get(url, axiosParams);
   return fetchCache[url];
+}
+
+export async function fetchGetCapabilitiesXml(
+  baseUrl: string,
+  forceFetch = false,
+): Promise<GetCapabilitiesXml> {
+  const query = {
+    service: 'wms',
+    request: 'GetCapabilities',
+    format: 'text/xml',
+  };
+  const queryString = stringify(query, { sort: false });
+  const url = `${baseUrl}?${queryString}`;
+  const res = await fetchCached(url, { responseType: 'text' }, forceFetch);
+  const parsedXml = await parseStringPromise(res.data);
+  return parsedXml;
+}
+
+export async function fetchGetCapabilitiesJson(baseUrl: string, forceFetch = false): Promise<any[]> {
+  const query = {
+    request: 'GetCapabilities',
+    format: 'application/json',
+  };
+  const queryString = stringify(query, { sort: false });
+  const url = `${baseUrl}?${queryString}`;
+  const res = await fetchCached(url, { responseType: 'json' }, forceFetch);
+  return res.data.layers;
+}
+
+export async function fetchGetCapabilitiesJsonV1(baseUrl: string, forceFetch = false): Promise<any[]> {
+  const instanceId = this.parseSHInstanceId(baseUrl);
+  const url = `https://eocloud.sentinel-hub.com/v1/config/instance/instance.${instanceId}?scope=ALL`;
+  const res = await fetchCached(url, { responseType: 'json' }, forceFetch);
+  return res.data.layers;
 }

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -1,4 +1,5 @@
 import { stringify } from 'query-string';
+import moment from 'moment';
 
 import { CRS_EPSG4326, CRS_IDS } from 'src/crs';
 import { GetMapParams, MimeTypes, MimeType } from 'src/layer/const';
@@ -88,7 +89,13 @@ export function wmsGetMapUrl(
     queryParams.format = params.format;
   }
 
-  queryParams.time = `${params.fromTime.toISOString()}/${params.toTime.toISOString()}`;
+  if (params.fromTime === null) {
+    queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z';
+  } else {
+    queryParams.time = `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
+      .utc(params.toTime)
+      .format('YYYY-MM-DDTHH:mm:ss') + 'Z'}`;
+  }
 
   if (params.width && params.height) {
     queryParams.width = params.width;

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -14,7 +14,8 @@ type OgcGetMapOptions = {
   version: string;
   service: ServiceType;
   request: string;
-  crs: CRS_IDS;
+  // crs: CRS_IDS; // if using WMS >= 1.3.0
+  srs: CRS_IDS; // if using WMS <= 1.1.1
   format: MimeType;
   transparent: boolean | number;
   layers: string;
@@ -61,7 +62,7 @@ export function wmsGetMapUrl(
     service: ServiceType.WMS,
     request: 'GetMap',
     format: MimeTypes.JPEG,
-    crs: CRS_EPSG4326.authId,
+    srs: CRS_EPSG4326.authId,
     layers: undefined,
     bbox: undefined,
     time: undefined,
@@ -83,7 +84,7 @@ export function wmsGetMapUrl(
     throw new Error('No bbox provided');
   }
   queryParams.bbox = `${params.bbox.minX},${params.bbox.minY},${params.bbox.maxX},${params.bbox.maxY}`;
-  queryParams.crs = params.bbox.crs.authId;
+  queryParams.srs = params.bbox.crs.authId;
 
   if (params.format) {
     queryParams.format = params.format;

--- a/stories/wms.gibs.stories.js
+++ b/stories/wms.gibs.stories.js
@@ -183,14 +183,13 @@ export const findDates = () => {
     const dates = await layer.findDates(bbox, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
+    const resDateStartOfDay = new Date(new Date(dates[5]).setUTCHours(0, 0, 0, 0));
 
     // prepare an image to show that the number makes sense:
     const getMapParams = {
       bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
+      fromTime: null,
+      toTime: resDateStartOfDay,
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,

--- a/stories/wms.gibs.stories.js
+++ b/stories/wms.gibs.stories.js
@@ -11,7 +11,6 @@ import {
 } from '../dist/sentinelHub.esm';
 
 const baseUrl = 'https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi';
-// const layerId = 'AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night';
 const layerId = 'MODIS_Terra_SurfaceReflectance_Bands721';
 const bbox = new BBox(CRS_EPSG3857, 1487158.82, 5322463.15, 1565430.34, 5400734.67);
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);

--- a/stories/wms.gibs.stories.js
+++ b/stories/wms.gibs.stories.js
@@ -10,13 +10,14 @@ import {
   LayersFactory,
 } from '../dist/sentinelHub.esm';
 
-const baseUrl = 'https://proba-v-mep.esa.int/applications/geo-viewer/app/geoserver/ows';
-const layerId = 'PROBAV_S5_TOA_100M';
+const baseUrl = 'https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi';
+// const layerId = 'AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night';
+const layerId = 'MODIS_Terra_SurfaceReflectance_Bands721';
 const bbox = new BBox(CRS_EPSG3857, 1487158.82, 5322463.15, 1565430.34, 5400734.67);
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
 
 export default {
-  title: 'WMS - ProbaV',
+  title: 'WMS - GIBS',
 };
 
 export const getMapURL = () => {
@@ -31,9 +32,9 @@ export const getMapURL = () => {
   const layer = new WmsLayer({ baseUrl, layerId });
 
   const getMapParams = {
-    bbox: bbox,
-    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
-    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    bbox: bbox4326,
+    fromTime: null,
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22)),
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
@@ -58,8 +59,8 @@ export const getMapWMS = () => {
 
     const getMapParams = {
       bbox: bbox,
-      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      fromTime: null,
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22)),
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
@@ -86,8 +87,8 @@ export const getMapWmsLayersFactory = () => {
 
     const getMapParams = {
       bbox: bbox,
-      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      fromTime: null,
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22)),
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,


### PR DESCRIPTION
A few changes were needed to support GIBS:

- `fetchGetCapabilities*()` are now in `utils.js` (to avoid circular imports - `LayersFactory -> WmsLayer -> LayersFactory`)
- fixed: `fetchGetCapabilitiesJson` is internal to the library (was even private to LayersFactory) and as such doesn't belong to node.js example; we want users to use our abstraction layers, if they want raw access, they should use fetch / axios / ... directly
- fixed: GIBS doesn't allow `from/to` format of dates; allow setting `fromDate` to `null`, in which case only one date is passed on
- fixed: GIBS doesn't allow milliseconds in dates, changed date formatting (other known services also support `YYYY-MM-DDThh:mm:ssZ` format which is now used)
- fixed: since we are using WMS version `1.1.1`, we should be using `srs` instead of `crs` parameter (other services don't mind, but GIBS follows the standard here)
- added support for `start/end/duration` times in GetCapabilities layer time dimension