### PR TITLE
Rename findDates() to findDatesUTC()

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ We can always use layer to search for data availability:
   });
   const { tiles, hasMore } = await layerS2L2A.findTiles(bbox, fromTime, toTime, maxCount, offset);
   const flyoversS2L2A = await layerS2L2A.findFlyovers(bbox, fromTime, toTime);
-  const datesS2L2A = await layerS2L2A.findDates(bbox, fromTime, toTime);
+  const datesS2L2A = await layerS2L2A.findDatesUTC(bbox, fromTime, toTime);
 
   const layerS1 = new S1GRDAWSEULayer({
     instanceId: '<my-instance-id>',
@@ -177,7 +177,7 @@ We can always use layer to search for data availability:
   });
   const { tiles: tilesS1 } = await layerS1.findTiles(bbox, fromTime, toTime, maxCount, offset);
   const flyoversS1 = await layerS1.findFlyovers(bbox, fromTime, toTime);
-  const datesS1 = await layerS1.findDates(bbox, fromTime, toTime);
+  const datesS1 = await layerS1.findDatesUTC(bbox, fromTime, toTime);
 ```
 
 ## Backwards compatibility

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -129,7 +129,7 @@ async function run() {
   );
   printOut('flyovers for S2 L2A:', flyoversS2L2A);
 
-  const datesS2L2A = await layerS2L2A.findDates(
+  const datesS2L2A = await layerS2L2A.findDatesUTC(
     getMapParams.bbox,
     getMapParams.fromTime,
     getMapParams.toTime,
@@ -156,7 +156,7 @@ async function run() {
   );
   printOut('flyovers for S1 GRD:', flyoversS1GRD);
 
-  const datesS1GRD = await layerS1.findDates(getMapParams.bbox, getMapParams.fromTime, getMapParams.toTime);
+  const datesS1GRD = await layerS1.findDatesUTC(getMapParams.bbox, getMapParams.fromTime, getMapParams.toTime);
   printOut('dates for S1 GRD', datesS1GRD);
 
   // finally, display the image:

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -227,13 +227,20 @@ export class AbstractLayer {
     return geometry.map((x: any) => this.roundCoordinates(x));
   }
 
-  public async findDates(
+  public async findDatesUTC(
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    // any additional
   ): Promise<Date[]> {
-    throw new Error('findDates() not implemented yet');
+    throw new Error('findDatesUTC() not implemented yet');
+  }
+
+  /**
+   * @deprecated Please use findDatesUTC() instead.
+   */
+  public async findDates(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
+    console.warn('Method findDates() is deprecated and will be removed, please use findDatesUTC() instead');
+    return await this.findDatesUTC(bbox, fromTime, toTime);
   }
 
   public async updateLayerFromServiceIfNeeded(): Promise<void> {}

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -119,8 +119,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     return {};
   }
 
-  public async findDates(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
-    if (!this.dataset.findDatesUrl) {
+  public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
+    if (!this.dataset.findDatesUTCUrl) {
       throw new Error('This dataset does not support searching for dates');
     }
 
@@ -131,7 +131,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       ...this.getFindDatesAdditionalParameters(),
     };
 
-    const url = `${this.dataset.findDatesUrl}?${stringify(params, { sort: false })}`;
+    const url = `${this.dataset.findDatesUTCUrl}?${stringify(params, { sort: false })}`;
     const response = await axios.post(url, payload, {
       headers: {
         'Content-Type': 'application/json',

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -115,7 +115,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     return {};
   }
 
@@ -128,7 +128,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     const params = {
       timefrom: fromTime.toISOString(),
       timeto: toTime.toISOString(),
-      ...this.getFindDatesAdditionalParameters(),
+      ...this.getFindDatesUTCAdditionalParameters(),
     };
 
     const url = `${this.dataset.findDatesUTCUrl}?${stringify(params, { sort: false })}`;

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -45,7 +45,7 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     return {
       maxcc: this.maxCloudCoverPercent / 100,
     };

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -221,8 +221,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return {};
   }
 
-  public async findDates(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
-    if (!this.dataset.findDatesUrl) {
+  public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
+    if (!this.dataset.findDatesUTCUrl) {
       throw new Error('This dataset does not support searching for dates');
     }
 
@@ -233,7 +233,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       to: toTime.toISOString(),
       ...this.getFindDatesAdditionalParameters(),
     };
-    const response = await axios.post(this.dataset.findDatesUrl, payload);
+    const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     return response.data.map((date: string) => moment.utc(date).toDate());
   }
 }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -217,7 +217,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return axios.post(this.dataset.searchIndexUrl, payload, this.createSearchIndexRequestConfig());
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     return {};
   }
 
@@ -231,7 +231,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       queryArea: bboxPolygon,
       from: fromTime.toISOString(),
       to: toTime.toISOString(),
-      ...this.getFindDatesAdditionalParameters(),
+      ...this.getFindDatesUTCAdditionalParameters(),
     };
     const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     return response.data.map((date: string) => moment.utc(date).toDate());

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -60,7 +60,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     return {
       maxCloudCoverage: this.maxCloudCoverPercent / 100,
     };

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -121,8 +121,8 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return result;
   }
 
-  public async findDates(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
-    if (!this.dataset.findDatesUrl) {
+  public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
+    if (!this.dataset.findDatesUTCUrl) {
       throw new Error('This dataset does not support searching for dates');
     }
 
@@ -134,7 +134,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       to: toTime.toISOString(),
       ...additionalFindDatesParameters,
     };
-    const response = await axios.post(this.dataset.findDatesUrl, payload);
+    const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     return response.data.map((date: string) => moment.utc(date).toDate());
   }
 }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -105,7 +105,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return {};
   }
 
-  protected async getFindDatesAdditionalParameters(): Promise<Record<string, any>> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     if (this.shouldFetchAdditionalParams()) {
       const layerParams = await this.fetchLayerParamsFromSHServiceV3();
       this.collectionId = layerParams['collectionId'];
@@ -126,13 +126,13 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       throw new Error('This dataset does not support searching for dates');
     }
 
-    const additionalFindDatesParameters = await this.getFindDatesAdditionalParameters();
+    const additionalFindDatesUTCParameters = await this.getFindDatesUTCAdditionalParameters();
     const bboxPolygon = bbox.toGeoJSON();
     const payload: any = {
       queryArea: bboxPolygon,
       from: fromTime.toISOString(),
       to: toTime.toISOString(),
-      ...additionalFindDatesParameters,
+      ...additionalFindDatesUTCParameters,
     };
     const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     return response.data.map((date: string) => moment.utc(date).toDate());

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -161,7 +161,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -118,7 +118,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     return result;
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     const result: Record<string, any> = {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -100,7 +100,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -112,7 +112,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesAdditionalParameters(): Record<string, any> {
+  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -31,11 +31,10 @@ export class WmsLayer extends AbstractLayer {
     return wmsGetMapUrl(this.baseUrl, this.layerId, params);
   }
 
-  public async findDates(
+  public async findDatesUTC(
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    // any additional
   ): Promise<Date[]> {
     // http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#dims
     const capabilities = await fetchGetCapabilitiesXml(this.baseUrl);

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -6,7 +6,7 @@ export type Dataset = {
   datasetParametersType: string | null;
   shServiceHostname: string;
   searchIndexUrl: string;
-  findDatesUrl: string;
+  findDatesUTCUrl: string;
   orbitTimeMinutes: number;
 };
 
@@ -18,7 +18,7 @@ export const DATASET_AWSEU_S1GRD: Dataset = {
   datasetParametersType: 'S1GRD',
   shServiceHostname: 'https://services.sentinel-hub.com/',
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/searchIndex',
-  findDatesUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/findAvailableData',
+  findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/findAvailableData',
   orbitTimeMinutes: 49.3,
 };
 
@@ -30,7 +30,7 @@ export const DATASET_EOCLOUD_S1GRD: Dataset = {
   datasetParametersType: 'S1GRD',
   shServiceHostname: 'https://eocloud.sentinel-hub.com/',
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/search',
-  findDatesUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/finddates',
+  findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/finddates',
   orbitTimeMinutes: 49.3,
 };
 
@@ -42,7 +42,7 @@ export const DATASET_S2L2A: Dataset = {
   datasetParametersType: 'S2',
   shServiceHostname: 'https://services.sentinel-hub.com/',
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/searchIndex',
-  findDatesUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/findAvailableData',
+  findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/findAvailableData',
   orbitTimeMinutes: 50.3,
 };
 
@@ -54,7 +54,7 @@ export const DATASET_S2L1C: Dataset = {
   datasetParametersType: 'S2',
   shServiceHostname: 'https://services.sentinel-hub.com/',
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex',
-  findDatesUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/findAvailableData',
+  findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/findAvailableData',
   orbitTimeMinutes: 50.3,
 };
 
@@ -66,7 +66,7 @@ export const DATASET_S3SLSTR: Dataset = {
   datasetParametersType: 'S3SLSTR',
   shServiceHostname: 'https://creodias.sentinel-hub.com/',
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/searchIndex',
-  findDatesUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/findAvailableData',
+  findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/findAvailableData',
   orbitTimeMinutes: 50.495,
 };
 
@@ -78,7 +78,7 @@ export const DATASET_S3OLCI: Dataset = {
   datasetParametersType: 'S3',
   shServiceHostname: 'https://creodias.sentinel-hub.com/',
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/searchIndex',
-  findDatesUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/findAvailableData',
+  findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/findAvailableData',
   orbitTimeMinutes: 50.495,
 };
 
@@ -90,7 +90,7 @@ export const DATASET_S5PL2: Dataset = {
   datasetParametersType: 'S5PL2',
   shServiceHostname: 'https://creodias.sentinel-hub.com/',
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/searchIndex',
-  findDatesUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/findAvailableData',
+  findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/findAvailableData',
   orbitTimeMinutes: 101,
 };
 
@@ -102,7 +102,7 @@ export const DATASET_AWS_L8L1C: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://services-uswest2.sentinel-hub.com/',
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/searchIndex',
-  findDatesUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/findAvailableData',
+  findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/findAvailableData',
   orbitTimeMinutes: 99,
 };
 
@@ -114,7 +114,7 @@ export const DATASET_EOCLOUD_LANDSAT5: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://eocloud.sentinel-hub.com/',
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/search',
-  findDatesUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/dates',
+  findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/dates',
   orbitTimeMinutes: 99,
 };
 
@@ -126,7 +126,7 @@ export const DATASET_EOCLOUD_LANDSAT7: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://eocloud.sentinel-hub.com/',
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/search',
-  findDatesUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/dates',
+  findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/dates',
   orbitTimeMinutes: 99,
 };
 
@@ -138,7 +138,7 @@ export const DATASET_EOCLOUD_LANDSAT8: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://eocloud.sentinel-hub.com/',
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/search',
-  findDatesUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/dates',
+  findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/dates',
   orbitTimeMinutes: 99,
 };
 
@@ -150,7 +150,7 @@ export const DATASET_EOCLOUD_ENVISAT_MERIS: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://eocloud.sentinel-hub.com/',
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/search',
-  findDatesUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/finddates',
+  findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/finddates',
   orbitTimeMinutes: 100.16,
 };
 
@@ -162,7 +162,7 @@ export const DATASET_MODIS: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://services-uswest2.sentinel-hub.com/',
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/searchIndex',
-  findDatesUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/findAvailableData',
+  findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/findAvailableData',
   orbitTimeMinutes: 99,
 };
 
@@ -174,7 +174,7 @@ export const DATASET_AWS_DEM: Dataset = {
   datasetParametersType: null,
   shServiceHostname: 'https://services-uswest2.sentinel-hub.com/',
   searchIndexUrl: null,
-  findDatesUrl: null,
+  findDatesUTCUrl: null,
   orbitTimeMinutes: null,
 };
 
@@ -186,6 +186,6 @@ export const DATASET_BYOC: Dataset = {
   datasetParametersType: 'BYOC',
   shServiceHostname: 'https://services.sentinel-hub.com/',
   searchIndexUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/searchIndex',
-  findDatesUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData',
+  findDatesUTCUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData',
   orbitTimeMinutes: null,
 };

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -221,7 +221,7 @@ export const findTilesAuth = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   if (!process.env.BYOC_COLLECTION_ID) {
     throw new Error('BYOC_COLLECTION_ID environment variable is not defined!');
   }
@@ -232,7 +232,7 @@ export const findDates = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDates (with collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC (with collectionId)</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -243,7 +243,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox,
       new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
@@ -270,14 +270,14 @@ export const findDates = () => {
   return wrapperEl;
 };
 
-export const findDatesAuth = () => {
+export const findDatesUTCAuth = () => {
   if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
     return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
   }
   const layer = new BYOCLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDates (without collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC (without collectionId)</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -289,7 +289,7 @@ export const findDatesAuth = () => {
 
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox,
       new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/envisatmeris.eocloud.stories.js
+++ b/stories/envisatmeris.eocloud.stories.js
@@ -209,12 +209,12 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG3857 = () => {
+export const findDatesUTCEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
   const layer = new EnvisatMerisEOCloudLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent} </h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent} </h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -228,7 +228,7 @@ export const findDatesEPSG3857 = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
 
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -209,12 +209,12 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG3857 = () => {
+export const findDatesUTCEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
   const layer = new Landsat5EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -228,7 +228,7 @@ export const findDatesEPSG3857 = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
 
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 

--- a/stories/landsat7.eocloud.stories.js
+++ b/stories/landsat7.eocloud.stories.js
@@ -209,12 +209,12 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG3857 = () => {
+export const findDatesUTCEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
   const layer = new Landsat7EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -228,7 +228,7 @@ export const findDatesEPSG3857 = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
 
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 

--- a/stories/landsat8.aws.stories.js
+++ b/stories/landsat8.aws.stories.js
@@ -209,12 +209,12 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const maxCloudCoverPercent = 40;
   const layer = new Landsat8AWSLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates for Landsat 8 on AWS; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC for Landsat 8 on AWS; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -228,7 +228,7 @@ export const findDates = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
     const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));

--- a/stories/landsat8.eocloud.stories.js
+++ b/stories/landsat8.eocloud.stories.js
@@ -209,12 +209,12 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG3857 = () => {
+export const findDatesUTCEPSG3857 = () => {
   const maxCloudCoverPercent = 60;
   const layer = new Landsat8EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC - BBox in EPSG:3857; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -228,7 +228,7 @@ export const findDatesEPSG3857 = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
 
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -278,13 +278,13 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new S1GRDAWSEULayer({ instanceId, layerId });
   const bbox4326 = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML =
-    '<h2>findDates</h2>' +
+    '<h2>findDatesUTC</h2>' +
     'from: ' +
     new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)) +
     '<br />' +
@@ -300,7 +300,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s1grdiw.eocloud.stories.js
+++ b/stories/s1grdiw.eocloud.stories.js
@@ -266,7 +266,7 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG4326 = () => {
+export const findDatesUTCEPSG4326 = () => {
   const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
@@ -276,7 +276,7 @@ export const findDatesEPSG4326 = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:4326</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC - BBox in EPSG:4326</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -287,7 +287,7 @@ export const findDatesEPSG4326 = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
@@ -314,7 +314,7 @@ export const findDatesEPSG4326 = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG3857 = () => {
+export const findDatesUTCEPSG3857 = () => {
   const layer = new S1GRDEOCloudLayer({
     instanceId,
     layerId,
@@ -324,7 +324,7 @@ export const findDatesEPSG3857 = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:3857</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC - BBox in EPSG:3857</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -335,7 +335,7 @@ export const findDatesEPSG3857 = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -342,7 +342,7 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesEPSG4326 = () => {
+export const findDatesUTCEPSG4326 = () => {
   const layer = new S1GRDAWSEULayer({
     instanceId,
     layerId,
@@ -352,7 +352,7 @@ export const findDatesEPSG4326 = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDates - BBox in EPSG:4326</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC - BBox in EPSG:4326</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -363,7 +363,7 @@ export const findDatesEPSG4326 = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -235,7 +235,7 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const maxCloudCoverPercent = 60;
   const layerS2L1C = new S2L1CLayer({
     instanceId,
@@ -244,7 +244,7 @@ export const findDates = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -255,7 +255,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layerS2L1C.findDates(
+    const dates = await layerS2L1C.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -235,7 +235,7 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const maxCloudCoverPercent = 60;
   const layerS2L2A = new S2L2ALayer({
     instanceId,
@@ -244,7 +244,7 @@ export const findDates = () => {
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -255,7 +255,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layerS2L2A.findDates(
+    const dates = await layerS2L2A.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -230,12 +230,12 @@ export const findFlyoversLinearRingError = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new S3OLCILayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML =
-    '<h2>findDates</h2>' +
+    '<h2>findDatesUTC</h2>' +
     'from: ' +
     new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)) +
     '<br />' +
@@ -251,7 +251,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(
+    const dates = await layer.findDatesUTC(
       bbox4326,
       new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
       new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -223,7 +223,7 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new S3SLSTRLayer({ instanceId, layerId });
   const specialBBox4326 = new BBox(CRS_EPSG4326, 10, 40, 14, 44);
 
@@ -232,7 +232,7 @@ export const findDates = () => {
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML =
-    '<h2>findDates</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
+    '<h2>findDatesUTC</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -243,7 +243,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(specialBBox4326, fromTime, toTime);
+    const dates = await layer.findDatesUTC(specialBBox4326, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
     const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -271,7 +271,7 @@ export const findTiles = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new S5PL2Layer({ instanceId, layerId, productType: 'NO2', maxCloudCoverPercent: 60 });
 
   const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
@@ -279,7 +279,7 @@ export const findDates = () => {
 
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML =
-    '<h2>findDates</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
+    '<h2>findDatesUTC</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -290,7 +290,7 @@ export const findDates = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox4326, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox4326, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
     const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));

--- a/stories/wms.gibs.stories.js
+++ b/stories/wms.gibs.stories.js
@@ -161,11 +161,11 @@ export const findFlyoversNotImplemented = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new WmsLayer({ baseUrl, layerId });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -179,7 +179,7 @@ export const findDates = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
     const resDateStartOfDay = new Date(new Date(dates[5]).setUTCHours(0, 0, 0, 0));

--- a/stories/wms.probav.stories.js
+++ b/stories/wms.probav.stories.js
@@ -161,11 +161,11 @@ export const findFlyoversNotImplemented = () => {
   return wrapperEl;
 };
 
-export const findDates = () => {
+export const findDatesUTC = () => {
   const layer = new WmsLayer({ baseUrl, layerId });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDates</h2>`;
+  wrapperEl.innerHTML = `<h2>findDatesUTC</h2>`;
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -179,7 +179,7 @@ export const findDates = () => {
   const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
 
   const perform = async () => {
-    const dates = await layer.findDates(bbox, fromTime, toTime);
+    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
     containerEl.innerHTML = JSON.stringify(dates, null, true);
 
     const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));


### PR DESCRIPTION
To avoid surprising users, we should rename `findDates` to `findDatesUTC`. 

This PR also provides a (deprecated) `findDates` method which issues a warning and calls `findDatesUTC`. I added a story to test `findDates`, but removed it later to avoid "polluting" the storybook.