### PR TITLE
Do not send auth token to external services

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -1,10 +1,9 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import moment from 'moment';
 
 import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval } from 'src/layer/const';
 import { BBox } from 'src/bbox';
 import { Dataset } from 'src/layer/dataset';
-import { RequestConfig } from 'src/utils/axiosInterceptors';
 import area from '@turf/area';
 import { union, intersection, Geom } from 'polygon-clipping';
 
@@ -29,7 +28,7 @@ export class AbstractLayer {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
-        const requestConfig: RequestConfig = { responseType: 'blob', useCache: true };
+        const requestConfig: AxiosRequestConfig = { responseType: 'blob', useCache: true };
         const response = await axios.get(url, requestConfig);
         return response.data;
       default:

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -4,7 +4,6 @@ import moment from 'moment';
 import { getAuthToken, isAuthTokenSet } from 'src/auth';
 import { BBox } from 'src/bbox';
 import { GetMapParams, ApiType, PaginatedTiles } from 'src/layer/const';
-import { fetchCached } from 'src/layer/utils';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
@@ -72,7 +71,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const headers = {
       Authorization: `Bearer ${authToken}`,
     };
-    const res = await fetchCached(url, { responseType: 'json', headers: headers }, false);
+    const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: true });
     const layersParams = res.data.map((l: any) => ({
       layerId: l.id,
       ...l.datasourceDefaults,

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -1,10 +1,9 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
 import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-import { RequestConfig } from 'src/utils/axiosInterceptors';
 
 enum PreviewMode {
   DETAIL = 'DETAIL',
@@ -154,7 +153,7 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
   }
-  const requestConfig: RequestConfig = {
+  const requestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: 'Bearer ' + authToken,
       'Content-Type': 'application/json',

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 import { stringify } from 'query-string';
 
 const SENTINEL_HUB_CACHE = 'sentinelhub-v1';

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -30,8 +30,8 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
   if (typeof window === 'undefined' || !window.caches) {
     return request;
   }
-  // resource not cacheable? It couldn't have been saved to cache:
   const cacheKey = await generateCacheKey(request);
+  // resource not cacheable? It couldn't have been saved to cache:
   if (cacheKey === null) {
     return request;
   }
@@ -89,12 +89,11 @@ const saveCacheResponse = async (response: any): Promise<any> => {
   if (typeof window === 'undefined' || !window.caches) {
     return response;
   }
-  // resource not cacheable?
   const cacheKey = await generateCacheKey(response.config);
+  // resource not cacheable?
   if (cacheKey === null) {
     return response;
   }
-  // Cache API not supported?
   let cache;
   try {
     cache = await caches.open(SENTINEL_HUB_CACHE);

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -68,7 +68,6 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
         responseData = await cachedResponse.text();
         break;
       case 'json':
-      case undefined:
         responseData = await cachedResponse.json();
         break;
       default:

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -19,7 +19,7 @@ declare module 'axios' {
 export const registerAxiosCacheRetryInterceptors = (): any => {
   findAndDeleteExpiredCachedItems();
   axios.interceptors.request.use(fetchCachedResponse, error => Promise.reject(error));
-  axios.interceptors.response.use(setCacheResponse, retryRequests);
+  axios.interceptors.response.use(setCacheResponse, error => retryRequests(error));
 };
 
 const fetchCachedResponse = async (request: any): Promise<any> => {

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -6,9 +6,14 @@ const EXPIRY_HEADER_KEY = 'Cache_Expires';
 const EXPIRES_IN_SECONDS = 60 * 30;
 const DELAY = 3000;
 const RETRIES = 5;
-export interface RequestConfig extends AxiosRequestConfig {
-  useCache?: boolean;
-  retries?: number;
+
+// we are extending axios' AxiosRequestConfig:
+// https://stackoverflow.com/questions/58777924/axios-typescript-customize-axiosrequestconfig
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    useCache?: boolean;
+    retries?: number;
+  }
 }
 
 export const registerAxiosCacheRetryInterceptors = (): any => {

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -26,7 +26,11 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
   if (!(request && request.useCache)) {
     return request;
   }
-
+  // do not perform caching if Cache API is not supported:
+  if (typeof window === 'undefined' || !window.caches) {
+    return request;
+  }
+  // resource not cacheable? It couldn't have been saved to cache:
   const cacheKey = await generateCacheKey(request);
   if (cacheKey === null) {
     return request;
@@ -81,6 +85,10 @@ const saveCacheResponse = async (response: any): Promise<any> => {
   if (!response.config.useCache) {
     return response;
   }
+  // do not perform caching if Cache API is not supported:
+  if (typeof window === 'undefined' || !window.caches) {
+    return response;
+  }
   // resource not cacheable?
   const cacheKey = await generateCacheKey(response.config);
   if (cacheKey === null) {
@@ -91,7 +99,7 @@ const saveCacheResponse = async (response: any): Promise<any> => {
   try {
     cache = await caches.open(SENTINEL_HUB_CACHE);
   } catch (err) {
-    console.debug('Cache API not supported, not caching', err);
+    console.warn('Caching failed', err);
     return response;
   }
 


### PR DESCRIPTION
Due to a bug (old code) in `fetchCached()`, which indiscriminately added auth token to any request, library was sending auth token to external services. This PR solves this by replacing `fetchCached` with `axios.get()` + cache interceptors.

Because the tests were complaining about invalid fields in `AxiosRequestConfig`, we [monkey patch](https://stackoverflow.com/a/58778671/593487) the type (officially known as [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)).

Consequently, `RequestConfig` was no longer needed as we can now use `AxiosRequestConfig` directly.

Since `forceFetch` parameter was not used anywhere, it was also removed.