### PR TITLE
fix refactored LayerFactory problems

### DIFF
--- a/example/node/index.js
+++ b/example/node/index.js
@@ -156,7 +156,11 @@ async function run() {
   );
   printOut('flyovers for S1 GRD:', flyoversS1GRD);
 
-  const datesS1GRD = await layerS1.findDatesUTC(getMapParams.bbox, getMapParams.fromTime, getMapParams.toTime);
+  const datesS1GRD = await layerS1.findDatesUTC(
+    getMapParams.bbox,
+    getMapParams.fromTime,
+    getMapParams.toTime,
+  );
   printOut('dates for S1 GRD', datesS1GRD);
 
   // finally, display the image:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,10 @@
       "."
     ],
     "testRegex": "/__tests__/.*\\.(ts|tsx|js)$",
-    "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   },
   "types": "dist/index.d.ts",
   "files": [

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -4,7 +4,7 @@ import {
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
 } from 'src/layer/utils';
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
 import {
   DATASET_S2L2A,
   DATASET_AWS_L8L1C,

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -91,3 +91,11 @@ export const MimeTypes: Record<string, MimeType> = {
   JPEG: 'image/jpeg',
   PNG: 'image/png',
 };
+
+export const SH_SERVICE_HOSTNAMES_V1_OR_V2: string[] = ['https://eocloud.sentinel-hub.com/'];
+
+export const SH_SERVICE_HOSTNAMES_V3: string[] = [
+  'https://services.sentinel-hub.com/',
+  'https://services-uswest2.sentinel-hub.com/',
+  'https://creodias.sentinel-hub.com/',
+];

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -3,6 +3,7 @@ import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
 import { getAuthToken, isAuthTokenSet } from 'src/auth';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
 
 let fetchCache: Record<string, Promise<AxiosResponse>> = {};
 
@@ -76,8 +77,31 @@ export async function fetchGetCapabilitiesJson(baseUrl: string, forceFetch = fal
 }
 
 export async function fetchGetCapabilitiesJsonV1(baseUrl: string, forceFetch = false): Promise<any[]> {
-  const instanceId = this.parseSHInstanceId(baseUrl);
+  const instanceId = parseSHInstanceId(baseUrl);
   const url = `https://eocloud.sentinel-hub.com/v1/config/instance/instance.${instanceId}?scope=ALL`;
   const res = await fetchCached(url, { responseType: 'json' }, forceFetch);
   return res.data.layers;
+}
+
+export function parseSHInstanceId(baseUrl: string): string {
+  const INSTANCE_ID_LENGTH = 36;
+  // AWS:
+  for (let hostname of SH_SERVICE_HOSTNAMES_V3) {
+    const prefix = `${hostname}ogc/wms/`;
+    if (!baseUrl.startsWith(prefix)) {
+      continue;
+    }
+    const instanceId = baseUrl.substr(prefix.length, INSTANCE_ID_LENGTH);
+    return instanceId;
+  }
+  // EOCloud:
+  for (let hostname of SH_SERVICE_HOSTNAMES_V1_OR_V2) {
+    const prefix = `${hostname}v1/wms/`;
+    if (!baseUrl.startsWith(prefix)) {
+      continue;
+    }
+    const instanceId = baseUrl.substr(prefix.length, INSTANCE_ID_LENGTH);
+    return instanceId;
+  }
+  throw new Error(`Could not parse instanceId from URL: ${baseUrl}`);
 }

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -3,7 +3,7 @@ import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
 import { getAuthToken, isAuthTokenSet } from 'src/auth';
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
 
 let fetchCache: Record<string, Promise<AxiosResponse>> = {};
 


### PR DESCRIPTION
After a small refactor of `src/layer/LayerFactory.ts` in https://github.com/sentinel-hub/sentinelhub-js/pull/49, `parseSHInstanceId()` was still in `src/layer/LayerFactory.ts`, but was called as `this.parseSHInstanceId()` in `src/layer/utils.ts`. So I moved it to `src/layer/utils.ts`

I also moved `SH_SERVICE_HOSTNAMES_V1_OR_V2`, `SH_SERVICE_HOSTNAMES_V3` from `src/layer/LayersFactory.ts` to `src/layer/const.ts` as it seems to be the right place for them, and they are needed both in  `src/layer/LayerFactory.ts` and `src/layer/utils.ts`.

Other changes are from running `npm run build` (which somehow reformats `package.json`) and `npm run prettier`.