### PR TITLE
Feature/export preview mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes, OrbitDirection } from 'src/layer/const';
+import { ApiType, MimeTypes, OrbitDirection, PreviewMode } from 'src/layer/const';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
 import {
@@ -93,6 +93,7 @@ export {
   Polarization,
   Resolution,
   OrbitDirection,
+  PreviewMode,
   S3SLSTRView,
   BBox,
   // legacy:

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -17,7 +17,7 @@ export type GetMapParams = {
   width?: number;
   height?: number;
   // optional additional parameters:
-  preview?: number;
+  preview?: PreviewMode;
   geometry?: string;
   quality?: number;
   gain?: number;
@@ -38,9 +38,9 @@ export type GetMapParams = {
 export type Interpolator = 'BILINEAR' | 'BICUBIC' | 'LANCZOS' | 'BOX' | 'NEAREST';
 
 export enum PreviewMode {
-  DETAIL = 'DETAIL',
-  PREVIEW = 'PREVIEW',
-  EXTENDED_PREVIEW = 'EXTENDED_PREVIEW',
+  DETAIL = 0,
+  PREVIEW = 1,
+  EXTENDED_PREVIEW = 2,
 }
 
 export enum ApiType {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
-import { MimeType, GetMapParams, Interpolator, PreviewMode } from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 import { RequestConfig } from 'src/utils/axiosInterceptors';
 
@@ -11,6 +11,13 @@ enum MosaickingOrder {
   LEAST_RECENT = 'leastRecent',
   LEAST_CC = 'leastCC',
 }
+
+enum PreviewModeString {
+  DETAIL = 'DETAIL',
+  PREVIEW = 'PREVIEW',
+  EXTENDED_PREVIEW = 'EXTENDED_PREVIEW',
+}
+
 export type ProcessingPayload = {
   input: {
     bounds: {
@@ -28,7 +35,7 @@ export type ProcessingPayload = {
             from: string;
             to: string;
           };
-          previewMode?: PreviewMode;
+          previewMode?: PreviewModeString;
           mosaickingOrder?: MosaickingOrder;
           [key: string]: any;
         };
@@ -118,16 +125,17 @@ export function createProcessingPayload(
     //   - 3 -> EXTENDED_PREVIEW (used, but not officially supported)
     switch (params.preview) {
       case 0:
-        payload.input.data[0].dataFilter.previewMode = PreviewMode.DETAIL;
+        payload.input.data[0].dataFilter.previewMode = PreviewModeString.DETAIL;
         break;
       case 1:
-        payload.input.data[0].dataFilter.previewMode = PreviewMode.PREVIEW;
+        payload.input.data[0].dataFilter.previewMode = PreviewModeString.PREVIEW;
         break;
       case 2:
       case 3:
-      default:
-        payload.input.data[0].dataFilter.previewMode = PreviewMode.EXTENDED_PREVIEW;
+        payload.input.data[0].dataFilter.previewMode = PreviewModeString.EXTENDED_PREVIEW;
         break;
+      default:
+        throw new Error('Preview mode does not exist, options are "DETAIL", "PREVIEW" or "EXTENDED_PREVIEW"');
     }
   }
 

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -2,15 +2,10 @@ import axios from 'axios';
 import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
-import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator, PreviewMode } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 import { RequestConfig } from 'src/utils/axiosInterceptors';
 
-enum PreviewMode {
-  DETAIL = 'DETAIL',
-  PREVIEW = 'PREVIEW',
-  EXTENDED_PREVIEW = 'EXTENDED_PREVIEW',
-}
 enum MosaickingOrder {
   MOST_RECENT = 'mostRecent',
   LEAST_RECENT = 'leastRecent',

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -121,8 +121,7 @@ export function wmsGetMapUrl(
   if (evalscriptUrl) {
     queryParams.evalscripturl = evalscriptUrl;
   }
-
-  if (params.preview) {
+  if (params.preview !== undefined) {
     queryParams.preview = params.preview;
   }
   if (params.geometry) {

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -1,6 +1,6 @@
 import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { S2L1CLayer, CRS_EPSG4326, BBox, MimeTypes, ApiType } from '../dist/sentinelHub.esm';
+import { S2L1CLayer, CRS_EPSG4326, BBox, MimeTypes, ApiType, PreviewMode } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -36,6 +36,7 @@ export const GetMapURL = () => {
     width: 512,
     height: 512,
     format: MimeTypes.JPEG,
+    preview: PreviewMode.DETAIL,
   };
   const imageUrl = layerS2L1C.getMapUrl(getMapParams, ApiType.WMS);
   img.src = imageUrl;
@@ -114,6 +115,7 @@ export const GetMapProcessing = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
+      preview: PreviewMode.EXTENDED_PREVIEW,
     };
     const imageBlob = await layerS2L1C.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);


### PR DESCRIPTION
Currently with getMap we have to add the `preview` param with `preview: 2`. This MR allows us to import the enum `PreviewMode` and add `preview` with `PreviewMode.EXTENDED_PREVIEW`.

`processing.ts` had its own `PreviewMode` declared, so this was removed and the imported enum is now used