### PR TITLE
Add support for geometry to getMap (WMS and Processing)

### DIFF
--- a/example/node/index.js
+++ b/example/node/index.js
@@ -167,7 +167,11 @@ async function run() {
   const imageUrl = layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);
   printOut('URL of S2 L2A image:', imageUrl);
 
-  const layerS2L2AWithEvalscript = new S2L2ALayer({ instanceId, layerId: s2l2aLayerId, evalscript: 'return [B02, B03, B04];' });
+  const layerS2L2AWithEvalscript = new S2L2ALayer({
+    instanceId,
+    layerId: s2l2aLayerId,
+    evalscript: 'return [B02, B03, B04];',
+  });
   const imageUrl2 = layerS2L2AWithEvalscript.getMapUrl(getMapParams, ApiType.WMS);
   printOut('URL of S2 L2A image with evalscript:', imageUrl2);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,6 +2195,11 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/geojson": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
+      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+    },
     "@types/history": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
@@ -13995,6 +14000,23 @@
       "requires": {
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "terraformer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.10.tgz",
+      "integrity": "sha512-5c6cAfKTZHAeRdT8sIRRidhN1w+vsmf3RmQn+PKksFhTUnsBtjQdbJG2vaxM6T47IU2EeR1S8t8UjTYY9Q1yJA==",
+      "requires": {
+        "@types/geojson": "^7946.0.0 || ^1.0.0"
+      }
+    },
+    "terraformer-wkt-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.1.tgz",
+      "integrity": "sha512-+CJyNLWb3lJ9RsZMTM66BY0MT3yIo4l4l22Jd9CrZuwzk54fsu4Sc7zejuS9fCITTuTQy3p06d4MZMVI7v5wSg==",
+      "requires": {
+        "@types/geojson": "^1.0.0",
+        "terraformer": "~1.0.5"
       }
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "moment": "^2.24.0",
     "polygon-clipping": "^0.14.3",
     "query-string": "^6.4.2",
+    "terraformer-wkt-parser": "^1.2.1",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -18,7 +18,7 @@ export type GetMapParams = {
   height?: number;
   // optional additional parameters:
   preview?: PreviewMode;
-  geometry?: Polygon;
+  geometry?: Polygon | MultiPolygon;
   quality?: number;
   gain?: number;
   gamma?: number;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -18,7 +18,7 @@ export type GetMapParams = {
   height?: number;
   // optional additional parameters:
   preview?: PreviewMode;
-  geometry?: string;
+  geometry?: Polygon;
   quality?: number;
   gain?: number;
   gamma?: number;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import { Polygon, BBox as BBoxTurf } from '@turf/helpers';
+import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
 import { MimeType, GetMapParams, Interpolator } from 'src/layer/const';
@@ -21,7 +21,7 @@ export type ProcessingPayload = {
   input: {
     bounds: {
       bbox?: BBoxTurf;
-      geometry?: Polygon;
+      geometry?: Polygon | MultiPolygon;
       properties: {
         crs: string;
       };

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -113,6 +113,9 @@ export function createProcessingPayload(
   if (params.downsampling !== undefined) {
     payload.input.data[0].processing.downsampling = params.downsampling;
   }
+  if (params.geometry !== undefined) {
+    payload.input.bounds.geometry = params.geometry;
+  }
 
   if (params.preview !== undefined) {
     // WMS parameter description:

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -1,5 +1,6 @@
 import { stringify } from 'query-string';
 import moment from 'moment';
+import WKT from 'terraformer-wkt-parser';
 
 import { CRS_EPSG4326, CRS_IDS } from 'src/crs';
 import { GetMapParams, MimeTypes, MimeType } from 'src/layer/const';
@@ -130,7 +131,7 @@ export function wmsGetMapUrl(
     queryParams.preview = params.preview;
   }
   if (params.geometry) {
-    queryParams.geometry = params.geometry;
+    queryParams.geometry = WKT.convert(params.geometry);
   }
   if (params.quality) {
     queryParams.quality = params.quality;

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -1,3 +1,6 @@
+import WKT from 'terraformer-wkt-parser';
+import { Polygon } from '@turf/helpers';
+
 import { BBox } from 'src/bbox';
 import { CRS_IDS, CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { ApiType, MimeType, GetMapParams } from 'src/layer/const';
@@ -161,7 +164,7 @@ function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegac
     getMapParams.preview = previewFromParams(params);
   }
   if (params.geometry) {
-    getMapParams.geometry = params.geometry;
+    getMapParams.geometry = WKT.parse(params.geometry) as Polygon;
   }
   if (params.quality) {
     getMapParams.quality = parseInt(params.quality);

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -13,7 +13,7 @@ if (!process.env.S2L2A_LAYER_ID) {
 const instanceId = process.env.INSTANCE_ID;
 const layerId = process.env.S2L2A_LAYER_ID;
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
-const geometry = {
+const geometryPolygon = {
   type: 'Polygon',
   coordinates: [
     [
@@ -22,6 +22,20 @@ const geometry = {
       [12.5, 42.0],
       [12.0, 42.5],
       [12.5, 43.0],
+    ],
+  ],
+};
+const geometryMultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [12.5, 43.0],
+        [12.9, 42.5],
+        [12.5, 42.0],
+        [12.0, 42.5],
+        [12.5, 43.0],
+      ],
     ],
   ],
 };
@@ -84,7 +98,7 @@ export const GetMapWMS = () => {
   return wrapperEl;
 };
 
-export const GetMapWMSWithGeometry = () => {
+export const GetMapWMSWithGeometryMultiPolygon = () => {
   const img = document.createElement('img');
   img.width = '512';
   img.height = '512';
@@ -101,7 +115,7 @@ export const GetMapWMSWithGeometry = () => {
       bbox: bbox4326,
       fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
       toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
-      geometry: geometry,
+      geometry: geometryMultiPolygon,
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
@@ -165,7 +179,7 @@ export const GetMapProcessing = () => {
   return wrapperEl;
 };
 
-export const GetMapProcessingWithGeometry = () => {
+export const GetMapProcessingWithGeometryPolygon = () => {
   if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
     return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
   }
@@ -204,7 +218,7 @@ export const GetMapProcessingWithGeometry = () => {
       bbox: bbox4326,
       fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
       toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
-      geometry: geometry,
+      geometry: geometryPolygon,
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,


### PR DESCRIPTION
WMS service expects `geometry` as WKT, while Processing API expects GeoJSON. This PR settles on GeoJSON for internal representation and:
- fixes `legacy*` to convert from WKT (input) to GeoJSON (internal representation)
- fixes WMS to convert from GeoJSON (internal) to WKT (output)
- fixes Processing to pass GeoJSON as `geometry` param.