### PR TITLE
Update all known dataset's min/max dates

### DIFF
--- a/example/node/.gitignore
+++ b/example/node/.gitignore
@@ -1,0 +1,1 @@
+image.jpeg

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -181,12 +181,10 @@ async function run() {
   const imageUrl2 = layerS2L2AWithEvalscript.getMapUrl(getMapParams, ApiType.WMS);
   printOut('URL of S2 L2A image with evalscript:', imageUrl2);
 
-  // this doesn't work because node.js doesn't support Blob:
-  // const fs = require('fs');
-  // const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
-  // fs.writeFileSync('/tmp/imagewms.jpeg', Buffer.from(new Uint8Array(imageBlob)));
-  // const imageBlob2 = await layer.getMap(getMapParams, API_PROCESSING);
-  // fs.writeFileSync('/tmp/imageprocessing.jpeg', Buffer.from(new Uint8Array(imageBlob)));
+  // write the satellite image to JPG file:
+  const fs = require('fs');
+  const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
+  fs.writeFileSync('./image.jpeg', imageBlob, { encoding: null });
 }
 
 run()

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -27,7 +27,11 @@ export class AbstractLayer {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
-        const requestConfig: AxiosRequestConfig = { responseType: 'blob', useCache: true };
+        const requestConfig: AxiosRequestConfig = {
+          // 'blob' responseType does not work with Node.js:
+          responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
+          useCache: true,
+        };
         const response = await axios.get(url, requestConfig);
         return response.data;
       default:

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -75,7 +75,7 @@ test('WmsLayer.getMap makes an appropriate request', () => {
     height: '512',
   });
   expect(axiosParams).toEqual({
-    responseType: 'blob',
+    responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     useCache: true,
   });
 });

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -64,7 +64,7 @@ export const DATASET_S2L1C: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/findAvailableData',
   orbitTimeMinutes: 50.3,
-  minDate: new Date(Date.UTC(2015, 6 - 1, 27, 0, 25, 31)), // 2015-06-27T10:25:31Z
+  minDate: new Date(Date.UTC(2015, 6 - 1, 27, 10, 25, 31)), // 2015-06-27T10:25:31Z
   maxDate: null,
 };
 

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -22,7 +22,7 @@ export const DATASET_AWSEU_S1GRD: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/findAvailableData',
   orbitTimeMinutes: 49.3,
-  minDate: new Date(Date.UTC(2017, 1 - 1, 1, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2014, 12 - 1, 7, 4, 14, 15)), // 2014-12-07T04:14:15Z
   maxDate: null,
 };
 
@@ -36,7 +36,7 @@ export const DATASET_EOCLOUD_S1GRD: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/finddates',
   orbitTimeMinutes: 49.3,
-  minDate: new Date(Date.UTC(2014, 10 - 1, 3, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2014, 10 - 1, 3, 10, 10, 18)), // 2014-10-03T10:10:18.000s
   maxDate: null,
 };
 
@@ -50,7 +50,7 @@ export const DATASET_S2L2A: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/findAvailableData',
   orbitTimeMinutes: 50.3,
-  minDate: new Date(Date.UTC(2017, 3 - 1, 28, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2016, 10 - 1, 20, 8, 9, 58)), // 2016-10-20T08:09:58Z
   maxDate: null,
 };
 
@@ -64,7 +64,7 @@ export const DATASET_S2L1C: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/findAvailableData',
   orbitTimeMinutes: 50.3,
-  minDate: new Date(Date.UTC(2015, 6 - 1, 17, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2015, 6 - 1, 27, 0, 25, 31)), // 2015-06-27T10:25:31Z
   maxDate: null,
 };
 
@@ -78,7 +78,7 @@ export const DATASET_S3SLSTR: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/findAvailableData',
   orbitTimeMinutes: 50.495,
-  minDate: new Date(Date.UTC(2016, 4 - 1, 1, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2016, 4 - 1, 19, 0, 46, 32)), // 2016-04-19T00:46:32.578Z
   maxDate: null,
 };
 
@@ -92,7 +92,7 @@ export const DATASET_S3OLCI: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/findAvailableData',
   orbitTimeMinutes: 50.495,
-  minDate: new Date(Date.UTC(2016, 2 - 1, 1, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2016, 4 - 1, 25, 11, 33, 14)), // 2016-04-25T11:33:14Z
   maxDate: null,
 };
 
@@ -106,7 +106,7 @@ export const DATASET_S5PL2: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/findAvailableData',
   orbitTimeMinutes: 101,
-  minDate: new Date(Date.UTC(2017, 10 - 1, 13, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2018, 4 - 1, 30, 0, 18, 51)), // 2018-04-30T00:18:51Z
   maxDate: null,
 };
 
@@ -120,7 +120,7 @@ export const DATASET_AWS_L8L1C: Dataset = {
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/searchIndex',
   findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/findAvailableData',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2013, 2 - 1, 1, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2013, 3 - 1, 19, 3, 30, 14)), // 2013-03-19T03:30:14.095Z
   maxDate: null,
 };
 
@@ -134,8 +134,8 @@ export const DATASET_EOCLOUD_LANDSAT5: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(1984, 1 - 1, 1, 0, 0, 0)),
-  maxDate: new Date(Date.UTC(2013, 5 - 1, 1, 23, 59, 59)),
+  minDate: new Date(Date.UTC(1990, 4 - 1, 3, 9, 29, 21)), // 1990-04-03T09:29:21.808
+  maxDate: new Date(Date.UTC(2011, 11 - 1, 16, 10, 2, 33)), // 2011-11-16T10:02:32.340
 };
 
 export const DATASET_EOCLOUD_LANDSAT7: Dataset = {
@@ -148,8 +148,8 @@ export const DATASET_EOCLOUD_LANDSAT7: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(1999, 1 - 1, 1, 0, 0, 0)),
-  maxDate: new Date(Date.UTC(2003, 12 - 1, 1, 23, 59, 59)),
+  minDate: new Date(Date.UTC(1999, 7 - 1, 9, 10, 10, 28)), // 1999-07-09T10:10:28.737
+  maxDate: new Date(Date.UTC(2017, 1 - 1, 8, 3, 47, 23)), // 2017-01-08T03:47:22.049Z,
 };
 
 export const DATASET_EOCLOUD_LANDSAT8: Dataset = {
@@ -162,7 +162,7 @@ export const DATASET_EOCLOUD_LANDSAT8: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2013, 1 - 1, 1, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2013, 4 - 1, 1, 3, 48, 51)), // 2013-04-01T03:48:51.190
   maxDate: null,
 };
 
@@ -176,8 +176,8 @@ export const DATASET_EOCLOUD_ENVISAT_MERIS: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/finddates',
   orbitTimeMinutes: 100.16,
-  minDate: new Date(Date.UTC(2002, 1 - 1, 1, 0, 0, 0)),
-  maxDate: new Date(Date.UTC(2012, 5 - 1, 1, 23, 59, 59)),
+  minDate: new Date(Date.UTC(2002, 5 - 1, 20, 10, 26, 26)), // 2002-05-20T10:26:26.497
+  maxDate: new Date(Date.UTC(2012, 4 - 1, 8, 10, 58, 58)), // 2012-04-08T10:58:57.237
 };
 
 export const DATASET_MODIS: Dataset = {
@@ -190,7 +190,7 @@ export const DATASET_MODIS: Dataset = {
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/searchIndex',
   findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/findAvailableData',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2000, 2 - 1, 24, 0, 0, 0)),
+  minDate: new Date(Date.UTC(2000, 2 - 1, 24, 12, 0, 0)), // 2000-02-24T12:00:00Z
   maxDate: null,
 };
 

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -22,7 +22,7 @@ export const DATASET_AWSEU_S1GRD: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S1GRD/findAvailableData',
   orbitTimeMinutes: 49.3,
-  minDate: new Date(Date.UTC(2014, 12 - 1, 7, 4, 14, 15)), // 2014-12-07T04:14:15Z
+  minDate: new Date(Date.UTC(2014, 12 - 1, 7, 4, 14, 15)), // 2014-12-07T04:14:15
   maxDate: null,
 };
 
@@ -36,7 +36,7 @@ export const DATASET_EOCLOUD_S1GRD: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/s1/v1/finddates',
   orbitTimeMinutes: 49.3,
-  minDate: new Date(Date.UTC(2014, 10 - 1, 3, 10, 10, 18)), // 2014-10-03T10:10:18.000s
+  minDate: new Date(Date.UTC(2014, 10 - 1, 3, 4, 5, 50)), // 2014-10-03T04:05:50.000
   maxDate: null,
 };
 
@@ -50,7 +50,7 @@ export const DATASET_S2L2A: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/findAvailableData',
   orbitTimeMinutes: 50.3,
-  minDate: new Date(Date.UTC(2016, 10 - 1, 20, 8, 9, 58)), // 2016-10-20T08:09:58Z
+  minDate: new Date(Date.UTC(2016, 10 - 1, 20, 8, 9, 58)), // 2016-10-20T08:09:58
   maxDate: null,
 };
 
@@ -64,7 +64,7 @@ export const DATASET_S2L1C: Dataset = {
   searchIndexUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex',
   findDatesUTCUrl: 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/findAvailableData',
   orbitTimeMinutes: 50.3,
-  minDate: new Date(Date.UTC(2015, 6 - 1, 27, 10, 25, 31)), // 2015-06-27T10:25:31Z
+  minDate: new Date(Date.UTC(2015, 6 - 1, 27, 10, 25, 31)), // 2015-06-27T10:25:31
   maxDate: null,
 };
 
@@ -78,7 +78,7 @@ export const DATASET_S3SLSTR: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/findAvailableData',
   orbitTimeMinutes: 50.495,
-  minDate: new Date(Date.UTC(2016, 4 - 1, 19, 0, 46, 32)), // 2016-04-19T00:46:32.578Z
+  minDate: new Date(Date.UTC(2016, 4 - 1, 19, 0, 46, 32)), // 2016-04-19T00:46:32.578
   maxDate: null,
 };
 
@@ -92,7 +92,7 @@ export const DATASET_S3OLCI: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/findAvailableData',
   orbitTimeMinutes: 50.495,
-  minDate: new Date(Date.UTC(2016, 4 - 1, 25, 11, 33, 14)), // 2016-04-25T11:33:14Z
+  minDate: new Date(Date.UTC(2016, 4 - 1, 25, 11, 33, 14)), // 2016-04-25T11:33:14
   maxDate: null,
 };
 
@@ -106,7 +106,7 @@ export const DATASET_S5PL2: Dataset = {
   searchIndexUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/searchIndex',
   findDatesUTCUrl: 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/findAvailableData',
   orbitTimeMinutes: 101,
-  minDate: new Date(Date.UTC(2018, 4 - 1, 30, 0, 18, 51)), // 2018-04-30T00:18:51Z
+  minDate: new Date(Date.UTC(2018, 4 - 1, 30, 0, 18, 51)), // 2018-04-30T00:18:51
   maxDate: null,
 };
 
@@ -120,7 +120,7 @@ export const DATASET_AWS_L8L1C: Dataset = {
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/searchIndex',
   findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/findAvailableData',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2013, 3 - 1, 19, 3, 30, 14)), // 2013-03-19T03:30:14.095Z
+  minDate: new Date(Date.UTC(2013, 3 - 1, 18, 15, 59, 2)), // 2013-03-18T15:59:02.334
   maxDate: null,
 };
 
@@ -134,7 +134,7 @@ export const DATASET_EOCLOUD_LANDSAT5: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat5/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(1990, 4 - 1, 3, 9, 29, 21)), // 1990-04-03T09:29:21.808
+  minDate: new Date(Date.UTC(1984, 4 - 1, 6, 7, 45, 13)), // 1984-04-06T07:45:13.428
   maxDate: new Date(Date.UTC(2011, 11 - 1, 16, 10, 2, 33)), // 2011-11-16T10:02:32.340
 };
 
@@ -148,8 +148,8 @@ export const DATASET_EOCLOUD_LANDSAT7: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(1999, 7 - 1, 9, 10, 10, 28)), // 1999-07-09T10:10:28.737
-  maxDate: new Date(Date.UTC(2017, 1 - 1, 8, 3, 47, 23)), // 2017-01-08T03:47:22.049Z,
+  minDate: new Date(Date.UTC(1999, 7 - 1, 3, 19, 16, 17)), // 1999-07-03T19:16:17.163
+  maxDate: new Date(Date.UTC(2017, 1 - 1, 15, 23, 49, 14)), // 2017-01-15T23:49:14.495
 };
 
 export const DATASET_EOCLOUD_LANDSAT8: Dataset = {
@@ -162,7 +162,7 @@ export const DATASET_EOCLOUD_LANDSAT8: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat8/v2/dates',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2013, 4 - 1, 1, 3, 48, 51)), // 2013-04-01T03:48:51.190
+  minDate: new Date(Date.UTC(2013, 3 - 1, 24, 0, 25, 55)), // 2013-03-24T00:25:55.457
   maxDate: null,
 };
 
@@ -176,7 +176,7 @@ export const DATASET_EOCLOUD_ENVISAT_MERIS: Dataset = {
   searchIndexUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/search',
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/envisat/v1/finddates',
   orbitTimeMinutes: 100.16,
-  minDate: new Date(Date.UTC(2002, 5 - 1, 20, 10, 26, 26)), // 2002-05-20T10:26:26.497
+  minDate: new Date(Date.UTC(2002, 5 - 1, 17, 14, 0, 27)), // 2002-05-17T14:00:27.893
   maxDate: new Date(Date.UTC(2012, 4 - 1, 8, 10, 58, 58)), // 2012-04-08T10:58:57.237
 };
 
@@ -190,7 +190,7 @@ export const DATASET_MODIS: Dataset = {
   searchIndexUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/searchIndex',
   findDatesUTCUrl: 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/findAvailableData',
   orbitTimeMinutes: 99,
-  minDate: new Date(Date.UTC(2000, 2 - 1, 24, 12, 0, 0)), // 2000-02-24T12:00:00Z
+  minDate: new Date(Date.UTC(2000, 2 - 1, 24, 12, 0, 0)), // 2000-02-24T12:00:00
   maxDate: null,
 };
 

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -149,7 +149,7 @@ export const DATASET_EOCLOUD_LANDSAT7: Dataset = {
   findDatesUTCUrl: 'https://eocloud.sentinel-hub.com/index/landsat7/v2/dates',
   orbitTimeMinutes: 99,
   minDate: new Date(Date.UTC(1999, 7 - 1, 3, 19, 16, 17)), // 1999-07-03T19:16:17.163
-  maxDate: new Date(Date.UTC(2017, 1 - 1, 15, 23, 49, 14)), // 2017-01-15T23:49:14.495
+  maxDate: new Date(Date.UTC(2017, 1 - 1, 15, 23, 49, 15)), // 2017-01-15T23:49:14.495
 };
 
 export const DATASET_EOCLOUD_LANDSAT8: Dataset = {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -168,7 +168,8 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
       'Content-Type': 'application/json',
       Accept: '*/*',
     },
-    responseType: 'blob',
+    // 'blob' responseType does not work with Node.js:
+    responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     useCache: true,
   };
   const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -116,12 +116,16 @@ const fetchCachedResponse = async (request: any): Promise<any> => {
 
   // serve from cache:
   request.adapter = async () => {
-    // when we get data from cache, we want to return it in the same form as the original axios request
-    // (without cache) would, so we convert it appropriately:
+    // when we get data (Response) from cache (Cache API), we want to return it in the
+    // same form as the original axios request (without cache) would, so we convert it
+    // appropriately:
     let responseData;
     switch (request.responseType) {
       case 'blob':
         responseData = await cachedResponse.blob();
+        break;
+      case 'arraybuffer':
+        responseData = await cachedResponse.arrayBuffer();
         break;
       case 'text':
         responseData = await cachedResponse.text();
@@ -180,8 +184,9 @@ const saveCacheResponse = async (response: any): Promise<any> => {
   let responseData;
   switch (request.responseType) {
     case 'blob':
+    case 'arraybuffer':
     case 'text':
-      // usual response types are strings, so we can save them as they are:
+      // we can save usual responses as they are:
       responseData = response.data;
       break;
     case 'json':


### PR DESCRIPTION
Process: I wrote a small script that searched for the most recent tile for each layer (anywhere), displaying the `curl` command in the process, then I manually modified the `curl` command to display the oldest / newest known tile. I also removed any unnecessary parameters (such as `productType` for S-5).

Script is:
```
  await setAuthTokenWithOAuthCredentials();
  setDebugEnabled(true);

  const layer = new S5PL2Layer({ evalscript: '', productType: 'CH4' });
  // const layer = new S2L2ALayer({ evalscript: '' });
  // const layer = new S2L1CLayer({ evalscript: '' });
  // const layer = new S3SLSTRLayer({ evalscript: '' });
  // const layer = new S3OLCILayer({ evalscript: '' });
  // const layer = new S5PL2Layer({ evalscript: '' });
  // const layer = new DEMLayer({ evalscript: '' });
  // const layer = new Landsat8AWSLayer({ evalscript: '' });  
  // const layer = new MODISLayer({ evalscript: '' });
  // const layer = new S1GRDEOCloudLayer({ evalscript: '', acquisitionMode: 'IW', polarization: 'DV', orbitDirection: 'ASCENDING' });
  // const layer = new S1GRDAWSEULayer({ evalscript: '', acquisitionMode: 'IW', polarization: 'DV', resolution: 'HIGH' });
  // const layer = new EnvisatMerisEOCloudLayer({ instanceId: 'asdf', layerId: 'asdf' });
  // const layer = new Landsat5EOCloudLayer({ evalscript: '' });
  // const layer = new Landsat7EOCloudLayer({ evalscript: '' });
  // const layer = new Landsat8EOCloudLayer({ evalscript: '' });

  const bbox = new BBox(CRS_EPSG4326, 0, 0, 180, 90);
  const now = moment.utc().toDate();
  const toTime = now;
  const fromTime = moment
    .utc(toTime)
    .subtract(40, 'years')
    .toDate();
  setDebugEnabled(true)
  const { tiles, hasMore } = await layer.findTiles(bbox, fromTime, toTime, 1, 0);
  console.log(tiles);
```