### PR TITLE
Return most recent results first from findDatesUTC

### DIFF
--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -115,7 +115,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     return {};
   }
 
@@ -128,7 +128,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     const params = {
       timefrom: fromTime.toISOString(),
       timeto: toTime.toISOString(),
-      ...this.getFindDatesUTCAdditionalParameters(),
+      ...(await this.getFindDatesUTCAdditionalParameters()),
     };
 
     const url = `${this.dataset.findDatesUTCUrl}?${stringify(params, { sort: false })}`;

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -45,7 +45,7 @@ export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1O
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     return {
       maxcc: this.maxCloudCoverPercent / 100,
     };

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -235,11 +235,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     const found: Moment[] = response.data.map((date: string) => moment.utc(date));
 
-    if (found.length > 1) {
-      // S-5P, S-3 and possibly other datasets return the results in reverse order (leastRecent).
-      // Let's sort the data so that we always return most recent results first:
-      found.sort((a, b) => b.unix() - a.unix());
-    }
+    // S-5P, S-3 and possibly other datasets return the results in reverse order (leastRecent).
+    // Let's sort the data so that we always return most recent results first:
+    found.sort((a, b) => b.unix() - a.unix());
     return found.map(m => m.toDate());
   }
 }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -216,7 +216,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return axios.post(this.dataset.searchIndexUrl, payload, this.createSearchIndexRequestConfig());
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     return {};
   }
 
@@ -230,7 +230,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       queryArea: bboxPolygon,
       from: fromTime.toISOString(),
       to: toTime.toISOString(),
-      ...this.getFindDatesUTCAdditionalParameters(),
+      ...(await this.getFindDatesUTCAdditionalParameters()),
     };
     const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
     const found: Moment[] = response.data.map((date: string) => moment.utc(date));

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -233,6 +233,16 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       ...this.getFindDatesUTCAdditionalParameters(),
     };
     const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
-    return response.data.map((date: string) => moment.utc(date).toDate());
+    const result = response.data.map((date: string) => moment.utc(date).toDate());
+
+    // S-5P, S-3 and possibly other datasets return the results in reverse order (leastRecent).
+    // Let's reverse it so that we return most recent results first:
+    if (result.length <= 1) {
+      return result;
+    }
+    if (moment.utc(result[0]).isBefore(moment.utc(result[result.length - 1]))) {
+      result.reverse();
+    }
+    return result;
   }
 }

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -60,7 +60,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     return {
       maxCloudCoverage: this.maxCloudCoverPercent / 100,
     };

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig } from 'axios';
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
@@ -119,22 +119,5 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     };
 
     return result;
-  }
-
-  public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
-    if (!this.dataset.findDatesUTCUrl) {
-      throw new Error('This dataset does not support searching for dates');
-    }
-
-    const additionalFindDatesUTCParameters = await this.getFindDatesUTCAdditionalParameters();
-    const bboxPolygon = bbox.toGeoJSON();
-    const payload: any = {
-      queryArea: bboxPolygon,
-      from: fromTime.toISOString(),
-      to: toTime.toISOString(),
-      ...additionalFindDatesUTCParameters,
-    };
-    const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
-    return response.data.map((date: string) => moment.utc(date).toDate());
   }
 }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -161,7 +161,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -118,7 +118,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     return result;
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -100,7 +100,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -112,7 +112,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected getFindDatesUTCAdditionalParameters(): Record<string, any> {
+  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 
 import { BBox } from 'src/bbox';
 import { GetMapParams, ApiType } from 'src/layer/const';
@@ -82,8 +82,10 @@ export class WmsLayer extends AbstractLayer {
       }
     }
 
-    return allTimesMomentUTC
-      .filter(t => t.isBetween(moment.utc(fromTime), moment.utc(toTime), null, '[]'))
-      .map(t => t.toDate());
+    const found: Moment[] = allTimesMomentUTC.filter(t =>
+      t.isBetween(moment.utc(fromTime), moment.utc(toTime), null, '[]'),
+    );
+    found.sort((a, b) => b.unix() - a.unix());
+    return found.map(m => m.toDate());
   }
 }


### PR DESCRIPTION
Service `findAvailableDates` is not consistent in the order in which the results are returned, so we check and reverse them if needed (we assume that the order is either `leastRecent` or `mostRecent`, not random).