### PR TITLE
Fix README - add await to LayersFactory.makeLayers() examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It is also possible to create layers by importing their definitions from the Sen
 ```javascript
   import { LayersFactory } from '@sentinel-hub/sentinelhub-js';
 
-  const layers = LayersFactory.makeLayers('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>');
+  const layers = await LayersFactory.makeLayers('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>');
     // [ layer1, layer2, ... ] - a list of Layer objects
 
   const layersIds = layers.map(l => l.layerId);
@@ -95,7 +95,7 @@ Alternatively, the list can be filtered to include only some of the layers:
   import { LayersFactory, DATASET_S2L2A } from '@sentinel-hub/sentinelhub-js';
 
   // this will return only a list of those S2L2A layers whose IDs start with "ABC_":
-  const layers = LayersFactory.makeLayers(
+  const layers = await LayersFactory.makeLayers(
     'https://services.sentinel-hub.com/ogc/wms/<your-instance-id>',
     (layerId, dataset) => layerId.startsWith("ABC_") && dataset === DATASET_S2L2A,
   );
@@ -194,9 +194,9 @@ The histogram uses the `equalfrequency` binning method and defaults to 5 bins.
   });
 
 const stats = await layerS2L2A.getStats({
-  geometry: geometry, 
-  fromTime: fromTime, 
-  toTime: toTime, 
+  geometry: geometry,
+  fromTime: fromTime,
+  toTime: toTime,
   resolution: resolution,
   bins: 10,
 });


### PR DESCRIPTION
The examples for `LayersFactory.makeLayers()` in README were missing `await`.