### PR TITLE
fixed retries setting on axios interceptors

### DIFF
--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -206,8 +206,8 @@ const retryRequests = (err: any): any => {
   }
   if (shouldRetry(err.response.status)) {
     err.config.retriesCount = err.config.retriesCount | 0;
-    const minRetries = err.config.retries || RETRIES;
-    const shouldRetry = err.config.retriesCount < minRetries;
+    const maxRetries = err.config.retries || RETRIES;
+    const shouldRetry = err.config.retriesCount < maxRetries;
     if (shouldRetry) {
       err.config.retriesCount += 1;
       return new Promise(resolve => setTimeout(() => resolve(axios(err.config)), DELAY));

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -206,7 +206,8 @@ const retryRequests = (err: any): any => {
   }
   if (shouldRetry(err.response.status)) {
     err.config.retriesCount = err.config.retriesCount | 0;
-    const shouldRetry = err.config.retriesCount < RETRIES;
+    const minRetries = err.config.retries || RETRIES;
+    const shouldRetry = err.config.retriesCount < minRetries;    
     if (shouldRetry) {
       err.config.retriesCount += 1;
       return new Promise(resolve => setTimeout(() => resolve(axios(err.config)), DELAY));

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -207,7 +207,7 @@ const retryRequests = (err: any): any => {
   if (shouldRetry(err.response.status)) {
     err.config.retriesCount = err.config.retriesCount | 0;
     const minRetries = err.config.retries || RETRIES;
-    const shouldRetry = err.config.retriesCount < minRetries;    
+    const shouldRetry = err.config.retriesCount < minRetries;
     if (shouldRetry) {
       err.config.retriesCount += 1;
       return new Promise(resolve => setTimeout(() => resolve(axios(err.config)), DELAY));


### PR DESCRIPTION
Now retries can be passed as a config parameter on the request in order to specify the amount of retries that it should try.
