### PR TITLE
Expose parseLegacyWmsGetMapParams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,12 @@ import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
 import { BYOCLayer } from 'src/layer/BYOCLayer';
 import { ProcessingDataFusionLayer } from 'src/layer/ProcessingDataFusionLayer';
 
-import { legacyGetMapFromUrl, legacyGetMapWmsUrlFromParams, legacyGetMapFromParams } from 'src/legacyCompat';
+import {
+  legacyGetMapFromUrl,
+  legacyGetMapWmsUrlFromParams,
+  legacyGetMapFromParams,
+  parseLegacyWmsGetMapParams,
+} from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 
@@ -104,4 +109,5 @@ export {
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,
   legacyGetMapFromParams,
+  parseLegacyWmsGetMapParams,
 };

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -125,7 +125,7 @@ type ParsedLegacyWmsGetMapParams = {
   getMapParams: GetMapParams;
 };
 
-function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegacyWmsGetMapParams {
+export function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): ParsedLegacyWmsGetMapParams {
   const params = convertKeysToLowercase(wmsParams);
 
   const layers = params.layers;


### PR DESCRIPTION
When doing data fusion, we don't want to call legacy functions because they do not support it. However we might still have original data in form of legacy GetMap parameters. Exposing `parseLegacyWmsGetMapParams` via export allow us to parse these parameters and use them to manually construct appropriate layers.