### PR TITLE
Add support for mosaickingOrder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes, OrbitDirection, PreviewMode } from 'src/layer/const';
+import { ApiType, MimeTypes, OrbitDirection, PreviewMode, MosaickingOrder } from 'src/layer/const';
 import { setDebugEnabled } from 'src/utils/debug';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
@@ -102,6 +102,7 @@ export {
   Resolution,
   OrbitDirection,
   PreviewMode,
+  MosaickingOrder,
   S3SLSTRView,
   BBox,
   setDebugEnabled,

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -12,6 +12,7 @@ import {
   GetStats,
   HistogramType,
   FisPayload,
+  MosaickingOrder,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
@@ -22,6 +23,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
+  mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
 }
@@ -32,12 +34,14 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   protected layerId: string;
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
+  protected mosaickingOrder: MosaickingOrder | null;
 
   public constructor({
     instanceId = null,
     layerId = null,
     evalscript = null,
     evalscriptUrl = null,
+    mosaickingOrder = null,
     title = null,
     description = null,
   }: ConstructorParameters) {
@@ -49,6 +53,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     this.layerId = layerId;
     this.evalscript = evalscript;
     this.evalscriptUrl = evalscriptUrl;
+    this.mosaickingOrder = mosaickingOrder;
   }
 
   protected getEvalsource(): string {
@@ -58,6 +63,11 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    if (this.mosaickingOrder) {
+      return {
+        priority: this.mosaickingOrder,
+      };
+    }
     return {};
   }
 

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,3 +1,4 @@
+import { MosaickingOrder } from 'src/layer/const';
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 
 interface ConstructorParameters {
@@ -8,27 +9,21 @@ interface ConstructorParameters {
   title?: string | null;
   description?: string | null;
   maxCloudCoverPercent?: number | null;
+  mosaickingOrder?: MosaickingOrder | null;
 }
 
 // same as AbstractSentinelHubV1OrV2Layer, but with maxCloudCoverPercent (useful for Landsat datasets)
 export class AbstractSentinelHubV1OrV2WithCCLayer extends AbstractSentinelHubV1OrV2Layer {
   public maxCloudCoverPercent: number;
 
-  public constructor({
-    instanceId = null,
-    layerId = null,
-    evalscript = null,
-    evalscriptUrl = null,
-    title = null,
-    description = null,
-    maxCloudCoverPercent = 100,
-  }: ConstructorParameters) {
-    super({ instanceId, layerId, evalscript, evalscriptUrl, title, description });
+  public constructor({ maxCloudCoverPercent = 100, ...rest }: ConstructorParameters) {
+    super(rest);
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
     return {
+      ...super.getWmsGetMapUrlAdditionalParameters(),
       maxcc: this.maxCloudCoverPercent,
     };
   }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -10,6 +10,7 @@ import {
   PaginatedTiles,
   HistogramType,
   FisPayload,
+  MosaickingOrder,
   GetStatsParams,
   GetStats,
 } from 'src/layer/const';
@@ -24,6 +25,7 @@ interface ConstructorParameters {
   evalscript?: string | null;
   evalscriptUrl?: string | null;
   dataProduct?: string | null;
+  mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
 }
@@ -35,6 +37,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
   protected dataProduct: string | null;
+  public mosaickingOrder: MosaickingOrder | null; // public because ProcessingDataFusionLayer needs to read it directly
 
   public constructor({
     instanceId = null,
@@ -42,6 +45,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     evalscript = null,
     evalscriptUrl = null,
     dataProduct = null,
+    mosaickingOrder = null,
     title = null,
     description = null,
   }: ConstructorParameters) {
@@ -61,6 +65,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     this.evalscript = evalscript;
     this.evalscriptUrl = evalscriptUrl;
     this.dataProduct = dataProduct;
+    this.mosaickingOrder = mosaickingOrder;
   }
 
   protected async fetchLayerParamsFromSHServiceV3(): Promise<any> {
@@ -121,8 +126,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
         this.evalscript = evalscriptV3;
       }
+      let layerParams = null;
       if (!this.evalscript && !this.dataProduct) {
-        const layerParams = await this.fetchLayerParamsFromSHServiceV3();
+        layerParams = await this.fetchLayerParamsFromSHServiceV3();
         if (layerParams.evalscript) {
           this.evalscript = layerParams.evalscript;
         } else if (layerParams.dataProduct) {
@@ -131,8 +137,20 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
           throw new Error(`Could not fetch evalscript / dataProduct from service for layer ${this.layerId}`);
         }
       }
+      if (!this.mosaickingOrder) {
+        if (!layerParams) {
+          layerParams = await this.fetchLayerParamsFromSHServiceV3();
+        }
+        this.mosaickingOrder = layerParams.mosaickingOrder;
+      }
 
-      const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
+      const payload = createProcessingPayload(
+        this.dataset,
+        params,
+        this.evalscript,
+        this.dataProduct,
+        this.mosaickingOrder,
+      );
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
 
@@ -147,6 +165,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    if (this.mosaickingOrder) {
+      return {
+        priority: this.mosaickingOrder,
+      };
+    }
     return {};
   }
 

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -2,7 +2,8 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
-import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from 'src/layer/processing';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -30,6 +31,12 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
       ...super.getWmsGetMapUrlAdditionalParameters(),
       maxcc: this.maxCloudCoverPercent,
     };
+  }
+
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    payload = await super.updateProcessingGetMapPayload(payload);
+    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    return payload;
   }
 
   public async findTiles(

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -25,6 +25,13 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 
+  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    return {
+      ...super.getWmsGetMapUrlAdditionalParameters(),
+      maxcc: this.maxCloudCoverPercent,
+    };
+  }
+
   public async findTiles(
     bbox: BBox,
     fromTime: Date,

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
 
 interface ConstructorParameters {
@@ -10,6 +10,7 @@ interface ConstructorParameters {
   evalscript?: string | null;
   evalscriptUrl?: string | null;
   dataProduct?: string | null;
+  mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
   maxCloudCoverPercent?: number | null;
@@ -19,17 +20,8 @@ interface ConstructorParameters {
 export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer {
   public maxCloudCoverPercent: number;
 
-  public constructor({
-    instanceId = null,
-    layerId = null,
-    evalscript = null,
-    evalscriptUrl = null,
-    dataProduct = null,
-    title = null,
-    description = null,
-    maxCloudCoverPercent = 100,
-  }: ConstructorParameters) {
-    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
+  public constructor({ maxCloudCoverPercent = 100, ...rest }: ConstructorParameters) {
+    super(rest);
     this.maxCloudCoverPercent = maxCloudCoverPercent;
   }
 

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -53,7 +53,13 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
 
     // when constructing the payload, we just take the first layer - we will rewrite its info later:
     const bogusFirstLayer = this.layers[0].layer;
-    let payload = createProcessingPayload(bogusFirstLayer.dataset, params, this.evalscript);
+    let payload = createProcessingPayload(
+      bogusFirstLayer.dataset,
+      params,
+      this.evalscript,
+      null,
+      this.mosaickingOrder,
+    );
 
     // replace payload.input.data with information from this.layers:
     payload.input.data = [];
@@ -81,10 +87,8 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
         datasource.dataFilter.previewMode = convertPreviewToString(params.preview);
       }
 
-      if (layerInfo.mosaickingOrder !== undefined) {
-        datasource.dataFilter.mosaickingOrder = layerInfo.mosaickingOrder;
-      } else if (params.mosaickingOrder !== undefined) {
-        datasource.dataFilter.mosaickingOrder = params.mosaickingOrder;
+      if (layerInfo.layer.mosaickingOrder) {
+        datasource.dataFilter.mosaickingOrder = layerInfo.layer.mosaickingOrder;
       }
 
       if (layerInfo.upsampling !== undefined) {

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -1,10 +1,16 @@
 import { BBox } from 'src/bbox';
-import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles } from 'src/layer/const';
+import {
+  GetMapParams,
+  Interpolator,
+  PreviewMode,
+  ApiType,
+  PaginatedTiles,
+  MosaickingOrder,
+} from 'src/layer/const';
 import {
   createProcessingPayload,
   convertPreviewToString,
   processingGetMap,
-  MosaickingOrder,
   ProcessingPayloadDatasource,
 } from 'src/layer/processing';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -27,6 +33,7 @@ export type DataFusionLayerInfo = {
   fromTime?: Date;
   toTime?: Date;
   preview?: PreviewMode;
+  mosaickingOrder?: MosaickingOrder;
   upsampling?: Interpolator;
   downsampling?: Interpolator;
 };
@@ -72,6 +79,12 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
         datasource.dataFilter.previewMode = convertPreviewToString(layerInfo.preview);
       } else if (params.preview !== undefined) {
         datasource.dataFilter.previewMode = convertPreviewToString(params.preview);
+      }
+
+      if (layerInfo.mosaickingOrder !== undefined) {
+        datasource.dataFilter.mosaickingOrder = layerInfo.mosaickingOrder;
+      } else if (params.mosaickingOrder !== undefined) {
+        datasource.dataFilter.mosaickingOrder = params.mosaickingOrder;
       }
 
       if (layerInfo.upsampling !== undefined) {

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,7 @@ import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection } from 'src/layer/const';
+import { OrbitDirection, MosaickingOrder } from 'src/layer/const';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -13,6 +13,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
+  mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
   acquisitionMode?: AcquisitionMode | null;
@@ -32,13 +33,14 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     layerId = null,
     evalscript = null,
     evalscriptUrl = null,
+    mosaickingOrder = null,
     title = null,
     description = null,
     acquisitionMode = null,
     polarization = null,
     orbitDirection = null,
   }: ConstructorParameters) {
-    super({ instanceId, layerId, evalscript, evalscriptUrl, title, description });
+    super({ instanceId, layerId, evalscript, evalscriptUrl, mosaickingOrder, title, description });
     // it is not possible to determine these parameters by querying the service, because there
     // is no endpoint which would return them:
     if ((evalscript || evalscriptUrl) && (!acquisitionMode || !polarization)) {

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -12,6 +12,7 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
     return {
+      ...super.getWmsGetMapUrlAdditionalParameters(),
       maxcc: this.maxCloudCoverPercent,
     };
   }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -1,12 +1,6 @@
 import { DATASET_S2L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { ProcessingPayload } from 'src/layer/processing';
 
 export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;
-
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
-    return payload;
-  }
 }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -9,11 +9,4 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
   }
-
-  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
-    return {
-      ...super.getWmsGetMapUrlAdditionalParameters(),
-      maxcc: this.maxCloudCoverPercent,
-    };
-  }
 }

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -9,11 +9,4 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
   }
-
-  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
-    return {
-      ...super.getWmsGetMapUrlAdditionalParameters(),
-      maxcc: this.maxCloudCoverPercent,
-    };
-  }
 }

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -12,6 +12,7 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
     return {
+      ...super.getWmsGetMapUrlAdditionalParameters(),
       maxcc: this.maxCloudCoverPercent,
     };
   }

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -60,13 +60,6 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     return payload;
   }
 
-  protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
-    return {
-      ...super.getWmsGetMapUrlAdditionalParameters(),
-      maxcc: this.maxCloudCoverPercent,
-    };
-  }
-
   public async findTiles(
     bbox: BBox,
     fromTime: Date,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { BBox } from 'src/bbox';
 import { PaginatedTiles, OrbitDirection } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
 
 interface ConstructorParameters {
@@ -29,32 +29,20 @@ type S3SLSTRFindTilesDatasetParameters = {
   view: S3SLSTRView;
 };
 
-export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
+export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S3SLSTR;
-  public maxCloudCoverPercent: number;
   public orbitDirection: OrbitDirection | null;
   public view: S3SLSTRView;
 
-  public constructor({
-    instanceId = null,
-    layerId = null,
-    evalscript = null,
-    evalscriptUrl = null,
-    dataProduct = null,
-    title = null,
-    description = null,
-    maxCloudCoverPercent = 100,
-    view = S3SLSTRView.NADIR,
-  }: ConstructorParameters) {
-    super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
-    this.maxCloudCoverPercent = maxCloudCoverPercent;
+  public constructor({ view = S3SLSTRView.NADIR, ...rest }: ConstructorParameters) {
+    super(rest);
     // images that are not DESCENDING appear empty:
     this.orbitDirection = OrbitDirection.DESCENDING;
     this.view = view;
   }
 
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+    payload = await super.updateProcessingGetMapPayload(payload);
     payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
     payload.input.data[0].processing.view = this.view;
     return payload;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -62,6 +62,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
     return {
+      ...super.getWmsGetMapUrlAdditionalParameters(),
       maxcc: this.maxCloudCoverPercent,
     };
   }

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -19,7 +19,6 @@ export type GetMapParams = {
   height?: number;
   // optional additional parameters:
   preview?: PreviewMode;
-  mosaickingOrder?: MosaickingOrder;
   geometry?: Polygon | MultiPolygon;
   quality?: number;
   gain?: number;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -19,6 +19,7 @@ export type GetMapParams = {
   height?: number;
   // optional additional parameters:
   preview?: PreviewMode;
+  mosaickingOrder?: MosaickingOrder;
   geometry?: Polygon | MultiPolygon;
   quality?: number;
   gain?: number;
@@ -42,6 +43,12 @@ export enum PreviewMode {
   DETAIL = 0,
   PREVIEW = 1,
   EXTENDED_PREVIEW = 2,
+}
+
+export enum MosaickingOrder {
+  MOST_RECENT = 'mostRecent',
+  LEAST_RECENT = 'leastRecent',
+  LEAST_CC = 'leastCC',
 }
 
 export enum ApiType {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -2,14 +2,8 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
-import { MimeType, GetMapParams, Interpolator, PreviewMode } from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator, PreviewMode, MosaickingOrder } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-
-export enum MosaickingOrder {
-  MOST_RECENT = 'mostRecent',
-  LEAST_RECENT = 'leastRecent',
-  LEAST_CC = 'leastCC',
-}
 
 enum PreviewModeString {
   DETAIL = 'DETAIL',
@@ -142,6 +136,9 @@ export function createProcessingPayload(
 
   if (params.preview !== undefined) {
     payload.input.data[0].dataFilter.previewMode = convertPreviewToString(params.preview);
+  }
+  if (params.mosaickingOrder !== undefined) {
+    payload.input.data[0].dataFilter.mosaickingOrder = params.mosaickingOrder;
   }
 
   //dataProduct should not be set if evalscript is passed as parameter

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -85,6 +85,7 @@ export function createProcessingPayload(
   params: GetMapParams,
   evalscript: string | null = null,
   dataProduct: string | null = null,
+  mosaickingOrder: MosaickingOrder | null = null,
 ): ProcessingPayload {
   const { bbox } = params;
 
@@ -103,7 +104,7 @@ export function createProcessingPayload(
               from: params.fromTime.toISOString(),
               to: params.toTime.toISOString(),
             },
-            mosaickingOrder: MosaickingOrder.MOST_RECENT,
+            mosaickingOrder: mosaickingOrder ? mosaickingOrder : MosaickingOrder.MOST_RECENT,
           },
           processing: {},
           type: dataset.shProcessingApiDatasourceAbbreviation,
@@ -136,9 +137,6 @@ export function createProcessingPayload(
 
   if (params.preview !== undefined) {
     payload.input.data[0].dataFilter.previewMode = convertPreviewToString(params.preview);
-  }
-  if (params.mosaickingOrder !== undefined) {
-    payload.input.data[0].dataFilter.mosaickingOrder = params.mosaickingOrder;
   }
 
   //dataProduct should not be set if evalscript is passed as parameter

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -131,9 +131,6 @@ export function wmsGetMapUrl(
   if (params.preview !== undefined) {
     queryParams.preview = params.preview;
   }
-  if (params.mosaickingOrder !== undefined) {
-    queryParams.priority = params.mosaickingOrder;
-  }
   if (params.geometry) {
     queryParams.geometry = WKT.convert(params.geometry);
   }

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 import WKT from 'terraformer-wkt-parser';
 
 import { CRS_EPSG4326, CRS_IDS } from 'src/crs';
-import { GetMapParams, MimeTypes, MimeType } from 'src/layer/const';
+import { GetMapParams, MimeTypes, MimeType, MosaickingOrder } from 'src/layer/const';
 
 export enum ServiceType {
   WMS = 'WMS',
@@ -32,6 +32,7 @@ type OgcGetMapOptions = {
   evalscript?: string;
   evalscripturl?: string;
   preview?: number;
+  priority?: MosaickingOrder;
   geometry?: string;
   quality?: number;
   evalsource?: string;
@@ -129,6 +130,9 @@ export function wmsGetMapUrl(
   }
   if (params.preview !== undefined) {
     queryParams.preview = params.preview;
+  }
+  if (params.mosaickingOrder !== undefined) {
+    queryParams.priority = params.mosaickingOrder;
   }
   if (params.geometry) {
     queryParams.geometry = WKT.convert(params.geometry);

--- a/stories/datafusion.stories.js
+++ b/stories/datafusion.stories.js
@@ -54,14 +54,17 @@ export const getMapProcessing = () => {
     await setAuthTokenWithOAuthCredentials();
 
     const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2l1cLayerId });
-    const layerS2L2A = new S2L2ALayer({ instanceId, layerId: s2l2aLayerId });
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId: s2l2aLayerId,
+      mosaickingOrder: MosaickingOrder.LEAST_RECENT,
+    });
     const layers = [
       {
         layer: layerS2L2A,
         id: 'l2a',
         fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 26, 0, 0, 0)),
-        mosaickingOrder: MosaickingOrder.LEAST_RECENT,
       },
       {
         layer: layerS2L1C,
@@ -77,7 +80,7 @@ export const getMapProcessing = () => {
         var setup = () => ({
           input: [
             {datasource: "l2a", bands:["B02", "B03", "B04"], units: "REFLECTANCE", mosaicking: "ORBIT"},
-            {datasource: "l1c", bands:["B02", "B03", "B04"], units:"REFLECTANCE"}],
+            {datasource: "l1c", bands:["B02", "B03", "B04"], units: "REFLECTANCE"}],
           output: [
             {id: "default", bands: 3, sampleType: SampleType.AUTO}
           ]
@@ -102,7 +105,6 @@ export const getMapProcessing = () => {
       width: 300,
       height: 300,
       format: MimeTypes.JPEG,
-      mosaickingOrder: MosaickingOrder.LEAST_CC,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/datafusion.stories.js
+++ b/stories/datafusion.stories.js
@@ -8,6 +8,7 @@ import {
   ApiType,
   S2L1CLayer,
   S2L2ALayer,
+  MosaickingOrder,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -60,6 +61,7 @@ export const getMapProcessing = () => {
         id: 'l2a',
         fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 26, 0, 0, 0)),
+        mosaickingOrder: MosaickingOrder.LEAST_RECENT,
       },
       {
         layer: layerS2L1C,
@@ -100,6 +102,7 @@ export const getMapProcessing = () => {
       width: 300,
       height: 300,
       format: MimeTypes.JPEG,
+      mosaickingOrder: MosaickingOrder.LEAST_CC,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -297,20 +297,25 @@ export const S2FindFlyovers = () => {
 
 export const MosaickingOrderWMS = () => {
   const img1 = document.createElement('img');
-  img1.width = '512';
-  img1.height = '512';
+  img1.width = '256';
+  img1.height = '256';
   const img2 = document.createElement('img');
-  img2.width = '512';
-  img2.height = '512';
+  img2.width = '256';
+  img2.height = '256';
   const img3 = document.createElement('img');
-  img3.width = '512';
-  img3.height = '512';
+  img3.width = '256';
+  img3.height = '256';
+  const img4 = document.createElement('img');
+  img4.width = '256';
+  img4.height = '256';
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>WMS mosaicking order - mostRecent, leastRecent and leastCC</h2>';
+  wrapperEl.innerHTML =
+    '<h2>WMS mosaicking order - default from instance, mostRecent, leastRecent and leastCC</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img1);
   wrapperEl.insertAdjacentElement('beforeend', img2);
   wrapperEl.insertAdjacentElement('beforeend', img3);
+  wrapperEl.insertAdjacentElement('beforeend', img4);
 
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
@@ -324,16 +329,17 @@ export const MosaickingOrderWMS = () => {
       bbox: bbox4326,
       fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
       toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
-      width: 512,
-      height: 512,
+      width: 256,
+      height: 256,
       format: MimeTypes.JPEG,
     };
-    getMapParams.mosaickingOrder = MosaickingOrder.MOST_RECENT;
     img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
-    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+    layerS2L2A.mosaickingOrder = MosaickingOrder.MOST_RECENT;
     img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
-    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
     img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    img4.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
   };
   perform().then(() => {});
 
@@ -346,20 +352,25 @@ export const MosaickingOrderProcessing = () => {
   }
 
   const img1 = document.createElement('img');
-  img1.width = '512';
-  img1.height = '512';
+  img1.width = '256';
+  img1.height = '256';
   const img2 = document.createElement('img');
-  img2.width = '512';
-  img2.height = '512';
+  img2.width = '256';
+  img2.height = '256';
   const img3 = document.createElement('img');
-  img3.width = '512';
-  img3.height = '512';
+  img3.width = '256';
+  img3.height = '256';
+  const img4 = document.createElement('img');
+  img4.width = '256';
+  img4.height = '256';
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>Processing mosaicking order - mostRecent, leastRecent and leastCC</h2>';
+  wrapperEl.innerHTML =
+    '<h2>Processing mosaicking order - default from instance, mostRecent, leastRecent and leastCC</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img1);
   wrapperEl.insertAdjacentElement('beforeend', img2);
   wrapperEl.insertAdjacentElement('beforeend', img3);
+  wrapperEl.insertAdjacentElement('beforeend', img4);
 
   // getMap is async:
   const perform = async () => {
@@ -374,16 +385,17 @@ export const MosaickingOrderProcessing = () => {
       bbox: bbox4326,
       fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
       toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
-      width: 512,
-      height: 512,
+      width: 256,
+      height: 256,
       format: MimeTypes.JPEG,
     };
-    getMapParams.mosaickingOrder = MosaickingOrder.MOST_RECENT;
     img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
-    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+    layerS2L2A.mosaickingOrder = MosaickingOrder.MOST_RECENT;
     img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
-    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
     img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    img4.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
   };
   perform().then(() => {});
 

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -8,6 +8,7 @@ import {
   BBox,
   MimeTypes,
   ApiType,
+  MosaickingOrder,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -288,6 +289,101 @@ export const S2FindFlyovers = () => {
     };
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const MosaickingOrderWMS = () => {
+  const img1 = document.createElement('img');
+  img1.width = '512';
+  img1.height = '512';
+  const img2 = document.createElement('img');
+  img2.width = '512';
+  img2.height = '512';
+  const img3 = document.createElement('img');
+  img3.width = '512';
+  img3.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS mosaicking order - mostRecent, leastRecent and leastCC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img1);
+  wrapperEl.insertAdjacentElement('beforeend', img2);
+  wrapperEl.insertAdjacentElement('beforeend', img3);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId: s2l2aLayerId,
+      evalscript: 'return [2.5 * B04, 2.5 * B03, 2.5 * B02]',
+    });
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    getMapParams.mosaickingOrder = MosaickingOrder.MOST_RECENT;
+    img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+    img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const MosaickingOrderProcessing = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+
+  const img1 = document.createElement('img');
+  img1.width = '512';
+  img1.height = '512';
+  const img2 = document.createElement('img');
+  img2.width = '512';
+  img2.height = '512';
+  const img3 = document.createElement('img');
+  img3.width = '512';
+  img3.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>Processing mosaicking order - mostRecent, leastRecent and leastCC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img1);
+  wrapperEl.insertAdjacentElement('beforeend', img2);
+  wrapperEl.insertAdjacentElement('beforeend', img3);
+
+  // getMap is async:
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId: s2l2aLayerId,
+      evalscript: 'return [2.5 * B04, 2.5 * B03, 2.5 * B02]',
+    });
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    getMapParams.mosaickingOrder = MosaickingOrder.MOST_RECENT;
+    img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+    img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    getMapParams.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
   };
   perform().then(() => {});
 


### PR DESCRIPTION
This PR adds support for `mosaickingOrder` (`mostRecent`, `leastRecent` or `leastCC`) to both Processing API and WMS requests.