### PR TITLE
Add LayersFactory.makeLayer() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ It is also possible to create layers by importing their definitions from the Sen
 
 Depending on `baseUrl`, method `makeLayers()` tries to determine if a specific `Layer` subclass would be better suited and instantiates it with all applicable parameters.
 
-Alternatively, the list can be filtered to include only some of the layers:
+The list can be filtered to include only some of the layers:
 ```javascript
   import { LayersFactory, DATASET_S2L2A } from '@sentinel-hub/sentinelhub-js';
 
@@ -99,6 +99,13 @@ Alternatively, the list can be filtered to include only some of the layers:
     'https://services.sentinel-hub.com/ogc/wms/<your-instance-id>',
     (layerId, dataset) => layerId.startsWith("ABC_") && dataset === DATASET_S2L2A,
   );
+```
+
+Alternatively, we can also fetch a single layer by using `makeLayer` method:
+```
+  import { LayersFactory } from '@sentinel-hub/sentinelhub-js';
+
+  const layer = await LayersFactory.makeLayer('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', '<layer-id>');
 ```
 
 Some information about the layer is only accessible to authenticated users. In case of Playground and EO Browser, ReCaptcha auth token is sufficient to fetch layer information (such as evalscript / dataProduct). To avoid updating every layer when auth token changes, we have a global function for updating it:

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -93,6 +93,14 @@ export class LayersFactory {
     [DATASET_EOCLOUD_ENVISAT_MERIS.id]: EnvisatMerisEOCloudLayer,
   };
 
+  public static async makeLayer(baseUrl: string, layerId: string): Promise<AbstractLayer> {
+    const layers = await LayersFactory.makeLayers(baseUrl, (lId: string) => lId === layerId);
+    if (layers.length === 0) {
+      return null;
+    }
+    return layers[0];
+  }
+
   public static async makeLayers(
     baseUrl: string,
     filterLayers: Function | null = null,

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -4,6 +4,8 @@ import {
   WmsLayer,
   S1GRDAWSEULayer,
   S2L2ALayer,
+  DATASET_S2L2A,
+  LayersFactory,
   CRS_EPSG4326,
   BBox,
   MimeTypes,
@@ -164,6 +166,36 @@ export const S1GetMapProcessingFromLayer = () => {
       format: MimeTypes.JPEG,
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const S2GetMapMakeLayer = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap with WMS for Sentinel-2 L2A - makeLayer</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  // getMap is async:
+  const perform = async () => {
+    const baseUrl = `${DATASET_S2L2A.shServiceHostname}ogc/wms/${instanceId}`;
+    const layerS2L2A = await LayersFactory.makeLayer(baseUrl, s2l2aLayerId);
+
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});


### PR DESCRIPTION
When using `LayersFactory.makeLayers` we are often interesting in only a single layer, leading to this construct:
```javascript
  const layer = (await LayersFactory.makeLayers(baseUrl, (lId, dataset) => lId === layerId))[0];
```

Aside from being awkward, it also makes error checking cumbersome. This PR is a suggestion (and implementation) of a shortcut method:
```
  const layer = await LayersFactory.makeLayer(baseUrl, layerId);
```