### PR TITLE
Fix/convert-evalscripts-v3

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -133,7 +133,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
 
       //Convert internal evalscript to V3 if it's not in that version.
-      if (!this.evalscript.startsWith('//VERSION=3')) {
+      if (this.evalscript && !this.evalscript.startsWith('//VERSION=3')) {
         let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
         this.evalscript = evalscriptV3;
       }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -132,6 +132,12 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
       }
 
+      //Convert internal evalscript to V3 if it's not in that version.
+      if (!this.evalscript.startsWith('//VERSION=3')) {
+        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
+        this.evalscript = evalscriptV3;
+      }
+
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);


### PR DESCRIPTION
Now sentinelhub-js converts evalscripts to V3 when the layer contains the `evalscripturl` (already implemented) and when it has the evalscript stored in `this.evalscript` (this MR).
This conversion would only happen when the processing API is being used.
Any changes that you feel that are necessary, please let me know.