### PR TITLE
Feature/byoc multi location

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   parseLegacyWmsGetMapParams,
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
+import { LocationIdSHv3 } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 
 registerAxiosCacheRetryInterceptors();
@@ -104,6 +105,7 @@ export {
   PreviewMode,
   S3SLSTRView,
   BBox,
+  LocationIdSHv3,
   setDebugEnabled,
   // legacy:
   legacyGetMapFromUrl,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -192,7 +192,14 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset);
+    const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
+      bbox,
+      fromTime,
+      toTime,
+      maxCount,
+      offset,
+    );
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
@@ -204,6 +211,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   protected fetchTiles(
+    searchIndexUrl: string,
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
@@ -212,7 +220,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     maxCloudCoverPercent?: number | null,
     datasetParameters?: Record<string, any> | null,
   ): Promise<{ data: { tiles: any[]; hasMore: boolean } }> {
-    if (!this.dataset.searchIndexUrl) {
+    if (!searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');
     }
     const bboxPolygon = bbox.toGeoJSON();
@@ -231,7 +239,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       payload.datasetParameters = datasetParameters;
     }
 
-    return axios.post(this.dataset.searchIndexUrl, payload, this.createSearchIndexRequestConfig());
+    return axios.post(searchIndexUrl, payload, this.createSearchIndexRequestConfig());
   }
 
   protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -104,6 +104,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return payload;
   }
 
+  protected getShServiceHostname(): string {
+    return this.dataset.shServiceHostname;
+  }
+
   public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
     // SHv3 services support Processing API:
     if (api === ApiType.PROCESSING) {
@@ -135,8 +139,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
-
-      return processingGetMap(this.dataset.shServiceHostname, updatedPayload);
+      const shServiceHostname = this.getShServiceHostname();
+      return processingGetMap(shServiceHostname, updatedPayload);
     }
 
     return super.getMap(params, api);
@@ -157,7 +161,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!this.dataset) {
       throw new Error('This layer does not have a dataset specified');
     }
-    const baseUrl = `${this.dataset.shServiceHostname}ogc/wms/${this.instanceId}`;
+    const shServiceHostname = this.getShServiceHostname();
+    const baseUrl = `${shServiceHostname}ogc/wms/${this.instanceId}`;
     const evalsource = this.dataset.shWmsEvalsource;
     return wmsGetMapUrl(
       baseUrl,
@@ -318,7 +323,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
     }
 
-    const { data } = await axios.post(this.dataset.shServiceHostname + 'ogc/fis/' + this.instanceId, payload);
+    const shServiceHostname = this.getShServiceHostname();
+    const { data } = await axios.post(shServiceHostname + 'ogc/fis/' + this.instanceId, payload);
     // convert date strings to Date objects
     for (let channel in data) {
       data[channel] = data[channel].map((dailyStats: any) => ({

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -250,8 +250,13 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return {};
   }
 
+  protected async getFindDatesUTCUrl(): Promise<string> {
+    return this.dataset.findDatesUTCUrl;
+  }
+
   public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {
-    if (!this.dataset.findDatesUTCUrl) {
+    const findDatesUTCUrl = await this.getFindDatesUTCUrl();
+    if (!findDatesUTCUrl) {
       throw new Error('This dataset does not support searching for dates');
     }
 
@@ -262,7 +267,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       to: toTime.toISOString(),
       ...(await this.getFindDatesUTCAdditionalParameters()),
     };
-    const response = await axios.post(this.dataset.findDatesUTCUrl, payload);
+    const response = await axios.post(findDatesUTCUrl, payload);
     const found: Moment[] = response.data.map((date: string) => moment.utc(date));
 
     // S-5P, S-3 and possibly other datasets return the results in reverse order (leastRecent).

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -41,6 +41,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     offset?: number,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
       bbox,
       fromTime,
       toTime,

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -1,8 +1,10 @@
 import { AxiosRequestConfig } from 'axios';
 import moment from 'moment';
+import axios from 'axios';
 
+import { getAuthToken } from 'src/auth';
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, LocationIdSHv3, SHV3_LOCATIONS_ROOT_URL } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -16,6 +18,7 @@ interface ConstructorParameters {
   title?: string | null;
   description?: string | null;
   collectionId?: string | null;
+  locationId?: LocationIdSHv3 | null;
 }
 
 type BYOCFindTilesDatasetParameters = {
@@ -26,6 +29,7 @@ type BYOCFindTilesDatasetParameters = {
 export class BYOCLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_BYOC;
   protected collectionId: string;
+  protected locationId: LocationIdSHv3;
 
   public constructor({
     instanceId = null,
@@ -36,28 +40,39 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     title = null,
     description = null,
     collectionId = null,
+    locationId = null,
   }: ConstructorParameters) {
     super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.collectionId = collectionId;
+    this.locationId = locationId;
   }
 
-  private shouldFetchAdditionalParams(): boolean {
-    if (this.collectionId === null) {
-      if (this.instanceId === null || this.layerId === null) {
-        throw new Error(
-          "Parameter collectionId is not set and can't be fetched from service because instanceId and layerId are not available",
-        );
-      }
-      return true;
+  public async updateLayerFromServiceIfNeeded(): Promise<void> {
+    if (this.collectionId !== null && this.locationId !== null) {
+      return;
     }
-    return false;
-  }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    if (this.shouldFetchAdditionalParams()) {
+    if (this.instanceId === null || this.layerId === null) {
+      throw new Error(
+        "Some of layer parameters (collectionId, locationId) are not set and can't be fetched from service because instanceId and layerId are not available",
+      );
+    }
+
+    if (this.collectionId === null) {
       const layerParams = await this.fetchLayerParamsFromSHServiceV3();
       this.collectionId = layerParams['collectionId'];
     }
+
+    if (this.locationId === null) {
+      const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/CUSTOM/${this.collectionId}`;
+      const headers = { Authorization: `Bearer ${getAuthToken()}` };
+      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false });
+      this.locationId = res.data.location.id;
+    }
+  }
+
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+    await this.updateLayerFromServiceIfNeeded();
     payload.input.data[0].dataFilter.collectionId = this.collectionId;
     return payload;
   }
@@ -69,16 +84,17 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
-    if (this.shouldFetchAdditionalParams()) {
-      const layerParams = await this.fetchLayerParamsFromSHServiceV3();
-      this.collectionId = layerParams['collectionId'];
-    }
+    await this.updateLayerFromServiceIfNeeded();
 
     const findTilesDatasetParameters: BYOCFindTilesDatasetParameters = {
       type: 'BYOC',
       collectionId: this.collectionId,
     };
+    // searchIndex URL depends on the locationId:
+    const rootUrl = SHV3_LOCATIONS_ROOT_URL[this.locationId];
+    const searchIndexUrl = `${rootUrl}byoc/v3/collections/CUSTOM/searchIndex`;
     const response = await this.fetchTiles(
+      searchIndexUrl,
       bbox,
       fromTime,
       toTime,
@@ -106,10 +122,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
-    if (this.shouldFetchAdditionalParams()) {
-      const layerParams = await this.fetchLayerParamsFromSHServiceV3();
-      this.collectionId = layerParams['collectionId'];
-    }
+    await this.updateLayerFromServiceIfNeeded();
 
     const result: Record<string, any> = {
       datasetParameters: {
@@ -117,7 +130,6 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
         collectionId: this.collectionId,
       },
     };
-
     return result;
   }
 }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -4,7 +4,13 @@ import axios from 'axios';
 
 import { getAuthToken } from 'src/auth';
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, LocationIdSHv3, SHV3_LOCATIONS_ROOT_URL } from 'src/layer/const';
+import {
+  PaginatedTiles,
+  LocationIdSHv3,
+  SHV3_LOCATIONS_ROOT_URL,
+  GetMapParams,
+  ApiType,
+} from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -71,6 +77,11 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     }
   }
 
+  public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
+    await this.updateLayerFromServiceIfNeeded();
+    return await super.getMap(params, api);
+  }
+
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
     await this.updateLayerFromServiceIfNeeded();
     payload.input.data[0].dataFilter.collectionId = this.collectionId;
@@ -115,6 +126,14 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       }),
       hasMore: response.data.hasMore,
     };
+  }
+
+  protected getShServiceHostname(): string {
+    if (this.locationId === null) {
+      throw new Error('Parameter locationId must be specified');
+    }
+    const shServiceHostname = SHV3_LOCATIONS_ROOT_URL[this.locationId];
+    return shServiceHostname;
   }
 
   protected createSearchIndexRequestConfig(): AxiosRequestConfig {

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -121,6 +121,13 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return {};
   }
 
+  protected async getFindDatesUTCUrl(): Promise<string> {
+    await this.updateLayerFromServiceIfNeeded();
+    const rootUrl = SHV3_LOCATIONS_ROOT_URL[this.locationId];
+    const findDatesUTCUrl = `${rootUrl}byoc/v3/collections/CUSTOM/findAvailableData`;
+    return findDatesUTCUrl;
+  }
+
   protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
     await this.updateLayerFromServiceIfNeeded();
 

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -138,6 +138,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     };
 
     const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
       bbox,
       fromTime,
       toTime,

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -15,7 +15,14 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
     maxCount?: number,
     offset?: number,
   ): Promise<PaginatedTiles> {
-    const response = await this.fetchTiles(bbox, fromTime, toTime, maxCount, offset);
+    const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
+      bbox,
+      fromTime,
+      toTime,
+      maxCount,
+      offset,
+    );
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -79,6 +79,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
       view: this.view,
     };
     const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
       bbox,
       fromTime,
       toTime,

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -92,6 +92,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
       // minQa: this.minQa,
     };
     const response = await this.fetchTiles(
+      this.dataset.searchIndexUrl,
       bbox,
       fromTime,
       toTime,

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -101,6 +101,21 @@ export const SH_SERVICE_HOSTNAMES_V3: string[] = [
   'https://creodias.sentinel-hub.com/',
 ];
 
+// See https://services.sentinel-hub.com/api/v1/metadata/location/ for an up-to-date
+// list of location ids and the corresponding URLs.
+export enum LocationIdSHv3 {
+  awsEuCentral1 = 'aws-eu-central-1',
+  awsUsWest2 = 'aws-us-west-2',
+  creo = 'creo',
+  mundi = 'mundi',
+}
+export const SHV3_LOCATIONS_ROOT_URL: Record<LocationIdSHv3, string> = {
+  [LocationIdSHv3.awsEuCentral1]: 'https://services.sentinel-hub.com/',
+  [LocationIdSHv3.awsUsWest2]: 'https://services-uswest2.sentinel-hub.com/',
+  [LocationIdSHv3.creo]: 'https://creodias.sentinel-hub.com/',
+  [LocationIdSHv3.mundi]: 'https://shservices.mundiwebservices.com/',
+};
+
 export type GetStatsParams = {
   fromTime: Date;
   toTime: Date;

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -214,7 +214,7 @@ export const DATASET_BYOC: Dataset = {
   shWmsEvalsource: 'CUSTOM',
   shProcessingApiDatasourceAbbreviation: 'CUSTOM',
   datasetParametersType: 'BYOC',
-  shServiceHostname: 'https://services.sentinel-hub.com/',
+  shServiceHostname: null, // depends on location, for example: https://services.sentinel-hub.com/
   searchIndexUrl: null, // depends on location, for example: https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/searchIndex
   findDatesUTCUrl: null, // depends on location, for example: https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData
   orbitTimeMinutes: null,

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -216,7 +216,7 @@ export const DATASET_BYOC: Dataset = {
   datasetParametersType: 'BYOC',
   shServiceHostname: 'https://services.sentinel-hub.com/',
   searchIndexUrl: null, // depends on location, for example: https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/searchIndex
-  findDatesUTCUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData',
+  findDatesUTCUrl: null, // depends on location, for example: https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData
   orbitTimeMinutes: null,
   minDate: null,
   maxDate: null,

--- a/src/layer/dataset.ts
+++ b/src/layer/dataset.ts
@@ -215,7 +215,7 @@ export const DATASET_BYOC: Dataset = {
   shProcessingApiDatasourceAbbreviation: 'CUSTOM',
   datasetParametersType: 'BYOC',
   shServiceHostname: 'https://services.sentinel-hub.com/',
-  searchIndexUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/searchIndex',
+  searchIndexUrl: null, // depends on location, for example: https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/searchIndex
   findDatesUTCUrl: 'https://services.sentinel-hub.com/byoc/v3/collections/CUSTOM/findAvailableData',
   orbitTimeMinutes: null,
   minDate: null,

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -34,7 +34,7 @@ export const getMapURL = () => {
   wrapperEl.innerHTML = '<h2>GetMapUrl (WMS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  const layer = new BYOCLayer({ instanceId, layerId });
+  const layer = new BYOCLayer({ instanceId, layerId, locationId: LocationIdSHv3.awsEuCentral1 });
 
   const getMapParams = {
     bbox: bbox,
@@ -60,6 +60,7 @@ export const getMapWMS = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
     const layer = new BYOCLayer({ instanceId, layerId });
 
     const getMapParams = {

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -175,7 +175,7 @@ export const findTiles = () => {
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findTiles (with collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findTiles (with collectionId and locationId)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
 
   const perform = async () => {
@@ -201,7 +201,7 @@ export const findTilesAuth = () => {
   const containerEl = document.createElement('pre');
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findTiles (without collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findTiles (without collectionId and locationId)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
 
   const perform = async () => {
@@ -230,10 +230,11 @@ export const findDatesUTC = () => {
     instanceId,
     layerId,
     collectionId: process.env.BYOC_COLLECTION_ID,
+    locationId: LocationIdSHv3.awsEuCentral1,
   });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDatesUTC (with collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC (with collectionId and locationId)</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
@@ -278,7 +279,7 @@ export const findDatesUTCAuth = () => {
   const layer = new BYOCLayer({ instanceId, layerId });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDatesUTC (without collectionId)</h2>';
+  wrapperEl.innerHTML = '<h2>findDatesUTC (without collectionId and locationId)</h2>';
 
   const containerEl = document.createElement('pre');
   wrapperEl.insertAdjacentElement('beforeend', containerEl);

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -1,6 +1,6 @@
 import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { BYOCLayer, CRS_EPSG3857, BBox, MimeTypes, ApiType } from '../dist/sentinelHub.esm';
+import { BYOCLayer, CRS_EPSG3857, BBox, MimeTypes, ApiType, LocationIdSHv3 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -170,6 +170,7 @@ export const findTiles = () => {
     instanceId,
     layerId,
     collectionId: process.env.BYOC_COLLECTION_ID,
+    locationId: LocationIdSHv3.awsEuCentral1,
   });
   const containerEl = document.createElement('pre');
 


### PR DESCRIPTION
BYOC can be deployed to multiple locations:
- aws-eu-central-1
- aws-us-west-2
- creo
- mundi

We can get basic information about the layer from `aws-eu-central-1` (https://services.sentinel-hub.com/), but when we would like to perform search or processing, we need to use the correct root URL, depending on the location of the collection. There is an endpoint on services.sentinel-hub.com which tells us the locationId. 

Alternatively, user can specify `locationId` when instantiating the `BYOCLayer`, thus avoiding the need for another request.