### PR TITLE
Feature/cancelling requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,18 +193,18 @@ We can always use layer to search for data availability:
 
 You can also cancel requests when searching/fetching data.
 
-To do so a factory of tokens needs to be created and a token passed through a request configuration object. In this object can also be defined the amount of retires desired in the case the petition fails.
+To do so a token needs to be created and passed through a requests configuration object. Other config such as retries can also be defined there.
 
 In the example below, a cancelFactory is created, passing a token inside the configuration request object. The timeout will cancel the requests after 500 miliseconds, throwing an exception.
 
-This exception can be caught and identified by isCancelled, function that can be imported from the library.
+This exception can be caught and identified by `isCancelled`.
 
 ```typescript
-import { cancelFactory, isCancelled, RequestConfiguration } from '@sentinel-hub/sentinelhub-js';
+import { CancelFactory, isCancelled } from '@sentinel-hub/sentinelhub-js';
 
 const source = CancelFactory.createSource();
 
-const requestConfig : RequestConfiguration = {
+const requestConfig = {
   cancelToken: source.getToken(),
   retries: 4
 }

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ try {
   const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestConfig);
   const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
   const stats = await layer.getStats(getStatsParams, requestConfig);
-  const tiles = await layer.findTiles(bbox, fromTime, toTime, undefined, undefined, requestConfig);
+  const tiles = await layer.findTiles(bbox, fromTime, toTime, null, null, requestConfig);
 }
 catch(err) {
   if (!isCancelled(err)) {

--- a/README.md
+++ b/README.md
@@ -188,6 +188,42 @@ We can always use layer to search for data availability:
   const datesS1 = await layerS1.findDatesUTC(bbox, fromTime, toTime);
 ```
 
+
+## Cancelling requests
+
+You can also cancel requests when searching/fetching data.
+
+To do so a factory of tokens needs to be created and a token passed through a request configuration object. In this object can also be defined the amount of retires desired in the case the petition fails.
+
+In the example below, a cancelFactory is created, passing a token inside the configuration request object. The timeout will cancel the requests after 500 miliseconds, throwing an exception.
+
+This exception can be caught and identified by isCancelled, function that can be imported from the library.
+
+```typescript
+import { cancelFactory, isCancelled, RequestConfiguration } from '@sentinel-hub/sentinelhub-js';
+
+const source = cancelFactory();
+
+const requestConfig : RequestConfiguration = {
+  cancelToken: source.token,
+  retries: 4
+}
+
+setTimeout(() => {
+  source.cancel();
+}, 500);
+
+try {
+  const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestConfig);
+  const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
+}
+catch(err) {
+  if (isCancelled(err)) {
+    // Exception thrown by the cancelled requests is going to be identified by isCancelled.
+  }
+}
+````
+
 ## Getting basic statistics and histogram
 
 Getting basic statistics (mean, min, max, standard deviation) and a histogram for a geometry (Polygon or MultiPolygon).

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ This exception can be caught and identified by isCancelled, function that can be
 ```typescript
 import { cancelFactory, isCancelled, RequestConfiguration } from '@sentinel-hub/sentinelhub-js';
 
-const source = cancelFactory();
+const source = CancelFactory.createSource();
 
 const requestConfig : RequestConfiguration = {
-  cancelToken: source.token,
+  cancelToken: source.getToken(),
   retries: 4
 }
 
@@ -216,10 +216,11 @@ setTimeout(() => {
 try {
   const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestConfig);
   const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
+  const stats = await layer.getStats(getStatsParams, requestConfig);
 }
 catch(err) {
-  if (isCancelled(err)) {
-    // Exception thrown by the cancelled requests is going to be identified by isCancelled.
+  if (!isCancelled(err)) {
+    throw err;
   }
 }
 ````

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ try {
   const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestConfig);
   const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
   const stats = await layer.getStats(getStatsParams, requestConfig);
+  const tiles = await layer.findTiles(bbox, fromTime, toTime, undefined, undefined, requestConfig);
 }
 catch(err) {
   if (!isCancelled(err)) {

--- a/README.md
+++ b/README.md
@@ -195,22 +195,22 @@ You can also cancel requests when searching/fetching data.
 
 To do so a token needs to be created and passed through a requests configuration object. Other config such as retries can also be defined there.
 
-In the example below, a cancelFactory is created, passing a token inside the configuration request object. The timeout will cancel the requests after 500 miliseconds, throwing an exception.
+In the example below, a cancel token is passed inside the configuration request object. The timeout will cancel the requests after 500 miliseconds, throwing an exception.
 
 This exception can be caught and identified by `isCancelled`.
 
 ```typescript
-import { CancelFactory, isCancelled } from '@sentinel-hub/sentinelhub-js';
+import { CancelToken, isCancelled } from '@sentinel-hub/sentinelhub-js';
 
-const source = CancelFactory.createSource();
+const token = new CancelToken();
 
 const requestConfig = {
-  cancelToken: source.getToken(),
+  cancelToken: token,
   retries: 4
 }
 
 setTimeout(() => {
-  source.cancel();
+  token.cancel();
 }, 500);
 
 try {

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -13,7 +13,7 @@ const {
   MimeTypes,
   ApiType,
   setDebugEnabled,
-  CancelFactory,
+  CancelToken,
   isCancelled,
 } = require('../../dist/sentinelHub.cjs');
 
@@ -190,13 +190,15 @@ async function run() {
 
   // Cancel request example
   // Create source and pass token as config on the request (getMap WMS/Processing and getStats supported for layerV3)
-  const source = CancelFactory.createSource();
+  const token = new CancelToken();
+
   setTimeout(() => {
     printOut('Cancelling request');
-    source.cancel();
+    token.cancel();
   }, 100);
+
   try {
-    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.token });
+    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: token });
     console.log(response);
   } catch (err) {
     //The exception thrown by cancelling requests can be identified by isCancelled

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -196,9 +196,7 @@ async function run() {
     source.cancel();
   }, 100);
   try {
-    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.getToken() });
-    // const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
-    // const stats = await layer.getStats(getStatsParams, requestConfig);
+    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.token });
     console.log(response);
   } catch (err) {
     //The exception thrown by cancelling requests can be identified by isCancelled

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -203,7 +203,7 @@ async function run() {
   } catch (err) {
     //The exception thrown by cancelling requests can be identified by isCancelled
     if (!isCancelled(err)) {
-      throw err
+      throw err;
     }
   }
 }

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -199,7 +199,7 @@ async function run() {
 
   try {
     const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: token });
-    console.log(response);
+    console.log('Image was recieved before 100 miliseconds');
   } catch (err) {
     //The exception thrown by cancelling requests can be identified by isCancelled
     if (!isCancelled(err)) {

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -13,6 +13,8 @@ const {
   MimeTypes,
   ApiType,
   setDebugEnabled,
+  cancelFactory,
+  isCancelled,
 } = require('../../dist/sentinelHub.cjs');
 
 function printOut(title, value) {
@@ -185,6 +187,23 @@ async function run() {
   const fs = require('fs');
   const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
   fs.writeFileSync('./image.jpeg', imageBlob, { encoding: null });
+
+  // Cancel request example
+  // Create source and pass token as config on the request (getMap WMS/Processing and getStats supported for layerV3)
+  const source = cancelFactory();
+  setTimeout(() => {
+    printOut('Cancelling request');
+    source.cancel();
+  }, 100);
+  try {
+    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.token });
+    console.log(response);
+  } catch (err) {
+    //The exception thrown by cancelling requests can be identified by isCancelled
+    if (isCancelled(err)) {
+      printOut('Error catched using isCancelled');
+    }
+  }
 }
 
 run()

--- a/example/node/index.js
+++ b/example/node/index.js
@@ -13,7 +13,7 @@ const {
   MimeTypes,
   ApiType,
   setDebugEnabled,
-  cancelFactory,
+  CancelFactory,
   isCancelled,
 } = require('../../dist/sentinelHub.cjs');
 
@@ -190,18 +190,20 @@ async function run() {
 
   // Cancel request example
   // Create source and pass token as config on the request (getMap WMS/Processing and getStats supported for layerV3)
-  const source = cancelFactory();
+  const source = CancelFactory.createSource();
   setTimeout(() => {
     printOut('Cancelling request');
     source.cancel();
   }, 100);
   try {
-    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.token });
+    const response = await layerS2L2A.getMap(getMapParams, ApiType.WMS, { cancelToken: source.getToken() });
+    // const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
+    // const stats = await layer.getStats(getStatsParams, requestConfig);
     console.log(response);
   } catch (err) {
     //The exception thrown by cancelling requests can be identified by isCancelled
-    if (isCancelled(err)) {
-      printOut('Error catched using isCancelled');
+    if (!isCancelled(err)) {
+      throw err
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,9 @@ import {
   parseLegacyWmsGetMapParams,
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
-import { LocationIdSHv3 } from 'src/layer/const';
+import { LocationIdSHv3} from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
-import { cancelFactory, isCancelled } from 'src/utils/cancelRequests';
+import { CancelFactory, isCancelled } from 'src/utils/cancelRequests';
 
 registerAxiosCacheRetryInterceptors();
 
@@ -108,11 +108,11 @@ export {
   BBox,
   LocationIdSHv3,
   setDebugEnabled,
+  CancelFactory,
+  isCancelled,
   // legacy:
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
-  cancelFactory,
-  isCancelled,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes, OrbitDirection, PreviewMode, MosaickingOrder } from 'src/layer/const';
+import {
+  ApiType,
+  MimeTypes,
+  OrbitDirection,
+  PreviewMode,
+  MosaickingOrder,
+  RequestConfiguration,
+} from 'src/layer/const';
 import { setDebugEnabled } from 'src/utils/debug';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
@@ -111,6 +118,7 @@ export {
   setDebugEnabled,
   CancelFactory,
   isCancelled,
+  RequestConfiguration,
   // legacy:
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
   parseLegacyWmsGetMapParams,
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
-import { LocationIdSHv3} from 'src/layer/const';
+import { LocationIdSHv3 } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelFactory, isCancelled } from 'src/utils/cancelRequests';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
 import { LocationIdSHv3 } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
-import { CancelFactory, isCancelled } from 'src/utils/cancelRequests';
+import { CancelToken, isCancelled } from 'src/utils/cancelRequests';
 
 registerAxiosCacheRetryInterceptors();
 
@@ -116,7 +116,7 @@ export {
   BBox,
   LocationIdSHv3,
   setDebugEnabled,
-  CancelFactory,
+  CancelToken,
   isCancelled,
   RequestConfiguration,
   // legacy:

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
+import { cancelFactory, isCancelled } from 'src/utils/cancelRequests';
 
 registerAxiosCacheRetryInterceptors();
 
@@ -110,4 +111,6 @@ export {
   legacyGetMapWmsUrlFromParams,
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
+  cancelFactory,
+  isCancelled,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import {
-  ApiType,
-  MimeTypes,
-  OrbitDirection,
-  PreviewMode,
-  MosaickingOrder,
-  RequestConfiguration,
-} from 'src/layer/const';
+import { ApiType, MimeTypes, OrbitDirection, PreviewMode, MosaickingOrder } from 'src/layer/const';
 import { setDebugEnabled } from 'src/utils/debug';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
@@ -56,7 +49,7 @@ import {
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
 import { LocationIdSHv3 } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
-import { CancelToken, isCancelled } from 'src/utils/cancelRequests';
+import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
 
 registerAxiosCacheRetryInterceptors();
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -13,6 +13,7 @@ import {
   RequestConfiguration,
 } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
+import { getAxiosReqParams } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   title?: string | null;
@@ -37,7 +38,7 @@ export class AbstractLayer {
           // 'blob' responseType does not work with Node.js:
           responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
           useCache: true,
-          ...reqConfig,
+          ...getAxiosReqParams(reqConfig),
         };
         const response = await axios.get(url, requestConfig);
         return response.data;
@@ -267,7 +268,7 @@ export class AbstractLayer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async getStats(payload: any, reqConfig?: AxiosRequestConfig): Promise<any> {
+  public async getStats(payload: any, reqConfig?: RequestConfiguration): Promise<any> {
     throw new Error('getStats() not implemented for this dataset');
   }
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -5,7 +5,13 @@ import { union, intersection, Geom } from 'polygon-clipping';
 
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326 } from 'src/crs';
-import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, RequestConfiguration } from 'src/layer/const';
+import {
+  GetMapParams,
+  ApiType,
+  PaginatedTiles,
+  FlyoverInterval,
+  RequestConfiguration,
+} from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 
 interface ConstructorParameters {
@@ -234,7 +240,7 @@ export class AbstractLayer {
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    reqConfig? : RequestConfiguration // eslint-disable-line @typescript-eslint/no-unused-vars
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Date[]> {
     throw new Error('findDatesUTC() not implemented yet');
   }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -5,7 +5,7 @@ import { union, intersection, Geom } from 'polygon-clipping';
 
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326 } from 'src/crs';
-import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval } from 'src/layer/const';
+import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, RequestConfiguration } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 
 interface ConstructorParameters {
@@ -23,7 +23,7 @@ export class AbstractLayer {
     this.description = description;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: AxiosRequestConfig): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
@@ -234,6 +234,7 @@ export class AbstractLayer {
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
+    reqConfig? : RequestConfiguration // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Date[]> {
     throw new Error('findDatesUTC() not implemented yet');
   }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -23,7 +23,7 @@ export class AbstractLayer {
     this.description = description;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType, config?: AxiosRequestConfig): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: AxiosRequestConfig): Promise<Blob> {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
@@ -31,7 +31,7 @@ export class AbstractLayer {
           // 'blob' responseType does not work with Node.js:
           responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
           useCache: true,
-          ...config,
+          ...reqConfig,
         };
         const response = await axios.get(url, requestConfig);
         return response.data;
@@ -247,7 +247,7 @@ export class AbstractLayer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async getStats(payload: any, config?: AxiosRequestConfig): Promise<any> {
+  public async getStats(payload: any, reqConfig?: AxiosRequestConfig): Promise<any> {
     throw new Error('getStats() not implemented for this dataset');
   }
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -62,6 +62,7 @@ export class AbstractLayer {
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     maxCount: number = 50, // eslint-disable-line @typescript-eslint/no-unused-vars
     offset: number = 0, // eslint-disable-line @typescript-eslint/no-unused-vars
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<PaginatedTiles> {
     throw new Error('findTiles() not implemented yet');
   }
@@ -72,6 +73,7 @@ export class AbstractLayer {
     toTime: Date,
     maxFindTilesRequests: number = 50,
     tilesPerRequest: number = 50,
+    reqConfig?: RequestConfiguration,
   ): Promise<FlyoverInterval[]> {
     if (!this.dataset || !this.dataset.orbitTimeMinutes) {
       throw new Error('Orbit time is needed for grouping tiles into flyovers.');
@@ -108,6 +110,7 @@ export class AbstractLayer {
         toTime,
         tilesPerRequest,
         i * tilesPerRequest,
+        reqConfig,
       );
 
       // apply each tile to the flyover to calculate coverage:

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -5,15 +5,9 @@ import { union, intersection, Geom } from 'polygon-clipping';
 
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326 } from 'src/crs';
-import {
-  GetMapParams,
-  ApiType,
-  PaginatedTiles,
-  FlyoverInterval,
-  RequestConfiguration,
-} from 'src/layer/const';
+import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-import { getAxiosReqParams } from 'src/utils/cancelRequests';
+import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   title?: string | null;
@@ -71,8 +65,8 @@ export class AbstractLayer {
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    maxCount: number = 50, // eslint-disable-line @typescript-eslint/no-unused-vars
-    offset: number = 0, // eslint-disable-line @typescript-eslint/no-unused-vars
+    maxCount: number | null = null, // eslint-disable-line @typescript-eslint/no-unused-vars
+    offset: number | null = null, // eslint-disable-line @typescript-eslint/no-unused-vars
     reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<PaginatedTiles> {
     throw new Error('findTiles() not implemented yet');

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -23,7 +23,7 @@ export class AbstractLayer {
     this.description = description;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, config?: AxiosRequestConfig): Promise<Blob> {
     switch (api) {
       case ApiType.WMS:
         const url = this.getMapUrl(params, api);
@@ -31,6 +31,7 @@ export class AbstractLayer {
           // 'blob' responseType does not work with Node.js:
           responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
           useCache: true,
+          ...config,
         };
         const response = await axios.get(url, requestConfig);
         return response.data;
@@ -246,7 +247,7 @@ export class AbstractLayer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async getStats(payload: any): Promise<any> {
+  public async getStats(payload: any, config?: AxiosRequestConfig): Promise<any> {
     throw new Error('getStats() not implemented for this dataset');
   }
 

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -15,7 +15,6 @@ import {
   MosaickingOrder,
   Link,
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
-  DEFAULT_FIND_TILES_OFFSET_PARAMETER,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
@@ -123,7 +122,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       maxCount = DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER;
     }
     if (offset === null) {
-      offset = DEFAULT_FIND_TILES_OFFSET_PARAMETER;
+      offset = 0;
     }
     const payload = bbox.toGeoJSON();
     const params = {

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -129,7 +129,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     return {};
   }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -12,14 +12,15 @@ import {
   Stats,
   HistogramType,
   FisPayload,
-  RequestConfiguration,
   MosaickingOrder,
   Link,
+  DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
+  DEFAULT_FIND_TILES_OFFSET_PARAMETER,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
-import { getAxiosReqParams } from 'src/utils/cancelRequests';
+import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -111,12 +112,18 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount: number = 50,
-    offset: number = 0,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     if (!this.dataset.searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');
+    }
+    if (maxCount === null) {
+      maxCount = DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER;
+    }
+    if (offset === null) {
+      offset = DEFAULT_FIND_TILES_OFFSET_PARAMETER;
     }
     const payload = bbox.toGeoJSON();
     const params = {

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -184,7 +184,6 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     return response.data.map((date: string) => moment.utc(date).toDate());
   }
 
-
   public async getStats(params: GetStatsParams, reqConfig?: RequestConfiguration): Promise<Stats> {
     if (!params.geometry) {
       throw new Error('Parameter "geometry" needs to be provided');

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -19,6 +19,7 @@ import {
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
+import { getAxiosReqParams } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -133,7 +134,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
         'Content-Type': 'application/json',
         'Accept-CRS': 'EPSG:4326',
       },
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     });
 
     const responseTiles: any[] = response.data.tiles;
@@ -184,7 +185,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       headers: {
         'Content-Type': 'application/json',
       },
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     });
 
     return response.data.map((date: string) => moment.utc(date).toDate());
@@ -235,7 +236,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
 
     const { data } = await axios.get(this.dataset.shServiceHostname + 'v1/fis/' + this.instanceId, {
       params: payload,
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     });
     // convert date strings to Date objects
     for (let channel in data) {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -126,7 +126,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return this.dataset.shServiceHostname;
   }
 
-
   protected async fetchEvalscriptUrlIfNeeded(): Promise<void> {
     if (this.evalscriptUrl && !this.evalscript) {
       const response = await axios.get(this.evalscriptUrl, { responseType: 'text', useCache: true });
@@ -173,7 +172,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
 
       await this.convertEvalscriptToV3IfNeeded();
-      
+
       const payload = createProcessingPayload(
         this.dataset,
         params,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -133,7 +133,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
 
       //Convert internal evalscript to V3 if it's not in that version.
-      if (!this.evalscript.startsWith('//VERSION=3')) {
+      if (this.evalscript && !this.evalscript.startsWith('//VERSION=3')) {
         let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
         this.evalscript = evalscriptV3;
       }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -82,12 +82,12 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const headers = {
       Authorization: `Bearer ${authToken}`,
     };
-    const requestConfig : AxiosRequestConfig = {
-      responseType:'json',
-      headers:headers,
-      useCache:true,
-      ...reqConfig
-    }
+    const requestConfig: AxiosRequestConfig = {
+      responseType: 'json',
+      headers: headers,
+      useCache: true,
+      ...reqConfig,
+    };
     const res = await axios.get(url, requestConfig);
     const layersParams = res.data.map((l: any) => ({
       layerId: l.id,
@@ -122,11 +122,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         throw new Error('This layer does not support Processing API (unknown dataset)');
       }
       if (this.evalscriptUrl && !this.evalscript) {
-        const requestConfiguration : AxiosRequestConfig = {
-          responseType:'text',
-          useCache:true,
-          ...reqConfig
-        }
+        const requestConfiguration: AxiosRequestConfig = {
+          responseType: 'text',
+          useCache: true,
+          ...reqConfig,
+        };
         const response = await axios.get(this.evalscriptUrl, requestConfiguration);
         let evalscriptV3;
         //Check version of fetched evalscript by checking if first line starts with //VERSION=3
@@ -271,7 +271,12 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return this.dataset.findDatesUTCUrl;
   }
 
-  public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date, reqConfig?:RequestConfiguration): Promise<Date[]> {
+  public async findDatesUTC(
+    bbox: BBox,
+    fromTime: Date,
+    toTime: Date,
+    reqConfig?: RequestConfiguration,
+  ): Promise<Date[]> {
     const findDatesUTCUrl = await this.getFindDatesUTCUrl();
     if (!findDatesUTCUrl) {
       throw new Error('This dataset does not support searching for dates');
@@ -285,9 +290,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       ...(await this.getFindDatesUTCAdditionalParameters()),
     };
 
-    const requestConfiguration : AxiosRequestConfig = {
-      ...reqConfig
-    }
+    const requestConfiguration: AxiosRequestConfig = {
+      ...reqConfig,
+    };
     const response = await axios.post(findDatesUTCUrl, payload, requestConfiguration);
     const found: Moment[] = response.data.map((date: string) => moment.utc(date));
 
@@ -339,12 +344,16 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
     }
 
-    const requestConfiguration : AxiosRequestConfig = {
-      ...reqConfig
-    }
+    const requestConfiguration: AxiosRequestConfig = {
+      ...reqConfig,
+    };
 
     const shServiceHostname = this.getShServiceHostname();
-    const { data } = await axios.post(shServiceHostname + 'ogc/fis/' + this.instanceId, payload, requestConfiguration);
+    const { data } = await axios.post(
+      shServiceHostname + 'ogc/fis/' + this.instanceId,
+      payload,
+      requestConfiguration,
+    );
     // convert date strings to Date objects
     for (let channel in data) {
       data[channel] = data[channel].map((dailyStats: any) => ({
@@ -355,7 +364,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return data;
   }
 
-  protected async convertEvalscriptToV3(evalscript: string, reqConfig?:RequestConfiguration): Promise<string> {
+  protected async convertEvalscriptToV3(
+    evalscript: string,
+    reqConfig?: RequestConfiguration,
+  ): Promise<string> {
     const authToken = getAuthToken();
     const url = `https://services.sentinel-hub.com/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
     const requestConfig: AxiosRequestConfig = {
@@ -365,7 +377,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       },
       useCache: true,
       responseType: 'text',
-      ...reqConfig
+      ...reqConfig,
     };
     const res = await axios.post(url, evalscript, requestConfig);
     return res.data;

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -133,13 +133,13 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     }
   }
 
-  protected async convertEvalscriptToV3IfNeeded(): Promise<void> {
+  protected async convertEvalscriptToV3IfNeeded(reqConfig: RequestConfiguration): Promise<void> {
     // Convert internal evalscript to V3 if it's not in that version.
     if (this.evalscriptWasConvertedToV3 || !this.evalscript) {
       return;
     }
     if (!this.evalscript.startsWith('//VERSION=3')) {
-      this.evalscript = await this.convertEvalscriptToV3(this.evalscript);
+      this.evalscript = await this.convertEvalscriptToV3(this.evalscript, reqConfig);
     }
     this.evalscriptWasConvertedToV3 = true;
   }
@@ -171,7 +171,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         this.mosaickingOrder = layerParams.mosaickingOrder;
       }
 
-      await this.convertEvalscriptToV3IfNeeded();
+      await this.convertEvalscriptToV3IfNeeded(reqConfig);
 
       const payload = createProcessingPayload(
         this.dataset,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -270,10 +270,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');
     }
-    if (!maxCount) {
+    if (maxCount === null) {
       maxCount = 1;
     }
-    if (!offset) {
+    if (offset === null) {
       offset = 0;
     }
     const bboxPolygon = bbox.toGeoJSON();

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -153,13 +153,13 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
       if (!this.mosaickingOrder) {
         if (!layerParams) {
-          layerParams = await this.fetchLayerParamsFromSHServiceV3();
+          layerParams = await this.fetchLayerParamsFromSHServiceV3(reqConfig);
         }
         this.mosaickingOrder = layerParams.mosaickingOrder;
       }
       //Convert internal evalscript to V3 if it's not in that version.
       if (!this.evalscriptWasConvertedToV3 && this.evalscript && !this.evalscript.startsWith('//VERSION=3')) {
-        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
+        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript, reqConfig);
         this.evalscript = evalscriptV3;
         this.evalscriptWasConvertedToV3 = true;
       }
@@ -341,7 +341,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     found.sort((a, b) => b.unix() - a.unix());
     return found.map(m => m.toDate());
   }
-
 
   public async getStats(params: GetStatsParams, reqConfig?: RequestConfiguration): Promise<Stats> {
     if (!params.geometry) {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -12,16 +12,16 @@ import {
   FisPayload,
   MosaickingOrder,
   GetStatsParams,
-  RequestConfiguration,
   Stats,
   Link,
+  DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
+  DEFAULT_FIND_TILES_OFFSET_PARAMETER,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
-
-import { getAxiosReqParams } from '../utils/cancelRequests';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -245,8 +245,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(
@@ -282,20 +282,20 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount: number = 1,
-    offset: number = 0,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig: RequestConfiguration,
     maxCloudCoverPercent?: number | null,
     datasetParameters?: Record<string, any> | null,
   ): Promise<{ data: { tiles: any[]; hasMore: boolean } }> {
-    if (!searchIndexUrl) {
-      throw new Error('This dataset does not support searching for tiles');
-    }
     if (maxCount === null) {
-      maxCount = 1;
+      maxCount = DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER;
     }
     if (offset === null) {
-      offset = 0;
+      offset = DEFAULT_FIND_TILES_OFFSET_PARAMETER;
+    }
+    if (!searchIndexUrl) {
+      throw new Error('This dataset does not support searching for tiles');
     }
     const bboxPolygon = bbox.toGeoJSON();
     // Note: we are requesting maxCloudCoverage as a number between 0 and 1, but in

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -15,7 +15,6 @@ import {
   Stats,
   Link,
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
-  DEFAULT_FIND_TILES_OFFSET_PARAMETER,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
@@ -292,7 +291,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       maxCount = DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER;
     }
     if (offset === null) {
-      offset = DEFAULT_FIND_TILES_OFFSET_PARAMETER;
+      offset = 0;
     }
     if (!searchIndexUrl) {
       throw new Error('This dataset does not support searching for tiles');

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -132,12 +132,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
       }
 
-      //Convert internal evalscript to V3 if it's not in that version.
-      if (this.evalscript && !this.evalscript.startsWith('//VERSION=3')) {
-        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
-        this.evalscript = evalscriptV3;
-      }
-
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -104,7 +104,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return payload;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, config?: AxiosRequestConfig): Promise<Blob> {
     // SHv3 services support Processing API:
     if (api === ApiType.PROCESSING) {
       if (!this.dataset) {
@@ -141,11 +141,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
-
-      return processingGetMap(this.dataset.shServiceHostname, updatedPayload);
+      return processingGetMap(this.dataset.shServiceHostname, updatedPayload, config);
     }
 
-    return super.getMap(params, api);
+    return super.getMap(params, api, config);
   }
 
   public supportsApiType(api: ApiType): boolean {
@@ -269,7 +268,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return found.map(m => m.toDate());
   }
 
-  public async getStats(params: GetStatsParams): Promise<GetStats> {
+  public async getStats(params: GetStatsParams, reqConfig?: AxiosRequestConfig): Promise<GetStats> {
     if (!params.geometry) {
       throw new Error('Parameter "geometry" needs to be provided');
     }
@@ -311,7 +310,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       }
     }
 
-    const { data } = await axios.post(this.dataset.shServiceHostname + 'ogc/fis/' + this.instanceId, payload);
+    const { data } = await axios.post(
+      this.dataset.shServiceHostname + 'ogc/fis/' + this.instanceId,
+      payload,
+      reqConfig,
+    );
     // convert date strings to Date objects
     for (let channel in data) {
       data[channel] = data[channel].map((dailyStats: any) => ({

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -105,7 +105,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected async updateProcessingGetMapPayload(
     payload: ProcessingPayload,
-    reqConfig?: RequestConfiguration,
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<ProcessingPayload> {
     // Subclasses should override this method if they wish to supply additional
     // parameters to Processing API.
@@ -273,7 +273,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig?: RequestConfiguration,
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     return {};
   }
@@ -282,7 +282,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return {};
   }
 
-  protected async getFindDatesUTCUrl(reqConfig?: RequestConfiguration): Promise<string> {
+  protected async getFindDatesUTCUrl(
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<string> {
     return this.dataset.findDatesUTCUrl;
   }
 

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -103,11 +103,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     //   const layerParams = await this.fetchLayerParamsFromSHServiceV3();
     return payload;
   }
-  
-    protected getShServiceHostname(): string {
+
+  protected getShServiceHostname(): string {
     return this.dataset.shServiceHostname;
   }
-  
+
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: AxiosRequestConfig): Promise<Blob> {
     // SHv3 services support Processing API:
     if (api === ApiType.PROCESSING) {
@@ -141,7 +141,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
       const shServiceHostname = this.getShServiceHostname();
       return processingGetMap(shServiceHostname, updatedPayload, reqConfig);
-
     }
 
     return super.getMap(params, api, reqConfig);
@@ -323,7 +322,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         payload.evalscript = Buffer.from(this.evalscript, 'utf8').toString('base64');
       }
     }
-
 
     const shServiceHostname = this.getShServiceHostname();
     const { data } = await axios.post(shServiceHostname + 'ogc/fis/' + this.instanceId, payload, reqConfig);

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -104,7 +104,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return payload;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType, config?: AxiosRequestConfig): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: AxiosRequestConfig): Promise<Blob> {
     // SHv3 services support Processing API:
     if (api === ApiType.PROCESSING) {
       if (!this.dataset) {
@@ -135,10 +135,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);
-      return processingGetMap(this.dataset.shServiceHostname, updatedPayload, config);
+      return processingGetMap(this.dataset.shServiceHostname, updatedPayload, reqConfig);
     }
 
-    return super.getMap(params, api, config);
+    return super.getMap(params, api, reqConfig);
   }
 
   public supportsApiType(api: ApiType): boolean {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -21,6 +21,8 @@ import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'sr
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
 
+import { getAxiosReqParams } from '../utils/cancelRequests';
+
 interface ConstructorParameters {
   instanceId?: string | null;
   layerId?: string | null;
@@ -94,7 +96,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       responseType: 'json',
       headers: headers,
       useCache: true,
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     };
     const res = await axios.get(url, requestConfig);
     const layersParams = res.data.map((l: any) => ({
@@ -234,7 +236,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected createSearchIndexRequestConfig(reqConfig: RequestConfiguration): AxiosRequestConfig {
     const requestConfig: AxiosRequestConfig = {
       headers: { 'Accept-CRS': 'EPSG:4326' },
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     };
     return requestConfig;
   }
@@ -350,7 +352,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     };
 
     const axiosReqConfig: AxiosRequestConfig = {
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     };
     const response = await axios.post(findDatesUTCUrl, payload, axiosReqConfig);
     const found: Moment[] = response.data.map((date: string) => moment.utc(date));
@@ -404,7 +406,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     }
 
     const axiosReqConfig: AxiosRequestConfig = {
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     };
 
     const shServiceHostname = this.getShServiceHostname();
@@ -436,7 +438,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       },
       useCache: true,
       responseType: 'text',
-      ...reqConfig,
+      ...getAxiosReqParams(reqConfig),
     };
     const res = await axios.post(url, evalscript, requestConfig);
     return res.data;

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -132,6 +132,12 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
       }
 
+      //Convert internal evalscript to V3 if it's not in that version.
+      if (!this.evalscript.startsWith('//VERSION=3')) {
+        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
+        this.evalscript = evalscriptV3;
+      }
+
       const payload = createProcessingPayload(this.dataset, params, this.evalscript, this.dataProduct);
       // allow subclasses to update payload with their own parameters:
       const updatedPayload = await this.updateProcessingGetMapPayload(payload);

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, RequestConfiguration } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
 
 interface ConstructorParameters {
@@ -39,6 +39,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     toTime: Date,
     maxCount?: number,
     offset?: number,
+    reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(
       this.dataset.searchIndexUrl,
@@ -47,6 +48,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
       toTime,
       maxCount,
       offset,
+      reqConfig,
       this.maxCloudCoverPercent,
     );
     return {
@@ -61,7 +63,9 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     };
   }
 
-  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
+  protected async getFindDatesUTCAdditionalParameters(
+    reqConfig: RequestConfiguration,
+  ): Promise<Record<string, any>> {
     return {
       maxCloudCoverage: this.maxCloudCoverPercent / 100,
     };

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -64,7 +64,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     return {
       maxCloudCoverage: this.maxCloudCoverPercent / 100,

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -2,9 +2,10 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import { PaginatedTiles, MosaickingOrder, RequestConfiguration } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -44,8 +45,8 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -10,14 +10,13 @@ import {
   SHV3_LOCATIONS_ROOT_URL,
   GetMapParams,
   ApiType,
-  RequestConfiguration,
   GetStatsParams,
   Stats,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
-import { getAxiosReqParams } from 'src/utils/cancelRequests';
+import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -104,8 +103,8 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -10,6 +10,7 @@ import {
   SHV3_LOCATIONS_ROOT_URL,
   GetMapParams,
   ApiType,
+  RequestConfiguration,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -53,7 +54,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     this.locationId = locationId;
   }
 
-  public async updateLayerFromServiceIfNeeded(): Promise<void> {
+  public async updateLayerFromServiceIfNeeded(reqConfig? : RequestConfiguration): Promise<void> {
     if (this.collectionId !== null && this.locationId !== null) {
       return;
     }
@@ -72,18 +73,18 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     if (this.locationId === null) {
       const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/CUSTOM/${this.collectionId}`;
       const headers = { Authorization: `Bearer ${getAuthToken()}` };
-      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false });
+      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false, ...reqConfig });
       this.locationId = res.data.location.id;
     }
   }
 
-  public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
-    await this.updateLayerFromServiceIfNeeded();
-    return await super.getMap(params, api);
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig? : RequestConfiguration): Promise<Blob> {
+    await this.updateLayerFromServiceIfNeeded(reqConfig);
+    return await super.getMap(params, api, reqConfig);
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    await this.updateLayerFromServiceIfNeeded();
+  protected async updateProcessingGetMapPayload(payload: ProcessingPayload, reqConfig? : RequestConfiguration): Promise<ProcessingPayload> {
+    await this.updateLayerFromServiceIfNeeded(reqConfig);
     payload.input.data[0].dataFilter.collectionId = this.collectionId;
     return payload;
   }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -17,6 +17,7 @@ import {
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { getAxiosReqParams } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -79,7 +80,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
         responseType: 'json',
         headers: headers,
         useCache: false,
-        ...reqConfig,
+        ...getAxiosReqParams(reqConfig),
       });
       this.locationId = res.data.location.id;
     }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -54,7 +54,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     this.locationId = locationId;
   }
 
-  public async updateLayerFromServiceIfNeeded(reqConfig? : RequestConfiguration): Promise<void> {
+  public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {
     if (this.collectionId !== null && this.locationId !== null) {
       return;
     }
@@ -73,17 +73,25 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     if (this.locationId === null) {
       const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/CUSTOM/${this.collectionId}`;
       const headers = { Authorization: `Bearer ${getAuthToken()}` };
-      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false, ...reqConfig });
+      const res = await axios.get(url, {
+        responseType: 'json',
+        headers: headers,
+        useCache: false,
+        ...reqConfig,
+      });
       this.locationId = res.data.location.id;
     }
   }
 
-  public async getMap(params: GetMapParams, api: ApiType, reqConfig? : RequestConfiguration): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);
     return await super.getMap(params, api, reqConfig);
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload, reqConfig? : RequestConfiguration): Promise<ProcessingPayload> {
+  protected async updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    reqConfig?: RequestConfiguration,
+  ): Promise<ProcessingPayload> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);
     payload.input.data[0].dataFilter.collectionId = this.collectionId;
     return payload;

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -66,7 +66,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     }
 
     if (this.collectionId === null) {
-      const layerParams = await this.fetchLayerParamsFromSHServiceV3();
+      const layerParams = await this.fetchLayerParamsFromSHServiceV3(reqConfig);
       this.collectionId = layerParams['collectionId'];
     }
 
@@ -90,7 +90,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
 
   protected async updateProcessingGetMapPayload(
     payload: ProcessingPayload,
-    reqConfig?: RequestConfiguration,
+    reqConfig: RequestConfiguration,
   ): Promise<ProcessingPayload> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);
     payload.input.data[0].dataFilter.collectionId = this.collectionId;
@@ -103,8 +103,9 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
+    reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
-    await this.updateLayerFromServiceIfNeeded();
+    await this.updateLayerFromServiceIfNeeded(reqConfig);
 
     const findTilesDatasetParameters: BYOCFindTilesDatasetParameters = {
       type: 'BYOC',
@@ -120,6 +121,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
+      reqConfig,
       null,
       findTilesDatasetParameters,
     );
@@ -149,15 +151,17 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return {};
   }
 
-  protected async getFindDatesUTCUrl(): Promise<string> {
-    await this.updateLayerFromServiceIfNeeded();
+  protected async getFindDatesUTCUrl(reqConfig: RequestConfiguration): Promise<string> {
+    await this.updateLayerFromServiceIfNeeded(reqConfig);
     const rootUrl = SHV3_LOCATIONS_ROOT_URL[this.locationId];
     const findDatesUTCUrl = `${rootUrl}byoc/v3/collections/CUSTOM/findAvailableData`;
     return findDatesUTCUrl;
   }
 
-  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
-    await this.updateLayerFromServiceIfNeeded();
+  protected async getFindDatesUTCAdditionalParameters(
+    reqConfig: RequestConfiguration,
+  ): Promise<Record<string, any>> {
+    await this.updateLayerFromServiceIfNeeded(reqConfig);
 
     const result: Record<string, any> = {
       datasetParameters: {

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -4,11 +4,7 @@ import {
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
 } from 'src/layer/utils';
-import {
-  SH_SERVICE_HOSTNAMES_V1_OR_V2,
-  SH_SERVICE_HOSTNAMES_V3,
-  RequestConfiguration,
-} from 'src/layer/const';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
 import {
   DATASET_S2L2A,
   DATASET_AWS_L8L1C,
@@ -44,6 +40,7 @@ import { Landsat5EOCloudLayer } from 'src/layer/Landsat5EOCloudLayer';
 import { Landsat7EOCloudLayer } from 'src/layer/Landsat7EOCloudLayer';
 import { Landsat8EOCloudLayer } from 'src/layer/Landsat8EOCloudLayer';
 import { EnvisatMerisEOCloudLayer } from 'src/layer/EnvisatMerisEOCloudLayer';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 export class LayersFactory {
   /*

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -5,7 +5,6 @@ import {
   PreviewMode,
   ApiType,
   PaginatedTiles,
-  RequestConfiguration,
   MosaickingOrder,
 } from 'src/layer/const';
 import {
@@ -15,7 +14,7 @@ import {
   ProcessingPayloadDatasource,
 } from 'src/layer/processing';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 /*
   This layer allows using Processing API "data fusion". It takes a list of layers and
   their accompanying parameters and allows us to call `getMap`. Note that `find*()`
@@ -121,8 +120,8 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
-    maxCount?: number, // eslint-disable-line @typescript-eslint/no-unused-vars
-    offset?: number, // eslint-disable-line @typescript-eslint/no-unused-vars
+    maxCount: number | null = null, // eslint-disable-line @typescript-eslint/no-unused-vars
+    offset: number | null = null, // eslint-disable-line @typescript-eslint/no-unused-vars
     reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<PaginatedTiles> {
     throw new Error('Not supported - use individual layers when searching for tiles or flyovers');

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -1,5 +1,12 @@
 import { BBox } from 'src/bbox';
-import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles, RequestConfiguration } from 'src/layer/const';
+import {
+  GetMapParams,
+  Interpolator,
+  PreviewMode,
+  ApiType,
+  PaginatedTiles,
+  RequestConfiguration,
+} from 'src/layer/const';
 import {
   createProcessingPayload,
   convertPreviewToString,
@@ -39,7 +46,7 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
     this.layers = layers;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType, reqConfig? : RequestConfiguration): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
     if (api !== ApiType.PROCESSING) {
       throw new Error(`Only API type "PROCESSING" is supported`);
     }

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -1,5 +1,5 @@
 import { BBox } from 'src/bbox';
-import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles } from 'src/layer/const';
+import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles, RequestConfiguration } from 'src/layer/const';
 import {
   createProcessingPayload,
   convertPreviewToString,
@@ -39,7 +39,7 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
     this.layers = layers;
   }
 
-  public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
+  public async getMap(params: GetMapParams, api: ApiType, reqConfig? : RequestConfiguration): Promise<Blob> {
     if (api !== ApiType.PROCESSING) {
       throw new Error(`Only API type "PROCESSING" is supported`);
     }
@@ -89,7 +89,7 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
       payload.input.data.push(datasource);
     }
 
-    return processingGetMap(bogusFirstLayer.dataset.shServiceHostname, payload);
+    return processingGetMap(bogusFirstLayer.dataset.shServiceHostname, payload, reqConfig);
   }
 
   public supportsApiType(api: ApiType): boolean {

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -109,6 +109,7 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
     toTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars
     maxCount?: number, // eslint-disable-line @typescript-eslint/no-unused-vars
     offset?: number, // eslint-disable-line @typescript-eslint/no-unused-vars
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<PaginatedTiles> {
     throw new Error('Not supported - use individual layers when searching for tiles or flyovers');
   }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -167,7 +167,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -2,18 +2,11 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import {
-  BackscatterCoeff,
-  PaginatedTiles,
-  OrbitDirection,
-  Link,
-  LinkType,
-  RequestConfiguration,
-} from 'src/layer/const';
+import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
-
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -135,8 +128,8 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -2,7 +2,14 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link, LinkType, RequestConfiguration } from 'src/layer/const';
+import {
+  BackscatterCoeff,
+  PaginatedTiles,
+  OrbitDirection,
+  Link,
+  LinkType,
+  RequestConfiguration,
+} from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
 

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,7 @@ import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection } from 'src/layer/const';
+import { OrbitDirection, RequestConfiguration } from 'src/layer/const';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -118,7 +118,9 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
     return result;
   }
 
-  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
+  protected async getFindDatesUTCAdditionalParameters(
+    reqConfig: RequestConfiguration,
+  ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       productType: 'GRD',
       acquisitionMode: this.acquisitionMode,

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -119,7 +119,7 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       productType: 'GRD',

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,8 @@ import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection, MosaickingOrder, Link, LinkType, RequestConfiguration } from 'src/layer/const';
+import { OrbitDirection, MosaickingOrder, Link, LinkType } from 'src/layer/const';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -1,11 +1,15 @@
 import { DATASET_S2L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { RequestConfiguration } from './const';
 
 export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
+  protected async updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    reqConfig?: RequestConfiguration,
+  ): Promise<ProcessingPayload> {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
   }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -8,7 +8,7 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
 
   protected async updateProcessingGetMapPayload(
     payload: ProcessingPayload,
-    reqConfig?: RequestConfiguration,
+    reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<ProcessingPayload> {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, RequestConfiguration } from 'src/layer/const';
 import { DATASET_S3OLCI } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 
@@ -14,6 +14,7 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
+    reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(
       this.dataset.searchIndexUrl,
@@ -22,6 +23,7 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
+      reqConfig,
     );
     return {
       tiles: response.data.tiles.map(tile => ({

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,11 +1,10 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-
-import { PaginatedTiles, Link, LinkType, RequestConfiguration } from 'src/layer/const';
-
+import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
 import { DATASET_S3OLCI } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 export class S3OLCILayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3OLCI;
@@ -14,8 +13,8 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const response = await this.fetchTiles(

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -104,7 +104,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection, RequestConfiguration } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -72,6 +72,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
+    reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const findTilesDatasetParameters: S3SLSTRFindTilesDatasetParameters = {
       type: this.dataset.shProcessingApiDatasourceAbbreviation,
@@ -85,6 +86,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
+      reqConfig,
       this.maxCloudCoverPercent,
       findTilesDatasetParameters,
     );
@@ -101,7 +103,9 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
+  protected async getFindDatesUTCAdditionalParameters(
+    reqConfig: RequestConfiguration,
+  ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,12 +1,11 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-
-import { PaginatedTiles, OrbitDirection, Link, LinkType, RequestConfiguration } from 'src/layer/const';
-
+import { PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -54,8 +53,8 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     const findTilesDatasetParameters: S3SLSTRFindTilesDatasetParameters = {

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,12 +1,11 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-
-import { PaginatedTiles, Link, LinkType, RequestConfiguration } from 'src/layer/const';
-
+import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 /*
   S-5P is a bit special in that we need to supply productType when searching
@@ -82,8 +81,8 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     bbox: BBox,
     fromTime: Date,
     toTime: Date,
-    maxCount?: number,
-    offset?: number,
+    maxCount: number | null = null,
+    offset: number | null = null,
     reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     if (this.productType === null) {

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -116,7 +116,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   }
 
   protected async getFindDatesUTCAdditionalParameters(
-    reqConfig: RequestConfiguration,
+    reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, RequestConfiguration } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -82,6 +82,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     toTime: Date,
     maxCount?: number,
     offset?: number,
+    reqConfig?: RequestConfiguration,
   ): Promise<PaginatedTiles> {
     if (this.productType === null) {
       throw new Error('Parameter productType must be specified!');
@@ -98,6 +99,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
       toTime,
       maxCount,
       offset,
+      reqConfig,
       this.maxCloudCoverPercent,
       findTilesDatasetParameters,
     );
@@ -113,7 +115,9 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     };
   }
 
-  protected async getFindDatesUTCAdditionalParameters(): Promise<Record<string, any>> {
+  protected async getFindDatesUTCAdditionalParameters(
+    reqConfig: RequestConfiguration,
+  ): Promise<Record<string, any>> {
     const result: Record<string, any> = {
       datasetParameters: {
         type: this.dataset.datasetParametersType,

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -1,10 +1,11 @@
 import moment, { Moment } from 'moment';
 
 import { BBox } from 'src/bbox';
-import { GetMapParams, ApiType, RequestConfiguration } from 'src/layer/const';
+import { GetMapParams, ApiType } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { fetchGetCapabilitiesXml } from './utils';
+import { RequestConfiguration } from 'src/utils/cancelRequests';
 
 interface ConstructorParameters {
   baseUrl?: string;

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment';
 
 import { BBox } from 'src/bbox';
-import { GetMapParams, ApiType } from 'src/layer/const';
+import { GetMapParams, ApiType, RequestConfiguration } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
 import { fetchGetCapabilitiesXml } from './utils';
@@ -35,9 +35,10 @@ export class WmsLayer extends AbstractLayer {
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date,
     toTime: Date,
+    reqConfig?: RequestConfiguration,
   ): Promise<Date[]> {
     // http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#dims
-    const capabilities = await fetchGetCapabilitiesXml(this.baseUrl);
+    const capabilities = await fetchGetCapabilitiesXml(this.baseUrl, reqConfig);
     const layer = capabilities.WMS_Capabilities.Capability[0].Layer[0].Layer.find(
       layerInfo => this.layerId === layerInfo.Name[0],
     );

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -185,4 +185,3 @@ export type Stats = {
 };
 
 export const DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER = 50;
-export const DEFAULT_FIND_TILES_OFFSET_PARAMETER = 0;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -2,6 +2,7 @@ import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from 'src/bbox';
 import { CRS_IDS } from 'src/crs';
+import {CancelToken} from 'axios'
 
 /**
  * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).
@@ -164,3 +165,8 @@ export type DailyChannelStats = {
 export type GetStats = {
   [key: string]: DailyChannelStats[];
 };
+
+export type RequestConfiguration = {
+  cancelToken?: CancelToken,
+  retries?: number
+}

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -2,7 +2,7 @@ import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from 'src/bbox';
 import { CRS_IDS } from 'src/crs';
-import {CancelToken} from 'axios'
+import { CancelToken } from 'axios';
 
 /**
  * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).
@@ -167,6 +167,6 @@ export type GetStats = {
 };
 
 export type RequestConfiguration = {
-  cancelToken?: CancelToken,
-  retries?: number
-}
+  cancelToken?: CancelToken;
+  retries?: number;
+};

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -2,7 +2,6 @@ import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from 'src/bbox';
 import { CRS_IDS } from 'src/crs';
-import { CancelToken } from 'src/utils/cancelRequests';
 
 /**
  * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).
@@ -185,7 +184,5 @@ export type Stats = {
   [key: string]: DailyChannelStats[];
 };
 
-export type RequestConfiguration = {
-  cancelToken?: CancelToken;
-  retries?: number;
-};
+export const DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER = 50;
+export const DEFAULT_FIND_TILES_OFFSET_PARAMETER = 0;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -2,7 +2,7 @@ import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from 'src/bbox';
 import { CRS_IDS } from 'src/crs';
-import { CancelToken } from 'axios';
+import { CancelToken } from 'src/utils/cancelRequests';
 
 /**
  * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -160,7 +160,7 @@ export function createProcessingPayload(
 export async function processingGetMap(
   shServiceHostname: string,
   payload: ProcessingPayload,
-  reqConfig?: RequestConfiguration,
+  reqConfig: RequestConfiguration,
 ): Promise<Blob> {
   const authToken = getAuthToken();
   if (!authToken) {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -3,7 +3,14 @@ import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
 
-import { MimeType, GetMapParams, Interpolator, PreviewMode, MosaickingOrder, RequestConfiguration } from 'src/layer/const';
+import {
+  MimeType,
+  GetMapParams,
+  Interpolator,
+  PreviewMode,
+  MosaickingOrder,
+  RequestConfiguration,
+} from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 
 enum PreviewModeString {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
-import { MimeType, GetMapParams, Interpolator, PreviewMode } from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator, PreviewMode,RequestConfiguration } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 
 export enum MosaickingOrder {
@@ -160,7 +160,7 @@ export function createProcessingPayload(
 export async function processingGetMap(
   shServiceHostname: string,
   payload: ProcessingPayload,
-  reqConfig?: AxiosRequestConfig,
+  reqConfig?: RequestConfiguration,
 ): Promise<Blob> {
   const authToken = getAuthToken();
   if (!authToken) {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
-import { MimeType, GetMapParams, Interpolator, PreviewMode,RequestConfiguration } from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator, PreviewMode, RequestConfiguration } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 
 export enum MosaickingOrder {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -12,6 +12,7 @@ import {
   RequestConfiguration,
 } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
+import { getAxiosReqParams } from 'src/utils/cancelRequests';
 
 enum PreviewModeString {
   DETAIL = 'DETAIL',
@@ -178,7 +179,7 @@ export async function processingGetMap(
     // 'blob' responseType does not work with Node.js:
     responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     useCache: true,
-    ...reqConfig,
+    ...getAxiosReqParams(reqConfig),
   };
   const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -160,7 +160,7 @@ export function createProcessingPayload(
 export async function processingGetMap(
   shServiceHostname: string,
   payload: ProcessingPayload,
-  config?: AxiosRequestConfig,
+  reqConfig?: AxiosRequestConfig,
 ): Promise<Blob> {
   const authToken = getAuthToken();
   if (!authToken) {
@@ -175,7 +175,7 @@ export async function processingGetMap(
     // 'blob' responseType does not work with Node.js:
     responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     useCache: true,
-    ...config,
+    ...reqConfig,
   };
   const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -157,7 +157,11 @@ export function createProcessingPayload(
   return payload;
 }
 
-export async function processingGetMap(shServiceHostname: string, payload: ProcessingPayload): Promise<Blob> {
+export async function processingGetMap(
+  shServiceHostname: string,
+  payload: ProcessingPayload,
+  config?: AxiosRequestConfig,
+): Promise<Blob> {
   const authToken = getAuthToken();
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
@@ -171,6 +175,7 @@ export async function processingGetMap(shServiceHostname: string, payload: Proce
     // 'blob' responseType does not work with Node.js:
     responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     useCache: true,
+    ...config,
   };
   const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -3,16 +3,9 @@ import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
 
-import {
-  MimeType,
-  GetMapParams,
-  Interpolator,
-  PreviewMode,
-  MosaickingOrder,
-  RequestConfiguration,
-} from 'src/layer/const';
+import { MimeType, GetMapParams, Interpolator, PreviewMode, MosaickingOrder } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
-import { getAxiosReqParams } from 'src/utils/cancelRequests';
+import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 enum PreviewModeString {
   DETAIL = 'DETAIL',

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -7,6 +7,7 @@ import {
   SH_SERVICE_HOSTNAMES_V3,
   RequestConfiguration,
 } from 'src/layer/const';
+import { getAxiosReqParams } from 'src/utils/cancelRequests';
 
 export type GetCapabilitiesXml = {
   WMS_Capabilities: {
@@ -43,7 +44,7 @@ export async function fetchGetCapabilitiesXml(
   const axiosReqConfig: AxiosRequestConfig = {
     responseType: 'text',
     useCache: true,
-    ...reqConfig,
+    ...getAxiosReqParams(reqConfig),
   };
   const queryString = stringify(query, { sort: false });
   const url = `${baseUrl}?${queryString}`;
@@ -65,7 +66,7 @@ export async function fetchGetCapabilitiesJson(
   const axiosReqConfig: AxiosRequestConfig = {
     responseType: 'json',
     useCache: true,
-    ...reqConfig,
+    ...getAxiosReqParams(reqConfig),
   };
   const res = await axios.get(url, axiosReqConfig);
   return res.data.layers;
@@ -80,7 +81,7 @@ export async function fetchGetCapabilitiesJsonV1(
   const axiosReqConfig: AxiosRequestConfig = {
     responseType: 'json',
     useCache: true,
-    ...reqConfig,
+    ...getAxiosReqParams(reqConfig),
   };
   const res = await axios.get(url, axiosReqConfig);
   return res.data.layers;

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,12 +2,8 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import {
-  SH_SERVICE_HOSTNAMES_V1_OR_V2,
-  SH_SERVICE_HOSTNAMES_V3,
-  RequestConfiguration,
-} from 'src/layer/const';
-import { getAxiosReqParams } from 'src/utils/cancelRequests';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
+import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 export type GetCapabilitiesXml = {
   WMS_Capabilities: {

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -1,8 +1,12 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
+import {
+  SH_SERVICE_HOSTNAMES_V1_OR_V2,
+  SH_SERVICE_HOSTNAMES_V3,
+  RequestConfiguration,
+} from 'src/layer/const';
 
 export type GetCapabilitiesXml = {
   WMS_Capabilities: {
@@ -27,34 +31,58 @@ export type GetCapabilitiesXml = {
   };
 };
 
-export async function fetchGetCapabilitiesXml(baseUrl: string): Promise<GetCapabilitiesXml> {
+export async function fetchGetCapabilitiesXml(
+  baseUrl: string,
+  reqConfig: RequestConfiguration,
+): Promise<GetCapabilitiesXml> {
   const query = {
     service: 'wms',
     request: 'GetCapabilities',
     format: 'text/xml',
   };
+  const axiosReqConfig: AxiosRequestConfig = {
+    responseType: 'text',
+    useCache: true,
+    ...reqConfig,
+  };
   const queryString = stringify(query, { sort: false });
   const url = `${baseUrl}?${queryString}`;
-  const res = await axios.get(url, { responseType: 'text', useCache: true });
+  const res = await axios.get(url, axiosReqConfig);
   const parsedXml = await parseStringPromise(res.data);
   return parsedXml;
 }
 
-export async function fetchGetCapabilitiesJson(baseUrl: string): Promise<any[]> {
+export async function fetchGetCapabilitiesJson(
+  baseUrl: string,
+  reqConfig: RequestConfiguration,
+): Promise<any[]> {
   const query = {
     request: 'GetCapabilities',
     format: 'application/json',
   };
   const queryString = stringify(query, { sort: false });
   const url = `${baseUrl}?${queryString}`;
-  const res = await axios.get(url, { responseType: 'json', useCache: true });
+  const axiosReqConfig: AxiosRequestConfig = {
+    responseType: 'json',
+    useCache: true,
+    ...reqConfig,
+  };
+  const res = await axios.get(url, axiosReqConfig);
   return res.data.layers;
 }
 
-export async function fetchGetCapabilitiesJsonV1(baseUrl: string): Promise<any[]> {
+export async function fetchGetCapabilitiesJsonV1(
+  baseUrl: string,
+  reqConfig: RequestConfiguration,
+): Promise<any[]> {
   const instanceId = parseSHInstanceId(baseUrl);
   const url = `https://eocloud.sentinel-hub.com/v1/config/instance/instance.${instanceId}?scope=ALL`;
-  const res = await axios.get(url, { responseType: 'json', useCache: true });
+  const axiosReqConfig: AxiosRequestConfig = {
+    responseType: 'json',
+    useCache: true,
+    ...reqConfig,
+  };
+  const res = await axios.get(url, axiosReqConfig);
   return res.data.layers;
 }
 

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, CancelToken } from 'axios';
 import { stringify } from 'query-string';
 
 import { isDebugEnabled } from 'src/utils/debug';
@@ -15,6 +15,7 @@ declare module 'axios' {
   export interface AxiosRequestConfig {
     useCache?: boolean;
     retries?: number;
+    cancelToken?: CancelToken;
   }
 }
 

--- a/src/utils/cancelRequests.js
+++ b/src/utils/cancelRequests.js
@@ -4,6 +4,6 @@ export const cancelFactory = () => {
   return axios.CancelToken.source();
 };
 
-export const isCancelled = (error) => {
-  return axios.isCancel(error);
+export const isCancelled = err => {
+  return axios.isCancel(err);
 };

--- a/src/utils/cancelRequests.js
+++ b/src/utils/cancelRequests.js
@@ -1,9 +1,0 @@
-import axios from 'axios';
-
-export const cancelFactory = () => {
-  return axios.CancelToken.source();
-};
-
-export const isCancelled = err => {
-  return axios.isCancel(err);
-};

--- a/src/utils/cancelRequests.js
+++ b/src/utils/cancelRequests.js
@@ -4,6 +4,6 @@ export const cancelFactory = () => {
   return axios.CancelToken.source();
 };
 
-export const isCancelled = (error: Error) => {
+export const isCancelled = (error) => {
   return axios.isCancel(error);
 };

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -4,6 +4,6 @@ export const cancelFactory = (): CancelTokenSource => {
   return axios.CancelToken.source();
 };
 
-export const isCancelled = (err:Error): boolean => {
+export const isCancelled = (err: Error): boolean => {
   return axios.isCancel(err);
 };

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,22 +1,14 @@
 import axios, { CancelTokenSource, CancelToken } from 'axios';
 
 export class CancelFactory {
-  protected source: CancelTokenSource;
-  private constructor() {
-    this.source = axios.CancelToken.source();
-  }
+  protected static source: CancelTokenSource | null = null;
 
-  public static createSource = (): CancelFactory => {
-    return new CancelFactory();
+  public static createSource = (): CancelTokenSource => {
+    if (CancelFactory.source === null) {
+      CancelFactory.source = axios.CancelToken.source();
+    }
+    return CancelFactory.source;
   };
-
-  public getToken(): CancelToken {
-    return this.source.token;
-  }
-
-  public cancel(): void {
-    this.source.cancel();
-  }
 }
 
 export const isCancelled = (err: Error): boolean => {

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -6,15 +6,15 @@ export class CancelFactory {
     this.source = axios.CancelToken.source();
   }
 
-  static createSource = () => {
+  public static createSource = () => {
     return new CancelFactory();
   };
 
-  getToken() {
+  public getToken() {
     return this.source.token;
   }
 
-  cancel() {
+  public cancel() {
     this.source.cancel();
   }
 }

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,8 +1,23 @@
 import axios, { CancelTokenSource } from 'axios';
 
-export const cancelFactory = (): CancelTokenSource => {
-  return axios.CancelToken.source();
-};
+export class CancelFactory {
+  protected source : CancelTokenSource;
+  private constructor() {
+    this.source = axios.CancelToken.source();
+  }
+
+  static createSource = () => {
+    return new CancelFactory()
+  }
+
+  getToken() {
+    return this.source.token;
+  }
+
+  cancel() {
+    this.source.cancel();
+  }
+}
 
 export const isCancelled = (err: Error): boolean => {
   return axios.isCancel(err);

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,4 +1,4 @@
-import axios, { CancelTokenSource } from 'axios';
+import axios, { CancelTokenSource, CancelToken } from 'axios';
 
 export class CancelFactory {
   protected source: CancelTokenSource;
@@ -6,15 +6,15 @@ export class CancelFactory {
     this.source = axios.CancelToken.source();
   }
 
-  public static createSource = () => {
+  public static createSource = (): CancelFactory => {
     return new CancelFactory();
   };
 
-  public getToken() {
+  public getToken(): CancelToken {
     return this.source.token;
   }
 
-  public cancel() {
+  public cancel(): void {
     this.source.cancel();
   }
 }

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,5 +1,9 @@
 import axios, { CancelTokenSource, AxiosRequestConfig, CancelToken as CancelTokenAxios } from 'axios';
-import { RequestConfiguration } from '../layer/const';
+
+export type RequestConfiguration = {
+  cancelToken?: CancelToken;
+  retries?: number;
+};
 
 export class CancelToken {
   protected token: CancelTokenAxios | null = null;

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export const cancelFactory = () => {
+  return axios.CancelToken.source();
+};
+
+export const isCancelled = (error: Error) => {
+  return axios.isCancel(error);
+};

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,16 +1,35 @@
-import axios, { CancelTokenSource } from 'axios';
+import axios, { CancelTokenSource, AxiosRequestConfig, CancelToken as CancelTokenAxios } from 'axios';
+import { RequestConfiguration } from '../layer/const';
 
-export class CancelFactory {
-  protected static source: CancelTokenSource | null = null;
+export class CancelToken {
+  protected token: CancelTokenAxios | null = null;
+  protected source: CancelTokenSource | null = null;
+  private constructor() {
+    this.source = axios.CancelToken.source();
+    this.token = this.source.token;
+  }
 
-  public static createSource = (): CancelTokenSource => {
-    if (CancelFactory.source === null) {
-      CancelFactory.source = axios.CancelToken.source();
-    }
-    return CancelFactory.source;
-  };
+  public cancel(): void {
+    this.source.cancel();
+  }
+
+  public getToken(): CancelTokenAxios {
+    return this.token;
+  }
 }
 
 export const isCancelled = (err: Error): boolean => {
   return axios.isCancel(err);
+};
+
+export const getAxiosReqParams = (reqConfig: RequestConfiguration): AxiosRequestConfig => {
+  let axiosReqConfig: AxiosRequestConfig = {};
+  if (!reqConfig) {
+    return axiosReqConfig;
+  }
+  if (reqConfig.cancelToken) {
+    axiosReqConfig.cancelToken = reqConfig.cancelToken.getToken();
+  }
+  axiosReqConfig.retries = reqConfig.retries;
+  return axiosReqConfig;
 };

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,14 +1,14 @@
 import axios, { CancelTokenSource } from 'axios';
 
 export class CancelFactory {
-  protected source : CancelTokenSource;
+  protected source: CancelTokenSource;
   private constructor() {
     this.source = axios.CancelToken.source();
   }
 
   static createSource = () => {
-    return new CancelFactory()
-  }
+    return new CancelFactory();
+  };
 
   getToken() {
     return this.source.token;

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,0 +1,9 @@
+import axios, { CancelTokenSource } from 'axios';
+
+export const cancelFactory = (): CancelTokenSource => {
+  return axios.CancelToken.source();
+};
+
+export const isCancelled = (err:Error): boolean => {
+  return axios.isCancel(err);
+};

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,4 +1,4 @@
-import axios, { CancelTokenSource, CancelToken } from 'axios';
+import axios, { CancelTokenSource } from 'axios';
 
 export class CancelFactory {
   protected static source: CancelTokenSource | null = null;

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -8,7 +8,7 @@ import {
   MimeTypes,
   ApiType,
   PreviewMode,
-  cancelFactory,
+  CancelFactory,
   isCancelled,
 } from '../dist/sentinelHub.esm';
 
@@ -415,11 +415,11 @@ export const cancelRequests = () => {
   let source;
 
   button.addEventListener('click', async () => {
-    source = cancelFactory();
+    source = CancelFactory.createSource();
     img.src = '';
     try {
       const imageBlob = await layerS2L1C.getMap(getMapParams, ApiType.PROCESSING, {
-        cancelToken: source.token,
+        cancelToken: source.getToken(),
       });
       img.src = URL.createObjectURL(imageBlob);
     } catch (err) {

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -8,7 +8,7 @@ import {
   MimeTypes,
   ApiType,
   PreviewMode,
-  CancelFactory,
+  CancelToken,
   isCancelled,
 } from '../dist/sentinelHub.esm';
 
@@ -412,25 +412,25 @@ export const cancelRequests = () => {
   wrapperEl.insertAdjacentElement('beforeend', button2);
   wrapperEl.insertAdjacentElement('beforeend', img);
 
-  let source;
+  let token;
 
   button.addEventListener('click', async () => {
-    source = CancelFactory.createSource();
+    token = new CancelToken();
     img.src = '';
     try {
       const imageBlob = await layerS2L1C.getMap(getMapParams, ApiType.PROCESSING, {
-        cancelToken: source.getToken(),
+        cancelToken: token,
       });
       img.src = URL.createObjectURL(imageBlob);
     } catch (err) {
-      if (isCancelled(err)) {
-        return;
+      if (!isCancelled(err)) {
+        throw err;
       }
     }
   });
 
   button2.addEventListener('click', () => {
-    source.cancel();
+    token.cancel();
   });
   const setToken = async () => {
     await setAuthTokenWithOAuthCredentials();

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -8,6 +8,9 @@ import {
   MimeTypes,
   ApiType,
   PreviewMode,
+  cancelFactory,
+  isCancelled,
+  WmsLayer,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -375,5 +378,64 @@ export const statsBBOX3857 = () => {
   };
   perform().then(() => {});
 
+  return wrapperEl;
+};
+
+export const cancelRequests = () => {
+  const layerS2L1C = new S2L1CLayer({
+    instanceId,
+    layerId,
+    maxCloudCoverPercent: 20,
+  });
+
+  const getMapParams = {
+    bbox: bbox4326,
+    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG,
+  };
+
+  const containerEl = document.createElement('pre');
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>Cancel Requests example</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', containerEl);
+
+  const button = document.createElement('button');
+  button.innerHTML = 'Start Request';
+  const button2 = document.createElement('button');
+  button2.innerHTML = 'Cancel Request';
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+  wrapperEl.insertAdjacentElement('beforeend', button);
+  wrapperEl.insertAdjacentElement('beforeend', button2);
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  let source;
+
+  button.addEventListener('click', async () => {
+    source = cancelFactory();
+    img.src = '';
+    try {
+      const imageBlob = await layerS2L1C.getMap(getMapParams, ApiType.PROCESSING, {
+        cancelToken: source.token,
+      });
+      img.src = URL.createObjectURL(imageBlob);
+    } catch (err) {
+      if (isCancelled(err)) {
+        return;
+      }
+    }
+  });
+
+  button2.addEventListener('click', () => {
+    source.cancel();
+  });
+  const setToken = async () => {
+    await setAuthTokenWithOAuthCredentials();
+  };
+  setToken();
   return wrapperEl;
 };

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -10,7 +10,6 @@ import {
   PreviewMode,
   cancelFactory,
   isCancelled,
-  WmsLayer,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {


### PR DESCRIPTION
Now it's possible to cancel and retry requests a certain amount of times by passing a configuration object (type: AxiosRequestConfig) to the getMap (both WMS and PROCESSING) and getStats.
There are new exports on index.ts to fulfill this functionality, one is cancelFactory that creates a factory of tokens and the other is isCancelled that allows to check the expection thrown by cancelling a request.
To test this there's a new example on `example/node/index.js` and a new story on S2L1C stories.

Anything you feel that needs to be changed, please let me know.