### PR TITLE
Fix/legacy proper layers

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -49,6 +49,16 @@ export class AbstractLayer {
     throw new Error('getMapUrl() not implemented yet');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public setEvalscript(evalscript: string): void {
+    throw new Error('Evalscript is only supported on Sentinel Hub layers');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public setEvalscriptUrl(evalscriptUrl: string): void {
+    throw new Error('EvalscriptUrl is only supported on Sentinel Hub layers');
+  }
+
   public async findTiles(
     bbox: BBox, // eslint-disable-line @typescript-eslint/no-unused-vars
     fromTime: Date, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -77,6 +77,14 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     );
   }
 
+  public setEvalscript(evalscript: string): void {
+    this.evalscript = evalscript;
+  }
+
+  public setEvalscriptUrl(evalscriptUrl: string): void {
+    this.evalscriptUrl = evalscriptUrl;
+  }
+
   protected getFindTilesAdditionalParameters(): Record<string, any> {
     return {};
   }

--- a/stories/legacy.stories.js
+++ b/stories/legacy.stories.js
@@ -1,6 +1,6 @@
 import { setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { legacyGetMapFromUrl, ApiType, BBox, CRS_EPSG3857, legacyGetMapFromParams } from '../dist/sentinelHub.esm';
+import { legacyGetMapFromUrl, ApiType, legacyGetMapFromParams } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');

--- a/stories/legacy.stories.js
+++ b/stories/legacy.stories.js
@@ -1,6 +1,6 @@
 import { setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { legacyGetMapFromUrl, ApiType } from '../dist/sentinelHub.esm';
+import { legacyGetMapFromUrl, ApiType, BBox, CRS_EPSG3857, legacyGetMapFromParams } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -126,6 +126,40 @@ export const WMSLegacyGetMapFromUrlDatesNotTimes = () => {
 
   const perform = async () => {
     const imageBlob = await legacyGetMapFromUrl(`${baseUrl}?${queryParamsNoEvalscriptJustDates}`);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const WMSLegacyGetMapFromParams = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS LegacyGetMapFromParams</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const params = {
+    bbox: [ 1110477.1469270408, 7078680.315433605, 1115369.1167372921, 7083572.285243855 ],
+    crs: "EPSG:3857",
+    evalscriptoverrides: "",
+    format: "image/png",
+    layers: s2l2aLayerId,
+    maxcc: 100,
+    pane: "activeLayer",
+    preview: 2,
+    showlogo: false,
+    time: "2019-07-01/2020-01-15",
+    transparent: true,
+    width: 512,
+    height: 512,
+  };
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const imageBlob = await legacyGetMapFromParams(baseUrl, params);
     img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});


### PR DESCRIPTION
This MR changes behaviour of `legacyGetMapFromParams` so that it uses layers from `LayersFactory` instead of always using a `WmsLayer`. The reason for this change is EO Browser, where we wish to work with BYOC layers which (even though their canonical WMS base URL points at eu-central-1 data location) need to be fetched from other locations.

There is also a breaking change to `parseLegacyWmsGetMapParams`, which now returns evalscript in decoded form (it is no longer base64 encoded). Since it is not used anywhere yet, it should be safe to do it now. 
