### PR TITLE
fix locationId null error for getStats

### DIFF
--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -9,7 +9,7 @@ import {
   ApiType,
   PaginatedTiles,
   GetStatsParams,
-  GetStats,
+  Stats,
   HistogramType,
   FisPayload,
 } from 'src/layer/const';
@@ -163,7 +163,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     return response.data.map((date: string) => moment.utc(date).toDate());
   }
 
-  public async getStats(params: GetStatsParams): Promise<GetStats> {
+  public async getStats(params: GetStatsParams): Promise<Stats> {
     if (!params.geometry) {
       throw new Error('Parameter "geometry" needs to be provided');
     }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -11,7 +11,7 @@ import {
   HistogramType,
   FisPayload,
   GetStatsParams,
-  GetStats,
+  Stats,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
@@ -281,7 +281,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return found.map(m => m.toDate());
   }
 
-  public async getStats(params: GetStatsParams): Promise<GetStats> {
+  public async getStats(params: GetStatsParams): Promise<Stats> {
     if (!params.geometry) {
       throw new Error('Parameter "geometry" needs to be provided');
     }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -11,7 +11,7 @@ import {
   GetMapParams,
   ApiType,
   GetStatsParams,
-  GetStats,
+  Stats,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -161,7 +161,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return result;
   }
 
-  public async getStats(params: GetStatsParams): Promise<GetStats> {
+  public async getStats(params: GetStatsParams): Promise<Stats> {
     await this.updateLayerFromServiceIfNeeded();
     return super.getStats(params);
   }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -10,6 +10,8 @@ import {
   SHV3_LOCATIONS_ROOT_URL,
   GetMapParams,
   ApiType,
+  GetStatsParams,
+  GetStats,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -157,5 +159,10 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       },
     };
     return result;
+  }
+
+  public async getStats(params: GetStatsParams): Promise<GetStats> {
+    await this.updateLayerFromServiceIfNeeded();
+    return super.getStats(params);
   }
 }

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -161,6 +161,6 @@ export type DailyChannelStats = {
   };
 };
 
-export type GetStats = {
+export type Stats = {
   [key: string]: DailyChannelStats[];
 };


### PR DESCRIPTION
* Fix issue where calling `getStats` on `BYOCLayer` would throw an error `'Parameter locationId must be specified'`