### PR TITLE
Fix/data fusion evalscripturl

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -153,7 +153,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
           throw new Error(`Could not fetch evalscript / dataProduct from service for layer ${this.layerId}`);
         }
       }
-      if (!this.mosaickingOrder) {
+      if (!this.mosaickingOrder && this.instanceId && this.layerId) {
         if (!layerParams) {
           layerParams = await this.fetchLayerParamsFromSHServiceV3();
         }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -115,16 +115,33 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return this.dataset.shServiceHostname;
   }
 
+  protected async fetchEvalscriptUrlIfNeeded(): Promise<void> {
+    if (this.evalscriptUrl && !this.evalscript) {
+      const response = await axios.get(this.evalscriptUrl, { responseType: 'text', useCache: true });
+      this.evalscript = response.data;
+    }
+  }
+
+  protected async convertEvalscriptToV3IfNeeded(): Promise<void> {
+    // Convert internal evalscript to V3 if it's not in that version.
+    if (this.evalscriptWasConvertedToV3 || !this.evalscript) {
+      return;
+    }
+    if (!this.evalscript.startsWith('//VERSION=3')) {
+      this.evalscript = await this.convertEvalscriptToV3(this.evalscript);
+    }
+    this.evalscriptWasConvertedToV3 = true;
+  }
+
   public async getMap(params: GetMapParams, api: ApiType): Promise<Blob> {
     // SHv3 services support Processing API:
     if (api === ApiType.PROCESSING) {
       if (!this.dataset) {
         throw new Error('This layer does not support Processing API (unknown dataset)');
       }
-      if (this.evalscriptUrl && !this.evalscript) {
-        const response = await axios.get(this.evalscriptUrl, { responseType: 'text', useCache: true });
-        this.evalscript = response.data;
-      }
+
+      await this.fetchEvalscriptUrlIfNeeded();
+
       let layerParams = null;
       if (!this.evalscript && !this.dataProduct) {
         layerParams = await this.fetchLayerParamsFromSHServiceV3();
@@ -142,12 +159,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         }
         this.mosaickingOrder = layerParams.mosaickingOrder;
       }
-      //Convert internal evalscript to V3 if it's not in that version.
-      if (!this.evalscriptWasConvertedToV3 && this.evalscript && !this.evalscript.startsWith('//VERSION=3')) {
-        let evalscriptV3 = await this.convertEvalscriptToV3(this.evalscript);
-        this.evalscript = evalscriptV3;
-        this.evalscriptWasConvertedToV3 = true;
-      }
+
+      await this.convertEvalscriptToV3IfNeeded();
+
       const payload = createProcessingPayload(
         this.dataset,
         params,

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -21,7 +21,8 @@ import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer
   methods wouldn't make sense and are thus disabled.
 */
 interface ConstructorParameters {
-  evalscript: string;
+  evalscript: string | null;
+  evalscriptUrl: string | null;
   layers: DataFusionLayerInfo[];
   title?: string | null;
   description?: string | null;
@@ -41,8 +42,14 @@ export type DataFusionLayerInfo = {
 export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
   protected layers: DataFusionLayerInfo[];
 
-  public constructor({ title = null, description = null, evalscript, layers }: ConstructorParameters) {
-    super({ title, description, evalscript });
+  public constructor({
+    title = null,
+    description = null,
+    evalscript = null,
+    evalscriptUrl = null,
+    layers,
+  }: ConstructorParameters) {
+    super({ title, description, evalscript, evalscriptUrl });
     this.layers = layers;
   }
 
@@ -50,6 +57,8 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
     if (api !== ApiType.PROCESSING) {
       throw new Error(`Only API type "PROCESSING" is supported`);
     }
+
+    await this.fetchEvalscriptUrlIfNeeded();
 
     // when constructing the payload, we just take the first layer - we will rewrite its info later:
     const bogusFirstLayer = this.layers[0].layer;

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -223,7 +223,7 @@ export function parseLegacyWmsGetMapParams(wmsParams: Record<string, any>): Pars
   return {
     layers: layers,
     evalscript: decodedEvalscript,
-    evalscriptUrl: params.evalscriptUrl,
+    evalscriptUrl: params.evalscripturl,
     evalsource: params.evalsource,
     getMapParams: getMapParams,
   };

--- a/stories/datafusion.stories.js
+++ b/stories/datafusion.stories.js
@@ -62,13 +62,13 @@ export const getMapProcessing = () => {
     const layers = [
       {
         layer: layerS2L2A,
-        id: 'l2a',
+        id: 's2l2a',
         fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 26, 0, 0, 0)),
       },
       {
         layer: layerS2L1C,
-        id: 'l1c',
+        id: 's2l1c',
         fromTime: new Date(Date.UTC(2020, 2 - 1, 10, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 24, 0, 0, 0)),
       },
@@ -79,8 +79,8 @@ export const getMapProcessing = () => {
         //VERSION=3
         var setup = () => ({
           input: [
-            {datasource: "l2a", bands:["B02", "B03", "B04"], units: "REFLECTANCE", mosaicking: "ORBIT"},
-            {datasource: "l1c", bands:["B02", "B03", "B04"], units: "REFLECTANCE"}],
+            {datasource: "s2l2a", bands:["B02", "B03", "B04"], units: "REFLECTANCE", mosaicking: "ORBIT"},
+            {datasource: "s2l1c", bands:["B02", "B03", "B04"], units: "REFLECTANCE"}],
           output: [
             {id: "default", bands: 3, sampleType: SampleType.AUTO}
           ]
@@ -88,7 +88,12 @@ export const getMapProcessing = () => {
 
 
         function evaluatePixel(samples, inputData, inputMetadata, customData, outputMetadata) {
-          var sample = samples.l2a[0];
+          var sample = samples.s2l2a[0];
+          if (!sample) {
+            return {
+              default: [0, 0, 0],
+            }
+          }
           let val = [sample.B04, sample.B03, sample.B02];
 
           return {
@@ -139,13 +144,13 @@ export const getMapProcessingEvalscriptUrl = () => {
     const layers = [
       {
         layer: layerS2L2A,
-        id: 'l2a',
+        id: 's2l2a',
         fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 26, 0, 0, 0)),
       },
       {
         layer: layerS2L1C,
-        id: 'l1c',
+        id: 's2l1c',
         fromTime: new Date(Date.UTC(2020, 2 - 1, 10, 0, 0, 0)),
         toTime: new Date(Date.UTC(2020, 2 - 1, 24, 0, 0, 0)),
       },
@@ -153,7 +158,7 @@ export const getMapProcessingEvalscriptUrl = () => {
     const layer = new ProcessingDataFusionLayer({
       layers: layers,
       evalscriptUrl:
-        'https://gist.githubusercontent.com/sinergise-anze/33fe78d9b1fd24d656882d7916a83d4d/raw/7b9c52160d0d1254937955398e6690dc88096742/data-fusion-evalscript.js',
+        'https://gist.githubusercontent.com/sinergise-anze/33fe78d9b1fd24d656882d7916a83d4d/raw/295b9d9f033c7e3f1e533363322d84846808564c/data-fusion-evalscript.js',
     });
 
     const getMapParams = {

--- a/stories/datafusion.stories.js
+++ b/stories/datafusion.stories.js
@@ -34,7 +34,7 @@ const bbox = new BBox(
 );
 
 export default {
-  title: 'Data fusion - Sentinel-2 L1C and Landsat 8',
+  title: 'Data fusion',
 };
 
 export const getMapProcessing = () => {


### PR DESCRIPTION
This MR adds support for `evalscriptUrl` to `ProcessingDataFusionLayer`. 

I have rearranged the code a bit. `convertEvalscriptToV3IfNeeded` is also changed a bit, so that conversion is marked as "done" if the evalscript starts with `//VERSION=3` already.

Additionally, `mosaickingOrder` is not fetched from the service when `instanceId` or `layerId` are not available (fixes storybook `GetMapProcessingEvalscripturlVersion2`).