### PR TITLE
Feature/tiles extra info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,4 @@ export {
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
 };
+console.log("LOCAL SENTINELHUB-JS")

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,4 +114,3 @@ export {
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
 };
-console.log('USING LOCAL SENTINELHUB-JS');

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,4 +114,4 @@ export {
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
 };
-console.log("LOCAL SENTINELHUB-JS")
+console.log('USING LOCAL SENTINELHUB-JS');

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -152,7 +152,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   protected getStatsAdditionalParameters(): Record<string, any> {
     return {};
   }
-
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [];
   }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -13,6 +13,7 @@ import {
   HistogramType,
   FisPayload,
   MosaickingOrder,
+  Link,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
@@ -138,6 +139,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
         geometry: tile.tileDrawRegionGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
         meta: this.extractFindTilesMeta(tile),
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
@@ -149,6 +151,10 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
 
   protected getStatsAdditionalParameters(): Record<string, any> {
     return {};
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [];
   }
 
   public async findDatesUTC(bbox: BBox, fromTime: Date, toTime: Date): Promise<Date[]> {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -239,7 +239,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       hasMore: response.data.hasMore,
     };
   }
-
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [];
   }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -233,11 +233,15 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
-        meta: {},
+        meta: this.extractFindTilesMeta(tile),
         links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {};
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getTileLinks(tile: Record<string, any>): Link[] {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -229,7 +229,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       maxCount,
       offset,
     );
-    console.log('Find tiles V3 layer');
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -13,6 +13,7 @@ import {
   MosaickingOrder,
   GetStatsParams,
   Stats,
+  Link,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
@@ -228,14 +229,20 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       maxCount,
       offset,
     );
+    console.log('Find tiles V3 layer');
     return {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
         meta: {},
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [];
   }
 
   protected fetchTiles(

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -76,9 +76,11 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
       maxcc: this.maxCloudCoverPercent,
     };
   }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {};
   }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [];
   }

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -59,14 +59,7 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
-        meta: {
-          cloudCoverPercent: tile.cloudCoverPercentage,
-          tileId: tile.id,
-          MGRSLocation: tile.dataUri
-            .split('/')
-            .slice(4, 7)
-            .join(''),
-        },
+        meta: this.extractFindTilesMeta(tile),
         links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
@@ -82,6 +75,9 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     return {
       maxcc: this.maxCloudCoverPercent,
     };
+  }
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {};
   }
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [];

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, MosaickingOrder, Link } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 
@@ -78,10 +78,9 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected extractFindTilesMeta(tile: any): Record<string, any> {
-    return {};
-  }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getTileLinks(tile: Record<string, any>): Link[] {
-    return [];
+    return {
+      ...super.extractFindTilesMeta(tile),
+      cloudCoverPercent: tile.cloudCoverPercentage,
+    };
   }
 }

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, MosaickingOrder, Link  } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder, Link } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 
@@ -63,9 +63,9 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
           cloudCoverPercent: tile.cloudCoverPercentage,
           tileId: tile.id,
           MGRSLocation: tile.dataUri
-          .split('/')
-          .slice(4, 7)
-          .join('')
+            .split('/')
+            .slice(4, 7)
+            .join(''),
         },
         links: this.getTileLinks(tile),
       })),

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder, Link  } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 
@@ -61,7 +61,13 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
         sensingTime: moment.utc(tile.sensingTime).toDate(),
         meta: {
           cloudCoverPercent: tile.cloudCoverPercentage,
+          tileId: tile.id,
+          MGRSLocation: tile.dataUri
+          .split('/')
+          .slice(4, 7)
+          .join('')
         },
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
@@ -76,5 +82,8 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     return {
       maxcc: this.maxCloudCoverPercent,
     };
+  }
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [];
   }
 }

--- a/src/layer/EnvisatMerisEOCloudLayer.ts
+++ b/src/layer/EnvisatMerisEOCloudLayer.ts
@@ -1,5 +1,5 @@
 import { DATASET_EOCLOUD_ENVISAT_MERIS } from 'src/layer/dataset';
-
+import { Link } from 'src/layer/const';
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 
 export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
@@ -22,5 +22,15 @@ export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
       title,
       description,
     });
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.pathFragment,
+        rel: 'self',
+        title: 'EOCloudPath',
+      },
+    ];
   }
 }

--- a/src/layer/EnvisatMerisEOCloudLayer.ts
+++ b/src/layer/EnvisatMerisEOCloudLayer.ts
@@ -1,5 +1,5 @@
 import { DATASET_EOCLOUD_ENVISAT_MERIS } from 'src/layer/dataset';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 
 export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
@@ -27,9 +27,8 @@ export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.pathFragment,
-        rel: 'self',
-        title: 'EOCloudPath',
+        target: tile.pathFragment,
+        type: LinkType.EOCLOUD,
       },
     ];
   }

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT5 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT5;
@@ -29,21 +29,19 @@ export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.pathFragment,
-        rel: 'self',
-        title: 'EOCloudPath',
+        target: tile.pathFragment,
+        type: LinkType.EOCLOUD,
       },
       {
-        href: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
-        rel: 'self',
-        title: 'Preview',
+        target: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
+        type: LinkType.PREVIEW,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       sunElevation: tile.sunElevation,
     };
   }

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -1,5 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT5 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link } from 'src/layer/const';
 
 export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT5;
@@ -23,5 +24,27 @@ export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       description,
       maxCloudCoverPercent,
     });
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.pathFragment,
+        rel: 'self',
+        title: 'EOCloudPath',
+      },
+      {
+        href: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
+  }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      sunElevation: tile.sunElevation,
+    };
   }
 }

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT7 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT7;
@@ -29,21 +29,19 @@ export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.pathFragment,
-        rel: 'self',
-        title: 'EOCloudPath',
+        target: tile.pathFragment,
+        type: LinkType.EOCLOUD,
       },
       {
-        href: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
-        rel: 'self',
-        title: 'Preview',
+        target: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
+        type: LinkType.PREVIEW,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       sunElevation: tile.sunElevation,
     };
   }

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -1,5 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT7 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link } from 'src/layer/const';
 
 export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT7;
@@ -23,5 +24,27 @@ export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       description,
       maxCloudCoverPercent,
     });
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.pathFragment,
+        rel: 'self',
+        title: 'EOCloudPath',
+      },
+      {
+        href: `${tile.previewUrl.replace('eocloud', 'creodias')}.JPG`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
+  }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      sunElevation: tile.sunElevation,
+    };
   }
 }

--- a/src/layer/Landsat8AWSLayer.ts
+++ b/src/layer/Landsat8AWSLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_AWS_L8L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class Landsat8AWSLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_AWS_L8L1C;
@@ -8,21 +8,19 @@ export class Landsat8AWSLayer extends AbstractSentinelHubV3WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.dataUri,
-        rel: 'self',
-        title: 'AWSPath',
+        target: tile.dataUri,
+        type: LinkType.AWS,
       },
       {
-        href: `${tile.dataUri}_thumb_small.jpg`,
-        rel: 'self',
-        title: 'Preview',
+        target: `${tile.dataUri}_thumb_small.jpg`,
+        type: LinkType.PREVIEW,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       sunElevation: tile.sunElevation,
     };
   }

--- a/src/layer/Landsat8AWSLayer.ts
+++ b/src/layer/Landsat8AWSLayer.ts
@@ -1,6 +1,29 @@
 import { DATASET_AWS_L8L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
+import { Link } from 'src/layer/const';
 
 export class Landsat8AWSLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_AWS_L8L1C;
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.dataUri,
+        rel: 'self',
+        title: 'AWSPath',
+      },
+      {
+        href: `${tile.dataUri}_thumb_small.jpg`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
+  }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      sunElevation: tile.sunElevation,
+    };
+  }
 }

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT8 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT8;
@@ -29,21 +29,19 @@ export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.pathFragment,
-        rel: 'self',
-        title: 'EOCloudPath',
+        target: tile.pathFragment,
+        type: LinkType.EOCLOUD,
       },
       {
-        href: `https://finder.creodias.eu/files${tile.pathFragment.replace('/eodata', '')}.png`,
-        rel: 'self',
-        title: 'Preview',
+        target: `https://finder.creodias.eu/files${tile.pathFragment.replace('/eodata', '')}.png`,
+        type: LinkType.PREVIEW,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       sunElevation: tile.sunElevation,
     };
   }

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -1,5 +1,6 @@
 import { DATASET_EOCLOUD_LANDSAT8 } from 'src/layer/dataset';
 import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link } from 'src/layer/const';
 
 export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT8;
@@ -23,5 +24,27 @@ export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
       description,
       maxCloudCoverPercent,
     });
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.pathFragment,
+        rel: 'self',
+        title: 'EOCloudPath',
+      },
+      {
+        href: `https://finder.creodias.eu/files${tile.pathFragment.replace('/eodata', '')}.png`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
+  }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      sunElevation: tile.sunElevation,
+    };
   }
 }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -179,11 +179,12 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   }
 
   protected getTileLinks(tile: Record<string, any>): Link[] {
-    return [{
-      href: tile.dataUri,
-      rel:'self',
-      title: 'AWSPath'
-    },
-   ];
+    return [
+      {
+        href: tile.dataUri,
+        rel: 'self',
+        title: 'AWSPath',
+      },
+    ];
   }
 }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link } from 'src/layer/const';
+import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
 
@@ -181,9 +181,8 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.dataUri,
-        rel: 'self',
-        title: 'AWSPath',
+        target: tile.dataUri,
+        type: LinkType.AWS,
       },
     ];
   }

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { BackscatterCoeff, PaginatedTiles, OrbitDirection } from 'src/layer/const';
+import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
 
@@ -157,6 +157,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
           acquisitionMode: tile.acquisitionMode,
           resolution: tile.resolution,
         },
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
@@ -175,5 +176,14 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
       result.datasetParameters.orbitDirection = this.orbitDirection;
     }
     return result;
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [{
+      href: tile.dataUri,
+      rel:'self',
+      title: 'AWSPath'
+    },
+   ];
   }
 }

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,7 @@ import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection, MosaickingOrder } from 'src/layer/const';
+import { OrbitDirection, MosaickingOrder, Link } from 'src/layer/const';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -130,5 +130,18 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
       result.orbitDirection = this.orbitDirection;
     }
     return result;
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [{
+      href: tile.pathFragment,
+      rel:'self',
+      title: 'EOCloudPath'
+    },
+    {
+      href: `https://finder.creodias.eu/files/${tile.pathFragment.split('eodata')[1]}/preview/quick-look.png`,
+      rel:'self',
+      title: 'Preview'
+    }];
   }
 }

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -2,7 +2,7 @@ import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
 
 import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
 import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection, MosaickingOrder, Link } from 'src/layer/const';
+import { OrbitDirection, MosaickingOrder, Link, LinkType } from 'src/layer/const';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
@@ -135,16 +135,14 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.pathFragment,
-        rel: 'self',
-        title: 'EOCloudPath',
+        target: tile.pathFragment,
+        type: LinkType.EOCLOUD,
       },
       {
-        href: `https://finder.creodias.eu/files/${
+        target: `https://finder.creodias.eu/files/${
           tile.pathFragment.split('eodata')[1]
         }/preview/quick-look.png`,
-        rel: 'self',
-        title: 'Preview',
+        type: LinkType.PREVIEW,
       },
     ];
   }

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -133,15 +133,19 @@ export class S1GRDEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   }
 
   protected getTileLinks(tile: Record<string, any>): Link[] {
-    return [{
-      href: tile.pathFragment,
-      rel:'self',
-      title: 'EOCloudPath'
-    },
-    {
-      href: `https://finder.creodias.eu/files/${tile.pathFragment.split('eodata')[1]}/preview/quick-look.png`,
-      rel:'self',
-      title: 'Preview'
-    }];
+    return [
+      {
+        href: tile.pathFragment,
+        rel: 'self',
+        title: 'EOCloudPath',
+      },
+      {
+        href: `https://finder.creodias.eu/files/${
+          tile.pathFragment.split('eodata')[1]
+        }/preview/quick-look.png`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
   }
 }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -1,6 +1,20 @@
 import { DATASET_S2L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
+import { Link } from 'src/layer/const';
 
 export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [{
+      href: tile.dataUri,
+      rel:'self',
+      title: 'AWSPath'
+    },
+    {
+      href: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${tile.dataUri.split('tiles')[1]}/preview.jpg`,
+      rel:'self',
+      title: 'Preview'
+    }];
+  }
 }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -21,4 +21,15 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
       },
     ];
   }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      tileId: tile.id,
+      MGRSLocation: tile.dataUri
+        .split('/')
+        .slice(4, 7)
+        .join(''),
+    };
+  }
 }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -6,15 +6,19 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;
 
   protected getTileLinks(tile: Record<string, any>): Link[] {
-    return [{
-      href: tile.dataUri,
-      rel:'self',
-      title: 'AWSPath'
-    },
-    {
-      href: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${tile.dataUri.split('tiles')[1]}/preview.jpg`,
-      rel:'self',
-      title: 'Preview'
-    }];
+    return [
+      {
+        href: tile.dataUri,
+        rel: 'self',
+        title: 'AWSPath',
+      },
+      {
+        href: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${
+          tile.dataUri.split('tiles')[1]
+        }/preview.jpg`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
   }
 }

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -1,6 +1,6 @@
 import { DATASET_S2L1C } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;
@@ -8,23 +8,21 @@ export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.dataUri,
-        rel: 'self',
-        title: 'AWSPath',
+        target: tile.dataUri,
+        type: LinkType.AWS,
       },
       {
-        href: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${
+        target: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${
           tile.dataUri.split('tiles')[1]
         }/preview.jpg`,
-        rel: 'self',
-        title: 'Preview',
+        type: LinkType.PREVIEW,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       tileId: tile.id,
       MGRSLocation: tile.dataUri
         .split('/')

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -1,7 +1,7 @@
 import { DATASET_S2L2A } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
-import { Link } from 'src/layer/const';
+import { Link, LinkType } from 'src/layer/const';
 
 export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L2A;
@@ -14,16 +14,15 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.dataUri,
-        rel: 'self',
-        title: 'AWSPath',
+        target: tile.dataUri,
+        type: LinkType.AWS,
       },
     ];
   }
 
   protected extractFindTilesMeta(tile: any): Record<string, any> {
     return {
-      cloudCoverPercent: tile.cloudCoverPercentage,
+      ...super.extractFindTilesMeta(tile),
       tileId: tile.id,
       MGRSLocation: tile.dataUri
         .split('/')

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -12,10 +12,12 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   }
 
   protected getTileLinks(tile: Record<string, any>): Link[] {
-    return [{
-      href: tile.dataUri,
-      rel:'self',
-      title: 'AWSPath'
-    }];
+    return [
+      {
+        href: tile.dataUri,
+        rel: 'self',
+        title: 'AWSPath',
+      },
+    ];
   }
 }

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -1,6 +1,7 @@
 import { DATASET_S2L2A } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
+import { Link } from 'src/layer/const';
 
 export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L2A;
@@ -8,5 +9,13 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
     payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [{
+      href: tile.dataUri,
+      rel:'self',
+      title: 'AWSPath'
+    }];
   }
 }

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -20,4 +20,15 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
       },
     ];
   }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      cloudCoverPercent: tile.cloudCoverPercentage,
+      tileId: tile.id,
+      MGRSLocation: tile.dataUri
+        .split('/')
+        .slice(4, 7)
+        .join(''),
+    };
+  }
 }

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, Link } from 'src/layer/const';
 import { DATASET_S3OLCI } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 
@@ -28,8 +28,28 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
         geometry: tile.dataGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
         meta: {},
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    console.log('In get tile links of OLCI');
+    return [
+      {
+        href: tile.originalId.replace('EODATA', '/eodata'),
+        rel: 'self',
+        title: 'creoDIASPath',
+      },
+      {
+        href: `https://finder.creodias.eu/files${tile.originalId.replace(
+          'EODATA',
+          '',
+        )}/${tile.productName.replace('.SEN3', '')}-ql.jpg`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
   }
 }

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link } from 'src/layer/const';
+import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
 import { DATASET_S3OLCI } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 
@@ -37,17 +37,15 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.originalId.replace('EODATA', '/eodata'),
-        rel: 'self',
-        title: 'creoDIASPath',
+        target: tile.originalId.replace('EODATA', '/eodata'),
+        type: LinkType.CREODIAS,
       },
       {
-        href: `https://finder.creodias.eu/files${tile.originalId.replace(
+        target: `https://finder.creodias.eu/files${tile.originalId.replace(
           'EODATA',
           '',
         )}/${tile.productName.replace('.SEN3', '')}-ql.jpg`,
-        rel: 'self',
-        title: 'Preview',
+        type: LinkType.PREVIEW,
       },
     ];
   }

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -35,7 +35,6 @@ export class S3OLCILayer extends AbstractSentinelHubV3Layer {
   }
 
   protected getTileLinks(tile: Record<string, any>): Link[] {
-    console.log('In get tile links of OLCI');
     return [
       {
         href: tile.originalId.replace('EODATA', '/eodata'),

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection, Link } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -74,10 +74,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
       tiles: response.data.tiles.map(tile => ({
         geometry: tile.dataGeometry,
         sensingTime: moment.utc(tile.sensingTime).toDate(),
-        meta: {
-          cloudCoverPercent: tile.cloudCoverPercentage,
-          orbitDirection: tile.orbitDirection,
-        },
+        meta: this.extractFindTilesMeta(tile),
         links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
@@ -105,18 +102,23 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.originalId.replace('EODATA', '/eodata'),
-        rel: 'self',
-        title: 'creoDIASPath',
+        target: tile.originalId.replace('EODATA', '/eodata'),
+        type: LinkType.CREODIAS,
       },
       {
-        href: `https://finder.creodias.eu/files${tile.originalId.replace(
+        target: `https://finder.creodias.eu/files${tile.originalId.replace(
           'EODATA',
           '',
         )}/${tile.productName.replace('.SEN3', '')}-ql.jpg`,
-        rel: 'self',
-        title: 'Preview',
+        type: LinkType.PREVIEW,
       },
     ];
+  }
+
+  protected extractFindTilesMeta(tile: any): Record<string, any> {
+    return {
+      ...super.extractFindTilesMeta(tile),
+      orbitDirection: tile.orbitDirection,
+    };
   }
 }

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection, Link } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -78,6 +78,7 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
           cloudCoverPercent: tile.cloudCoverPercentage,
           orbitDirection: tile.orbitDirection,
         },
+        links: this.getTileLinks(tile),
       })),
       hasMore: response.data.hasMore,
     };
@@ -99,5 +100,23 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
     }
 
     return result;
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.originalId.replace('EODATA', '/eodata'),
+        rel: 'self',
+        title: 'creoDIASPath',
+      },
+      {
+        href: `https://finder.creodias.eu/files${tile.originalId.replace(
+          'EODATA',
+          '',
+        )}/${tile.productName.replace('.SEN3', '')}-ql.jpg`,
+        rel: 'self',
+        title: 'Preview',
+      },
+    ];
   }
 }

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles } from 'src/layer/const';
+import { PaginatedTiles, Link } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -107,6 +107,7 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
           geometry: tile.tileDrawRegionGeometry,
           sensingTime: moment.utc(tile.sensingTime).toDate(),
           meta: {},
+          links: this.getTileLinks(tile),
         };
       }),
       hasMore: response.data.hasMore,
@@ -134,5 +135,15 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     return {
       maxcc: this.maxCloudCoverPercent,
     };
+  }
+
+  protected getTileLinks(tile: Record<string, any>): Link[] {
+    return [
+      {
+        href: tile.originalId.replace('EODATA', '/eodata'),
+        rel: 'self',
+        title: 'creoDIASPath',
+      },
+    ];
   }
 }

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link } from 'src/layer/const';
+import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -140,9 +140,8 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
-        href: tile.originalId.replace('EODATA', '/eodata'),
-        rel: 'self',
-        title: 'creoDIASPath',
+        target: tile.originalId.replace('EODATA', '/eodata'),
+        type: LinkType.CREODIAS,
       },
     ];
   }

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -11,6 +11,8 @@ import {
   OrbitDirection,
 } from 'src';
 
+import { LinkType } from 'src/layer/const';
+
 test('timezone should NOT be UTC', () => {
   // We are testing correctness in case of local timezones, so it doesn't make sense to
   // run these tests in UTC timezone. Env var in package.json should take care of that, but we
@@ -128,10 +130,9 @@ test.each([
         },
         links: [
           {
-            href:
+            target:
               's3://sentinel-s1-l1c/GRD/2020/2/2/EW/DH/S1A_EW_GRDM_1SDH_20200202T180532_20200202T180632_031077_03921C_E6C8',
-            rel: 'self',
-            title: 'AWSPath',
+            type: LinkType.AWS,
           },
         ],
       },

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -126,6 +126,14 @@ test.each([
           resolution: Resolution.HIGH,
           orbitDirection: OrbitDirection.ASCENDING,
         },
+        links: [
+          {
+            href:
+              's3://sentinel-s1-l1c/GRD/2020/2/2/EW/DH/S1A_EW_GRDM_1SDH_20200202T180532_20200202T180632_031077_03921C_E6C8',
+            rel: 'self',
+            title: 'AWSPath',
+          },
+        ],
       },
     ]);
   },

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -66,12 +66,16 @@ export enum BackscatterCoeff {
   SIGMA0_ELLIPSOID = 'SIGMA0_ELLIPSOID',
 }
 
+export enum LinkType {
+  EOCLOUD = 'eocloud',
+  AWS = 'aws',
+  PREVIEW = 'preview',
+  CREODIAS = 'creodias',
+}
+
 export type Link = {
-  // https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#link-object
-  href: string;
-  rel: string;
-  title?: string;
-  type?: string;
+  target: string;
+  type: LinkType;
 };
 
 export type Tile = {

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -68,10 +68,10 @@ export enum BackscatterCoeff {
 
 export type Link = {
   // https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#link-object
-  href: string,
-  rel: string,
-  title?: string,
-  type?: string 
+  href: string;
+  rel: string;
+  title?: string;
+  type?: string;
 };
 
 export type Tile = {

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -66,10 +66,19 @@ export enum BackscatterCoeff {
   SIGMA0_ELLIPSOID = 'SIGMA0_ELLIPSOID',
 }
 
+export type Link = {
+  // https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#link-object
+  href: string,
+  rel: string,
+  title?: string,
+  type?: string 
+};
+
 export type Tile = {
   geometry: Polygon | MultiPolygon;
   sensingTime: Date;
   meta: Record<string, any>;
+  links?: Link[];
 };
 
 export type PaginatedTiles = {


### PR DESCRIPTION
This MR enriches tiles from  `findTiles` with `links` and additional metadata. Specifically, metadata and links which are displayed in EOBrowser.

I kept the `links`  fields optional.
https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#item-fields