### PR TITLE
Feature/upsampling defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes, OrbitDirection, PreviewMode, MosaickingOrder } from 'src/layer/const';
+import {
+  ApiType,
+  MimeTypes,
+  OrbitDirection,
+  PreviewMode,
+  MosaickingOrder,
+  Interpolator,
+} from 'src/layer/const';
 import { setDebugEnabled } from 'src/utils/debug';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
@@ -104,6 +111,7 @@ export {
   OrbitDirection,
   PreviewMode,
   MosaickingOrder,
+  Interpolator,
   S3SLSTRView,
   BBox,
   LocationIdSHv3,

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -81,7 +81,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       additionalParameters.upsampling = this.upsampling;
     }
     if (this.downsampling) {
-      additionalParameters.priority = this.downsampling;
+      additionalParameters.downsampling = this.downsampling;
     }
     return additionalParameters;
   }

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -13,6 +13,7 @@ import {
   HistogramType,
   FisPayload,
   MosaickingOrder,
+  Interpolator,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { AbstractLayer } from 'src/layer/AbstractLayer';
@@ -26,6 +27,8 @@ interface ConstructorParameters {
   mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
+  upsampling?: Interpolator | null;
+  downsampling?: Interpolator | null;
 }
 
 // this class provides any SHv1- or SHv2-specific (EO Cloud) functionality to the subclasses:
@@ -35,6 +38,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
   protected mosaickingOrder: MosaickingOrder | null;
+  protected upsampling: Interpolator | null;
+  protected downsampling: Interpolator | null;
 
   public constructor({
     instanceId = null,
@@ -44,6 +49,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     mosaickingOrder = null,
     title = null,
     description = null,
+    upsampling = null,
+    downsampling = null,
   }: ConstructorParameters) {
     super({ title, description });
     if (!layerId || !instanceId) {
@@ -54,6 +61,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
     this.evalscript = evalscript;
     this.evalscriptUrl = evalscriptUrl;
     this.mosaickingOrder = mosaickingOrder;
+    this.upsampling = upsampling;
+    this.downsampling = downsampling;
   }
 
   protected getEvalsource(): string {
@@ -63,12 +72,17 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
+    let additionalParameters: Record<string, any> = {};
     if (this.mosaickingOrder) {
-      return {
-        priority: this.mosaickingOrder,
-      };
+      additionalParameters.priority = this.mosaickingOrder;
     }
-    return {};
+    if (this.upsampling) {
+      additionalParameters.upsampling = this.upsampling;
+    }
+    if (this.downsampling) {
+      additionalParameters.priority = this.downsampling;
+    }
+    return additionalParameters;
   }
 
   public getMapUrl(params: GetMapParams, api: ApiType): string {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -97,7 +97,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const headers = {
       Authorization: `Bearer ${authToken}`,
     };
-    const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false });
+    const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: true });
     const layersParams = res.data.map((l: any) => ({
       layerId: l.id,
       ...l.datasourceDefaults,

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -79,7 +79,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     this.downsampling = downsampling;
   }
 
-  public async fetchLayerParamsFromSHServiceV3(): Promise<any> {
+  protected async fetchLayerParamsFromSHServiceV3(): Promise<any> {
     if (this.instanceId === null || this.layerId === null) {
       throw new Error('Could not fetch layer params - instanceId and layerId must be set on Layer');
     }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -109,7 +109,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!layerParams) {
       throw new Error('Layer params could not be found');
     }
-    console.log('AbstractSentinelHubV3Layer -> layerParams', layerParams);
     return layerParams;
   }
 

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -42,8 +42,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected dataProduct: string | null;
   protected evalscriptWasConvertedToV3: boolean | null;
   public mosaickingOrder: MosaickingOrder | null; // public because ProcessingDataFusionLayer needs to read it directly
-  protected upsampling: Interpolator | null;
-  protected downsampling: Interpolator | null;
+  public upsampling: Interpolator | null;
+  public downsampling: Interpolator | null;
 
   public constructor({
     instanceId = null,
@@ -79,7 +79,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     this.downsampling = downsampling;
   }
 
-  protected async fetchLayerParamsFromSHServiceV3(): Promise<any> {
+  public async fetchLayerParamsFromSHServiceV3(): Promise<any> {
     if (this.instanceId === null || this.layerId === null) {
       throw new Error('Could not fetch layer params - instanceId and layerId must be set on Layer');
     }
@@ -97,7 +97,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const headers = {
       Authorization: `Bearer ${authToken}`,
     };
-    const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: true });
+    const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false });
     const layersParams = res.data.map((l: any) => ({
       layerId: l.id,
       ...l.datasourceDefaults,
@@ -109,6 +109,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!layerParams) {
       throw new Error('Layer params could not be found');
     }
+    console.log('AbstractSentinelHubV3Layer -> layerParams', layerParams);
     return layerParams;
   }
 

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -94,16 +94,12 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
         datasource.dataFilter.mosaickingOrder = layerInfo.layer.mosaickingOrder;
       }
 
-      if (layerInfo.upsampling !== undefined) {
-        payload.input.data[0].processing.upsampling = layerInfo.upsampling;
-      } else if (params.upsampling !== undefined) {
-        payload.input.data[0].processing.upsampling = params.upsampling;
+      if (layerInfo.layer.upsampling) {
+        datasource.processing.upsampling = layerInfo.layer.upsampling;
       }
 
-      if (layerInfo.downsampling !== undefined) {
-        payload.input.data[0].processing.downsampling = layerInfo.downsampling;
-      } else if (params.downsampling !== undefined) {
-        payload.input.data[0].processing.downsampling = params.downsampling;
+      if (layerInfo.layer.downsampling) {
+        datasource.processing.downsampling = layerInfo.layer.downsampling;
       }
 
       payload.input.data.push(datasource);

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -36,7 +36,13 @@ export type GetMapParams = {
   };
 };
 
-export type Interpolator = 'BILINEAR' | 'BICUBIC' | 'LANCZOS' | 'BOX' | 'NEAREST';
+export enum Interpolator {
+  BILINEAR = 'BILINEAR',
+  BICUBIC = 'BICUBIC',
+  LANCZOS = 'LANCZOS',
+  BOX = 'BOX',
+  NEAREST = 'NEAREST',
+}
 
 export enum PreviewMode {
   DETAIL = 0,

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -86,6 +86,8 @@ export function createProcessingPayload(
   evalscript: string | null = null,
   dataProduct: string | null = null,
   mosaickingOrder: MosaickingOrder | null = null,
+  upsampling: Interpolator | null = null,
+  downsampling: Interpolator | null = null,
 ): ProcessingPayload {
   const { bbox } = params;
 
@@ -125,11 +127,11 @@ export function createProcessingPayload(
     },
   };
 
-  if (params.upsampling !== undefined) {
-    payload.input.data[0].processing.upsampling = params.upsampling;
+  if (params.upsampling || upsampling) {
+    payload.input.data[0].processing.upsampling = params.upsampling ? params.upsampling : upsampling;
   }
-  if (params.downsampling !== undefined) {
-    payload.input.data[0].processing.downsampling = params.downsampling;
+  if (params.downsampling || downsampling) {
+    payload.input.data[0].processing.downsampling = params.downsampling ? params.downsampling : downsampling;
   }
   if (params.geometry !== undefined) {
     payload.input.bounds.geometry = params.geometry;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -11,6 +11,7 @@ import {
   MimeTypes,
   ApiType,
   MosaickingOrder,
+  Interpolator,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -427,6 +428,121 @@ export const MosaickingOrderProcessing = () => {
     layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
     img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
     layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_CC;
+    img4.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const UpsamplingWMS = () => {
+  const img1 = document.createElement('img');
+  img1.width = '256';
+  img1.height = '256';
+  const img2 = document.createElement('img');
+  img2.width = '256';
+  img2.height = '256';
+  const img3 = document.createElement('img');
+  img3.width = '256';
+  img3.height = '256';
+  const img4 = document.createElement('img');
+  img4.width = '256';
+  img4.height = '256';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS upsampling - default from instance, NEAREST, BILINEAR and BICUBIC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img1);
+  wrapperEl.insertAdjacentElement('beforeend', img2);
+  wrapperEl.insertAdjacentElement('beforeend', img3);
+  wrapperEl.insertAdjacentElement('beforeend', img4);
+
+  const bboxUpsampling = new BBox(
+    CRS_EPSG4326,
+    12.534885406494142,
+    42.53034594479704,
+    12.579259872436525,
+    42.56044583171783,
+  );
+
+  const perform = async () => {
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId: 'S2L2A_SCL',
+    });
+    const getMapParams = {
+      bbox: bboxUpsampling,
+      fromTime: new Date(Date.UTC(2020, 4 - 1, 10, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 4 - 1, 10, 23, 59, 59)),
+      width: 256,
+      height: 256,
+      format: MimeTypes.JPEG,
+    };
+    img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    layerS2L2A.upsampling = Interpolator.NEAREST;
+    img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    layerS2L2A.upsampling = Interpolator.BILINEAR;
+    img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+    layerS2L2A.upsampling = Interpolator.BICUBIC;
+    img4.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.WMS));
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const UpsamplingProcessing = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+  const img1 = document.createElement('img');
+  img1.width = '256';
+  img1.height = '256';
+  const img2 = document.createElement('img');
+  img2.width = '256';
+  img2.height = '256';
+  const img3 = document.createElement('img');
+  img3.width = '256';
+  img3.height = '256';
+  const img4 = document.createElement('img');
+  img4.width = '256';
+  img4.height = '256';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS upsampling - default from instance, NEAREST, BILINEAR and BICUBIC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img1);
+  wrapperEl.insertAdjacentElement('beforeend', img2);
+  wrapperEl.insertAdjacentElement('beforeend', img3);
+  wrapperEl.insertAdjacentElement('beforeend', img4);
+
+  const bboxUpsampling = new BBox(
+    CRS_EPSG4326,
+    12.534885406494142,
+    42.53034594479704,
+    12.579259872436525,
+    42.56044583171783,
+  );
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId: 'S2L2A_SCL',
+    });
+    const getMapParams = {
+      bbox: bboxUpsampling,
+      fromTime: new Date(Date.UTC(2020, 4 - 1, 10, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 4 - 1, 10, 23, 59, 59)),
+      width: 256,
+      height: 256,
+      format: MimeTypes.JPEG,
+    };
+    img1.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    layerS2L2A.upsampling = Interpolator.NEAREST;
+    img2.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    layerS2L2A.upsampling = Interpolator.BILINEAR;
+    img3.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
+    layerS2L2A.upsampling = Interpolator.BICUBIC;
     img4.src = URL.createObjectURL(await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING));
   };
   perform().then(() => {});


### PR DESCRIPTION
This is pretty much the same problem as  with `mosaickingOrder` and `maxCloudCoverage`. Default values for `upsampling` and `downsampling` can be defined in dashboard and that can lead to different images when using wms and processing.  Nice example is eob3 where in dashboard  upsampling for all S2L1C layers is set to `BICUBIC` , but `NEAREST` is used when calling getMap (you can see this as blurry vs. pixelated image when using small zoom). To "solve" this, upsampling and downsampling were moved to layer properties.   

     