### PR TITLE
added shServiceHostname to evalscript conversion

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -384,7 +384,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected async convertEvalscriptToV3(evalscript: string): Promise<string> {
     const authToken = getAuthToken();
-    const url = `https://services.sentinel-hub.com/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
+    const shServiceHostname = this.getShServiceHostname();
+    const url = `${shServiceHostname}/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
     const requestConfig: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${authToken}`,


### PR DESCRIPTION
One line change to use the correct shHostName. Without this, evalscripts from L8L1C, MODIS and creodias ones didn't it's evalscript converted.