### PR TITLE
Showing acquisition dates with legacyGetMap

### DIFF
--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -39,23 +39,31 @@ export async function legacyGetMapFromParams(
     wmsParams,
   );
 
-  const layerId = layers.split(',')[0];
-  const layer = await LayersFactory.makeLayer(baseUrl, layerId);
-  if (!layer) {
-    throw new Error(`Layer with id ${layerId} was not found on service endpoint ${baseUrl}`);
-  }
+  let layer;
+  // Layers parameter may contain list of layers which is at the moment supported only by WmsLayer.
+  // In case there is more then one layer specified in layers parameter, WmsLayer will be used.
 
-  if (evalscript || evalscriptUrl) {
-    // we assume that devs don't do things like setting evalsource on a layer to something
-    // that doesn't match layer's dataset - but we check it nevertheless:
-    const expectedEvalsource = layer.dataset.shWmsEvalsource;
-    if (expectedEvalsource !== evalsource) {
-      console.warn(`Evalsource ${evalsource} is not valid on this layer, will use: ${expectedEvalsource}`);
+  if (layers && layers.split(',').length > 1) {
+    layer = new WmsLayer({ baseUrl, layerId: layers });
+  } else {
+    const layerId = layers;
+    layer = await LayersFactory.makeLayer(baseUrl, layerId);
+    if (!layer) {
+      throw new Error(`Layer with id ${layerId} was not found on service endpoint ${baseUrl}`);
     }
-    if (evalscriptUrl) {
-      layer.setEvalscriptUrl(evalscriptUrl);
-    } else {
-      layer.setEvalscript(evalscript);
+
+    if (evalscript || evalscriptUrl) {
+      // we assume that devs don't do things like setting evalsource on a layer to something
+      // that doesn't match layer's dataset - but we check it nevertheless:
+      const expectedEvalsource = layer.dataset.shWmsEvalsource;
+      if (expectedEvalsource !== evalsource) {
+        console.warn(`Evalsource ${evalsource} is not valid on this layer, will use: ${expectedEvalsource}`);
+      }
+      if (evalscriptUrl) {
+        layer.setEvalscriptUrl(evalscriptUrl);
+      } else {
+        layer.setEvalscript(evalscript);
+      }
     }
   }
 

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -41,7 +41,7 @@ export async function legacyGetMapFromParams(
 
   let layer;
   // Layers parameter may contain list of layers which is at the moment supported only by WmsLayer.
-  // In case there is more then one layer specified in layers parameter, WmsLayer will be used.
+  // In case there is more than one layer specified in layers parameter, WmsLayer will be used.
 
   if (layers && layers.split(',').length > 1) {
     layer = new WmsLayer({ baseUrl, layerId: layers });

--- a/stories/legacy.stories.js
+++ b/stories/legacy.stories.js
@@ -202,3 +202,37 @@ export const WMSLegacyGetMapFromParamsWrongEvalsource = () => {
 
   return wrapperEl;
 };
+
+export const WMSLegacyGetMapFromParamsWithDates = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS LegacyGetMapFromParams with aquisition dates</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const params = {
+    bbox: [1110477.1469270408, 7078680.315433605, 1115369.1167372921, 7083572.285243855],
+    crs: 'EPSG:3857',
+    evalscriptoverrides: '',
+    format: 'image/png',
+    layers: `${s2l2aLayerId},DATE`,
+    maxcc: 100,
+    pane: 'activeLayer',
+    preview: 2,
+    showlogo: false,
+    time: '2019-07-01/2020-01-15',
+    transparent: true,
+    width: 512,
+    height: 512,
+  };
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const imageBlob = await legacyGetMapFromParams(baseUrl, params);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};


### PR DESCRIPTION
[trello](https://trello.com/c/N6wljHFh/38-showing-acquisition-dates-doesnt-work-with-legacygetmapfromparams)

This is just a workaround for a problem spotted in Playground. If there is more than one layer passed as parameter (layers: 1-NATURAL-COLOR,DATE) , WmsLayer will be used for getting map.
To solve this properly, some sort of overlays will need to be introduced to SentinelHub layers.   