### PR TITLE
Add Sentinel-2 L1C's previews to L2A

### DIFF
--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -17,6 +17,12 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
         target: tile.dataUri,
         type: LinkType.AWS,
       },
+      {
+        target: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${
+          tile.dataUri.split('tiles')[1]
+        }/preview.jpg`,
+        type: LinkType.PREVIEW,
+      },
     ];
   }
 

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -18,6 +18,7 @@ export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
         type: LinkType.AWS,
       },
       {
+        // S-2 L2A doesn't have previews, but we can use corresponding L1C ones instead:
         target: `https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles${
           tile.dataUri.split('tiles')[1]
         }/preview.jpg`,


### PR DESCRIPTION
Adds previews for Sentinel-2 L2A (same as L1C)

https://trello.com/c/g719ReMy/431-s2l2a-doesnt-show-preview-image