### PR TITLE
cache request made to get locationId

### DIFF
--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -74,7 +74,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     if (this.locationId === null) {
       const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/CUSTOM/${this.collectionId}`;
       const headers = { Authorization: `Bearer ${getAuthToken()}` };
-      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: false });
+      const res = await axios.get(url, { responseType: 'json', headers: headers, useCache: true });
       this.locationId = res.data.location.id;
     }
   }


### PR DESCRIPTION
Cache the request to `https://services.sentinel-hub.com/api/v1/metadata/collection/CUSTOM/` as the request is made on each `getMap` call, and `locationId` for a dataset shouldnt change, so it should be safe to cache this request.