### PR TITLE
Fix/convert byoc evalscript

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -397,7 +397,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return res.data;
   }
 
-  protected getConvertScriptBaseUrl() {
+  protected getConvertScriptBaseUrl(): string {
     const shServiceHostname = this.getShServiceHostname();
     return `${shServiceHostname}api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
   }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -384,8 +384,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected async convertEvalscriptToV3(evalscript: string): Promise<string> {
     const authToken = getAuthToken();
-    const shServiceHostname = this.getShServiceHostname();
-    const url = `${shServiceHostname}/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
+    const url = this.getConvertScriptBaseUrl();
     const requestConfig: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${authToken}`,
@@ -396,5 +395,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     };
     const res = await axios.post(url, evalscript, requestConfig);
     return res.data;
+  }
+
+  protected getConvertScriptBaseUrl() {
+    const shServiceHostname = this.getShServiceHostname();
+    return `${shServiceHostname}/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
   }
 }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -399,6 +399,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected getConvertScriptBaseUrl() {
     const shServiceHostname = this.getShServiceHostname();
-    return `${shServiceHostname}/api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
+    return `${shServiceHostname}api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
   }
 }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -384,7 +384,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
   protected async convertEvalscriptToV3(evalscript: string): Promise<string> {
     const authToken = getAuthToken();
-    const url = this.getConvertScriptBaseUrl();
+    const url = this.getConvertEvalscriptBaseUrl();
     const requestConfig: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${authToken}`,
@@ -397,7 +397,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return res.data;
   }
 
-  protected getConvertScriptBaseUrl(): string {
+  protected getConvertEvalscriptBaseUrl(): string {
     const shServiceHostname = this.getShServiceHostname();
     return `${shServiceHostname}api/v1/process/convertscript?datasetType=${this.dataset.shProcessingApiDatasourceAbbreviation}`;
   }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -165,4 +165,8 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     await this.updateLayerFromServiceIfNeeded();
     return super.getStats(params);
   }
+
+  protected getConvertScriptBaseUrl() {
+    return `${super.getConvertScriptBaseUrl()}&byocCollectionId=${this.collectionId}`;
+  }
 }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -166,7 +166,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return super.getStats(params);
   }
 
-  protected getConvertScriptBaseUrl(): string {
-    return `${super.getConvertScriptBaseUrl()}&byocCollectionId=${this.collectionId}`;
+  protected getConvertEvalscriptBaseUrl(): string {
+    return `${super.getConvertEvalscriptBaseUrl()}&byocCollectionId=${this.collectionId}`;
   }
 }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -166,7 +166,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return super.getStats(params);
   }
 
-  protected getConvertScriptBaseUrl() {
+  protected getConvertScriptBaseUrl(): string {
     return `${super.getConvertScriptBaseUrl()}&byocCollectionId=${this.collectionId}`;
   }
 }


### PR DESCRIPTION
When converting evalscripts used by BYOC layers, additional parameter `byocCollectionId` is required by service.