### PR TITLE
Add accidentally removed exports back to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { BBox } from 'src/bbox';
 import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
-import { ApiType, MimeTypes, OrbitDirection, PreviewMode } from 'src/layer/const';
+import { ApiType, MimeTypes, OrbitDirection, PreviewMode, MosaickingOrder } from 'src/layer/const';
 import { setDebugEnabled } from 'src/utils/debug';
 
 import { LayersFactory } from 'src/layer/LayersFactory';
@@ -40,8 +40,14 @@ import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
 import { BYOCLayer } from 'src/layer/BYOCLayer';
 import { ProcessingDataFusionLayer } from 'src/layer/ProcessingDataFusionLayer';
 
-import { legacyGetMapFromUrl, legacyGetMapWmsUrlFromParams, legacyGetMapFromParams } from 'src/legacyCompat';
+import {
+  legacyGetMapFromUrl,
+  legacyGetMapWmsUrlFromParams,
+  legacyGetMapFromParams,
+  parseLegacyWmsGetMapParams,
+} from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
+import { LocationIdSHv3 } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
 
@@ -98,8 +104,10 @@ export {
   Resolution,
   OrbitDirection,
   PreviewMode,
+  MosaickingOrder,
   S3SLSTRView,
   BBox,
+  LocationIdSHv3,
   setDebugEnabled,
   CancelToken,
   isCancelled,
@@ -108,4 +116,5 @@ export {
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,
   legacyGetMapFromParams,
+  parseLegacyWmsGetMapParams,
 };


### PR DESCRIPTION
`index.ts` was accidentally changed in [this MR](https://github.com/sentinel-hub/sentinelhub-js/pull/75). This MR adds it back.