### PR TITLE
Fix/ pass maxcc from legacy functions to makeLayer(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It is also possible to create layers by importing their definitions from the Sen
     // [ '<layer-id-1>', '<layer-id-2>',... ]
 ```
 
-Depending on `baseUrl`, method `makeLayers()` tries to determine if a specific `Layer` subclass would be better suited and instantiates it with all applicable parameters.
+Depending on the first parameter (`baseUrl`), method `makeLayers()` tries to determine if a specific `Layer` subclass would be better suited and instantiates it with all applicable parameters.
 
 The list can be filtered to include only some of the layers:
 ```javascript
@@ -102,11 +102,19 @@ The list can be filtered to include only some of the layers:
 ```
 
 Alternatively, we can also fetch a single layer by using `makeLayer` method:
-```
+```javascript
   import { LayersFactory } from '@sentinel-hub/sentinelhub-js';
 
   const layer = await LayersFactory.makeLayer('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', '<layer-id>');
 ```
+
+Some additional layer information can be passed to `makeLayer` and `makeLayers` as an object in order to create layers with the provided information instead of the information from the services.
+
+```javascript
+  const layer = await LayersFactory.makeLayer('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', '<layer-id>', { maxCloudCoverPercent: 30 });
+
+  const layers = await LayersFactory.makeLayers('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', null, { maxCloudCoverPercent: 30 });
+  ```
 
 Some information about the layer is only accessible to authenticated users. In case of Playground and EO Browser, ReCaptcha auth token is sufficient to fetch layer information (such as evalscript / dataProduct). To avoid updating every layer when auth token changes, we have a global function for updating it:
 
@@ -214,6 +222,8 @@ setTimeout(() => {
 }, 500);
 
 try {
+  const layer = await LayersFactory.makeLayer('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', '<layer-id>', null, requestConfig);
+  const layers = await LayersFactory.makeLayers('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', null, null, requestConfig);
   const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestConfig);
   const dates = await layer.findDatesUTC(bbox, fromTime, toTime, requestConfig);
   const stats = await layer.getStats(getStatsParams, requestConfig);

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -97,9 +97,15 @@ export class LayersFactory {
   public static async makeLayer(
     baseUrl: string,
     layerId: string,
+    overrideSHLayerParams: Record<string, any> | null,
     reqConfig?: RequestConfiguration,
   ): Promise<AbstractLayer> {
-    const layers = await LayersFactory.makeLayers(baseUrl, (lId: string) => lId === layerId, reqConfig);
+    const layers = await LayersFactory.makeLayers(
+      baseUrl,
+      (lId: string) => lId === layerId,
+      overrideSHLayerParams,
+      reqConfig,
+    );
     if (layers.length === 0) {
       return null;
     }
@@ -109,17 +115,18 @@ export class LayersFactory {
   public static async makeLayers(
     baseUrl: string,
     filterLayers: Function | null = null,
+    overrideSHLayerParams?: Record<string, any>,
     reqConfig?: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     for (let hostname of SH_SERVICE_HOSTNAMES_V3) {
       if (baseUrl.startsWith(hostname)) {
-        return await this.makeLayersSHv3(baseUrl, filterLayers, reqConfig);
+        return await this.makeLayersSHv3(baseUrl, filterLayers, overrideSHLayerParams, reqConfig);
       }
     }
 
     for (let hostname of SH_SERVICE_HOSTNAMES_V1_OR_V2) {
       if (baseUrl.startsWith(hostname)) {
-        return await this.makeLayersSHv12(baseUrl, filterLayers, reqConfig);
+        return await this.makeLayersSHv12(baseUrl, filterLayers, overrideSHLayerParams, reqConfig);
       }
     }
 
@@ -129,6 +136,7 @@ export class LayersFactory {
   private static async makeLayersSHv3(
     baseUrl: string,
     filterLayers: Function | null,
+    overrideSHLayerParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const getCapabilitiesJson = await fetchGetCapabilitiesJson(baseUrl, reqConfig);
@@ -164,6 +172,9 @@ export class LayersFactory {
         title,
         description,
         legendUrl,
+        // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
+        // otherwise the default values from layer definition on the service will be used.
+        ...overrideSHLayerParams,
       });
     });
   }
@@ -171,6 +182,7 @@ export class LayersFactory {
   private static async makeLayersSHv12(
     baseUrl: string,
     filterLayers: Function | null,
+    overrideSHLayerParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const getCapabilitiesJsonV1 = await fetchGetCapabilitiesJsonV1(baseUrl, reqConfig);
@@ -194,6 +206,13 @@ export class LayersFactory {
       if (!SH12LayerClass) {
         throw new Error(`Dataset ${dataset.id} is not defined in LayersFactory.LAYER_FROM_DATASET_V12`);
       }
+
+      // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
+      // otherwise the default values from layer definition on the service will be used.
+      if (overrideSHLayerParams.maxCloudCoverPercent) {
+        layerInfo.settings.maxCC = overrideSHLayerParams.maxCloudCoverPercent;
+      }
+
       const layer = SH12LayerClass.makeLayer(
         layerInfo,
         parseSHInstanceId(baseUrl),

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -97,13 +97,13 @@ export class LayersFactory {
   public static async makeLayer(
     baseUrl: string,
     layerId: string,
-    overrideSHLayerParams: Record<string, any> | null,
+    overrideConstructorParams: Record<string, any> | null,
     reqConfig?: RequestConfiguration,
   ): Promise<AbstractLayer> {
     const layers = await LayersFactory.makeLayers(
       baseUrl,
       (lId: string) => lId === layerId,
-      overrideSHLayerParams,
+      overrideConstructorParams,
       reqConfig,
     );
     if (layers.length === 0) {
@@ -115,28 +115,28 @@ export class LayersFactory {
   public static async makeLayers(
     baseUrl: string,
     filterLayers: Function | null = null,
-    overrideSHLayerParams?: Record<string, any>,
+    overrideConstructorParams?: Record<string, any>,
     reqConfig?: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     for (let hostname of SH_SERVICE_HOSTNAMES_V3) {
       if (baseUrl.startsWith(hostname)) {
-        return await this.makeLayersSHv3(baseUrl, filterLayers, overrideSHLayerParams, reqConfig);
+        return await this.makeLayersSHv3(baseUrl, filterLayers, overrideConstructorParams, reqConfig);
       }
     }
 
     for (let hostname of SH_SERVICE_HOSTNAMES_V1_OR_V2) {
       if (baseUrl.startsWith(hostname)) {
-        return await this.makeLayersSHv12(baseUrl, filterLayers, overrideSHLayerParams, reqConfig);
+        return await this.makeLayersSHv12(baseUrl, filterLayers, overrideConstructorParams, reqConfig);
       }
     }
 
-    return await this.makeLayersWms(baseUrl, filterLayers, reqConfig);
+    return await this.makeLayersWms(baseUrl, filterLayers, overrideConstructorParams, reqConfig);
   }
 
   private static async makeLayersSHv3(
     baseUrl: string,
     filterLayers: Function | null,
-    overrideSHLayerParams: Record<string, any> | null,
+    overrideConstructorParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const getCapabilitiesJson = await fetchGetCapabilitiesJson(baseUrl, reqConfig);
@@ -174,7 +174,7 @@ export class LayersFactory {
         legendUrl,
         // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
         // otherwise the default values from layer definition on the service will be used.
-        ...overrideSHLayerParams,
+        ...overrideConstructorParams,
       });
     });
   }
@@ -182,7 +182,7 @@ export class LayersFactory {
   private static async makeLayersSHv12(
     baseUrl: string,
     filterLayers: Function | null,
-    overrideSHLayerParams: Record<string, any> | null,
+    overrideConstructorParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const getCapabilitiesJsonV1 = await fetchGetCapabilitiesJsonV1(baseUrl, reqConfig);
@@ -209,8 +209,8 @@ export class LayersFactory {
 
       // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
       // otherwise the default values from layer definition on the service will be used.
-      if (overrideSHLayerParams.maxCloudCoverPercent) {
-        layerInfo.settings.maxCC = overrideSHLayerParams.maxCloudCoverPercent;
+      if (overrideConstructorParams.maxCloudCoverPercent) {
+        layerInfo.settings.maxCC = overrideConstructorParams.maxCloudCoverPercent;
       }
 
       const layer = SH12LayerClass.makeLayer(
@@ -230,6 +230,7 @@ export class LayersFactory {
   private static async makeLayersWms(
     baseUrl: string,
     filterLayers: Function | null,
+    overrideConstructorParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const parsedXml = await fetchGetCapabilitiesXml(baseUrl, reqConfig);

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -44,8 +44,6 @@ export async function legacyGetMapFromParams(
     otherLayerParams,
   } = parseLegacyWmsGetMapParams(wmsParams);
 
-  console.log('lgmfromparams', { getMapParams, otherLayerParams });
-
   let layer;
   // Layers parameter may contain list of layers which is at the moment supported only by WmsLayer.
   // In case there is more than one layer specified in layers parameter, WmsLayer will be used.

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -148,6 +148,48 @@ export const getMapWMSEvalscript = () => {
   return wrapperEl;
 };
 
+export const GetMapWMSMaxCC20vs60 = () => {
+  const layerL520 = new Landsat5EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent: 20 });
+  const layerL560 = new Landsat5EOCloudLayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>GetMap: maxCC=20 vs maxCC=60</h2>`;
+
+  const img20 = document.createElement('img');
+  img20.width = '512';
+  img20.height = '512';
+  img20.style.border = '2px solid green';
+  img20.style.margin = '10px';
+  wrapperEl.insertAdjacentElement('beforeend', img20);
+
+  const img60 = document.createElement('img');
+  img60.width = '512';
+  img60.height = '512';
+  img60.style.border = '2px solid blue';
+  img60.style.margin = '10px';
+  wrapperEl.insertAdjacentElement('beforeend', img60);
+
+  const perform = async () => {
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2010, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2010, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+
+    const imageBlob20 = await layerL520.getMap(getMapParams, ApiType.WMS);
+    img20.src = URL.createObjectURL(imageBlob20);
+
+    const imageBlob60 = await layerL560.getMap(getMapParams, ApiType.WMS);
+    img60.src = URL.createObjectURL(imageBlob60);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
 export const findTiles = () => {
   const layer = new Landsat5EOCloudLayer({ instanceId, layerId });
   const containerEl = document.createElement('pre');

--- a/stories/legacy.stories.js
+++ b/stories/legacy.stories.js
@@ -10,8 +10,19 @@ if (!process.env.S2L2A_LAYER_ID) {
   throw new Error('S2L2A_LAYER_ID environment variable is not defined!');
 }
 
+if (!process.env.EOC_INSTANCE_ID) {
+  throw new Error('EOC_INSTANCE_ID environment variable is not defined!');
+}
+
+if (!process.env.EOC_LANDSAT5_LAYER_ID) {
+  throw new Error('EOC_LANDSAT5_LAYER_ID environment variable is not defined!');
+}
+
 const instanceId = process.env.INSTANCE_ID;
 const s2l2aLayerId = process.env.S2L2A_LAYER_ID;
+
+const eocloudInstandeId = process.env.EOC_INSTANCE_ID;
+const l5LayerId = process.env.EOC_LANDSAT5_LAYER_ID;
 
 export default {
   title: 'legacyGetMap[Url]',
@@ -22,6 +33,12 @@ const baseUrl = `https://services.sentinel-hub.com/ogc/wms/${instanceId}`;
 const queryParamsEvalscript = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01T00%3A00%3A00.000Z%2F2020-01-15T23%3A59%3A59.000Z&width=512&height=512&showlogo=false&transparent=true&maxcc=20&evalscript=cmV0dXJuIFtCMDEqMi41LEIwMioyLjUsQjAzKjIuNV0%3D&evalsource=S2L2A&preview=3&bgcolor=000000`;
 const queryParamsNoEvalscript = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01T00%3A00%3A00.000Z%2F2020-01-15T23%3A59%3A59.000Z&width=512&height=512&showlogo=false&transparent=true&maxcc=20&preview=3&bgcolor=000000`;
 const queryParamsNoEvalscriptJustDates = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01%2F2020-01-15&width=512&height=512&showlogo=false&transparent=true&maxcc=20&preview=3&bgcolor=000000`;
+const queryParamsNoEvalscriptNoMaxCc = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01T00%3A00%3A00.000Z%2F2020-01-15T23%3A59%3A59.000Z&width=512&height=512&showlogo=false&transparent=true&preview=3&bgcolor=000000`;
+
+const eocBaseUrl = `https://eocloud.sentinel-hub.com/v1/wms/${eocloudInstandeId}`;
+const maxCC = 37;
+const l5QueryParams = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fpng&srs=EPSG%3A3857&layers=${l5LayerId}&bbox=1408887.3053523689%2C5165920.119625352%2C1487158.8223163893%2C5244191.636589374&time=2011-11-11T00%3A00%3A00Z%2F2011-11-11T23%3A59%3A59Z&width=512&height=512&maxcc=${maxCC}&evalsource=L5&preview=2`;
+const l5QueryParamsNoMaxCC = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fpng&srs=EPSG%3A3857&layers=${l5LayerId}&bbox=1408887.3053523689%2C5165920.119625352%2C1487158.8223163893%2C5244191.636589374&time=2011-11-11T00%3A00%3A00Z%2F2011-11-11T23%3A59%3A59Z&width=512&height=512&evalsource=L5&preview=2`;
 
 export const WMSLegacyGetMapFromUrlWithEvalscript = () => {
   const img = document.createElement('img');
@@ -230,6 +247,88 @@ export const WMSLegacyGetMapFromParamsWithDates = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
     const imageBlob = await legacyGetMapFromParams(baseUrl, params);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const WMSLegacyGetMapFromUrlNoMaxCc = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>WMS LegacyGetMapFromUrl No MaxCC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const imageBlob = await legacyGetMapFromUrl(`${baseUrl}?${queryParamsNoEvalscriptNoMaxCc}`);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const ProcessingLegacyGetMapFromUrlNoMaxCc = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>Processing LegacyGetMapFromUrl No MaxCC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const imageBlob = await legacyGetMapFromUrl(
+      `${baseUrl}?${queryParamsNoEvalscriptNoMaxCc}`,
+      ApiType.PROCESSING,
+      true,
+    );
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const Landsat5WMSLegacyGetMapFromUrlWithMaxCC = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>Landsat 5 WMS LegacyGetMapFromUrl, maxCC=${maxCC}</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const imageBlob = await legacyGetMapFromUrl(`${eocBaseUrl}?${l5QueryParams}`);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const Landsat5WMSLegacyGetMapFromUrlNoMaxCC = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>Landsat 5 WMS LegacyGetMapFromUrl, no MacCC</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const imageBlob = await legacyGetMapFromUrl(`${eocBaseUrl}?${l5QueryParamsNoMaxCC}`);
     img.src = URL.createObjectURL(imageBlob);
   };
   perform().then(() => {});

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -141,11 +141,7 @@ export const GetMapWMSMaxCC20vs60 = () => {
   const layerS2L1C60 = new S2L1CLayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `
-  <h2>GetMap: maxCC=20 vs maxCC=60</h2>
-  <p>top left part of left image should be white (cc of the tile is above 20)</p>
-  <p>TODO: this story doesn't work because there is no data for S-2 in 2014 available; should be fixed.</p>
-  `;
+  wrapperEl.innerHTML = `<h2>GetMap: maxCC=20 vs maxCC=60</h2>`;
 
   const img20 = document.createElement('img');
   img20.width = '512';
@@ -164,8 +160,8 @@ export const GetMapWMSMaxCC20vs60 = () => {
   const perform = async () => {
     const getMapParams = {
       bbox: bbox4326,
-      fromTime: new Date(Date.UTC(2014, 1 - 1, 14, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2014, 1 - 1, 14, 23, 59, 59)),
+      fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59)),
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -328,11 +328,7 @@ export const GetMapWMSMaxCC20vs60 = () => {
   const layerS2L2A60 = new S2L2ALayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `
-  <h2>GetMap: maxCC=20 vs maxCC=60</h2>
-  <p>top left part of left image should be white (cc of the tile is above 20)</p>
-  <p>TODO: this story doesn't work because there is no data for S-2 in 2014 available; should be fixed.</p>
-  `;
+  wrapperEl.innerHTML = `<h2>GetMap: maxCC=20 vs maxCC=60</h2>`;
 
   const img20 = document.createElement('img');
   img20.width = '512';
@@ -351,8 +347,8 @@ export const GetMapWMSMaxCC20vs60 = () => {
   const perform = async () => {
     const getMapParams = {
       bbox: bbox4326,
-      fromTime: new Date(Date.UTC(2014, 1 - 1, 14, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2014, 1 - 1, 14, 23, 59, 59)),
+      fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59)),
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
@@ -362,6 +358,50 @@ export const GetMapWMSMaxCC20vs60 = () => {
     img20.src = URL.createObjectURL(imageBlob20);
 
     const imageBlob60 = await layerS2L2A60.getMap(getMapParams, ApiType.WMS);
+    img60.src = URL.createObjectURL(imageBlob60);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const GetMapProcessingMaxCC20vs60 = () => {
+  const layerS2L2A20 = new S2L2ALayer({ instanceId, layerId, maxCloudCoverPercent: 20 });
+  const layerS2L2A60 = new S2L2ALayer({ instanceId, layerId, maxCloudCoverPercent: 60 });
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>GetMap: maxCC=20 vs maxCC=60</h2>`;
+
+  const img20 = document.createElement('img');
+  img20.width = '512';
+  img20.height = '512';
+  img20.style.border = '2px solid green';
+  img20.style.margin = '10px';
+  wrapperEl.insertAdjacentElement('beforeend', img20);
+
+  const img60 = document.createElement('img');
+  img60.width = '512';
+  img60.height = '512';
+  img60.style.border = '2px solid blue';
+  img60.style.margin = '10px';
+  wrapperEl.insertAdjacentElement('beforeend', img60);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 1 - 1, 15, 6, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+
+    const imageBlob20 = await layerS2L2A20.getMap(getMapParams, ApiType.PROCESSING);
+    img20.src = URL.createObjectURL(imageBlob20);
+
+    const imageBlob60 = await layerS2L2A60.getMap(getMapParams, ApiType.PROCESSING);
     img60.src = URL.createObjectURL(imageBlob60);
   };
   perform().then(() => {});


### PR DESCRIPTION
When using legacy functions, `maxcc` parameter was ignored and thus in Playground and EOBrowser the layers were created using the `maxCloudCoverPercent` from the layers definitions from services (mostly 100 on Sentinel Hub and 20 on EOCloud).
This MR passes the `maxcc` parameter (is implemented that it could also pass others, like the ones for Sentinel-1) to `makeLayer` and `makeLayers` and is used to override the default values from layers definitions.