### PR TITLE
Temporary fix to use WMS when there's a dataProduct on the layer

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -225,9 +225,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   public supportsApiType(api: ApiType): boolean {
     if (this.dataProduct) {
       return api === ApiType.WMS;
-    } else {
-      return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);
     }
+    return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {
@@ -494,6 +493,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {
     const layerParams = await this.fetchLayerParamsFromSHServiceV3(reqConfig);
     this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+    // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
     this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
   }
   protected getConvertEvalscriptBaseUrl(): string {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -491,9 +491,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return res.data;
   }
 
-  public async updateLayerFromServiceIfNeeded(reqConfig: RequestConfiguration): Promise<void> {
+  public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {
     const layerParams = await this.fetchLayerParamsFromSHServiceV3(reqConfig);
     this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+    this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
   }
   protected getConvertEvalscriptBaseUrl(): string {
     const shServiceHostname = this.getShServiceHostname();

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -223,7 +223,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   public supportsApiType(api: ApiType): boolean {
-    return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);
+    if (this.dataProduct) {
+      return api === ApiType.WMS;
+    } else {
+      return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);
+    }
   }
 
   protected getWmsGetMapUrlAdditionalParameters(): Record<string, any> {

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -108,6 +108,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     this.orthorectify = layerParams['orthorectify'];
     this.orbitDirection = layerParams['orbitDirection'] ? layerParams['orbitDirection'] : null;
     this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+    this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
   }
 
   protected async updateProcessingGetMapPayload(

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -108,6 +108,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     this.orthorectify = layerParams['orthorectify'];
     this.orbitDirection = layerParams['orbitDirection'] ? layerParams['orbitDirection'] : null;
     this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+    // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
     this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
   }
 


### PR DESCRIPTION
Temporal fix to only use WMS when a layer has a dataProduct on it. This should be reverted when the core team fixes or converts all dataProducts to V3