### PR TITLE
fix/ makeLayersSHv12: only use overrideConstructorParams if its not null + mapDataManipulation return correct blob type

### DIFF
--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -209,7 +209,7 @@ export class LayersFactory {
 
       // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
       // otherwise the default values from layer definition on the service will be used.
-      if (overrideConstructorParams.maxCloudCoverPercent) {
+      if (overrideConstructorParams && overrideConstructorParams.maxCloudCoverPercent) {
         layerInfo.settings.maxCC = overrideConstructorParams.maxCloudCoverPercent;
       }
 

--- a/src/mapDataManipulation/mapDataManipulation.ts
+++ b/src/mapDataManipulation/mapDataManipulation.ts
@@ -23,7 +23,7 @@ export async function mapDataManipulation(originalBlob: Blob, manipulatePixel: a
     const blob: Blob = await new Promise(resolve => {
       imgCanvas.toBlob(blob => {
         resolve(blob);
-      }, 'image/jpeg');
+      }, originalBlob.type);
     });
     return blob;
   } catch (e) {

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -205,6 +205,38 @@ export const S2GetMapMakeLayer = () => {
   return wrapperEl;
 };
 
+export const S2GetMapMakeLayerOverrideConstructorParamsNull = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap with WMS for Sentinel-2 L2A - makeLayer, overrideConstructorParams = null</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  // getMap is async:
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const baseUrl = `${DATASET_S2L2A.shServiceHostname}ogc/wms/${instanceId}`;
+    const layerS2L2A = await LayersFactory.makeLayer(baseUrl, s2l2aLayerId, null);
+
+    const getMapParams = {
+      bbox: bbox4326,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => { });
+
+  return wrapperEl;
+};
+
 export const WmsGetMap = () => {
   const img = document.createElement('img');
   img.width = '512';

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -211,7 +211,8 @@ export const S2GetMapMakeLayerOverrideConstructorParamsNull = () => {
   img.height = '512';
 
   const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>GetMap with WMS for Sentinel-2 L2A - makeLayer, overrideConstructorParams = null</h2>';
+  wrapperEl.innerHTML =
+    '<h2>GetMap with WMS for Sentinel-2 L2A - makeLayer, overrideConstructorParams = null</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   // getMap is async:
@@ -232,7 +233,7 @@ export const S2GetMapMakeLayerOverrideConstructorParamsNull = () => {
     const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
     img.src = URL.createObjectURL(imageBlob);
   };
-  perform().then(() => { });
+  perform().then(() => {});
 
   return wrapperEl;
 };

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -128,7 +128,7 @@ export const getMapWMSLayersFactoryOverrideConstructorParamsNull = () => {
       await LayersFactory.makeLayers(
         `${DATASET_EOCLOUD_LANDSAT5.shServiceHostname}v1/wms/${instanceId}`,
         (lId, datasetId) => layerId === lId,
-        null
+        null,
       )
     )[0];
     const getMapParams = {
@@ -142,7 +142,7 @@ export const getMapWMSLayersFactoryOverrideConstructorParamsNull = () => {
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
     img.src = URL.createObjectURL(imageBlob);
   };
-  perform().then(() => { });
+  perform().then(() => {});
 
   return wrapperEl;
 };

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -114,6 +114,39 @@ export const getMapWMSLayersFactory = () => {
   return wrapperEl;
 };
 
+export const getMapWMSLayersFactoryOverrideConstructorParamsNull = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>makeLayers with overrideConstructorParams = null</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+
+  const perform = async () => {
+    const layer = (
+      await LayersFactory.makeLayers(
+        `${DATASET_EOCLOUD_LANDSAT5.shServiceHostname}v1/wms/${instanceId}`,
+        (lId, datasetId) => layerId === lId,
+        null
+      )
+    )[0];
+    const getMapParams = {
+      bbox: bbox,
+      fromTime: new Date(Date.UTC(2010, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2010, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.JPEG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+    img.src = URL.createObjectURL(imageBlob);
+  };
+  perform().then(() => { });
+
+  return wrapperEl;
+};
+
 export const getMapWMSEvalscript = () => {
   const img = document.createElement('img');
   img.width = '512';

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -641,6 +641,7 @@ export const getMapProcessingGainGammaCheckTransparency = () => {
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = '<h2>S2L2A getMapProcessingGainGamma; Check transparency</h2>';
   wrapperEl.innerHTML += '<h4>no gain/gamma | gain | gamma | gain and gamma</h4>';
+  wrapperEl.innerHTML += '<p>Note: Whole images can be transparent if there is no data to show</p>';
   wrapperEl.style.backgroundColor = 'lightgreen';
   wrapperEl.insertAdjacentElement('beforeend', imgNoGainGamma);
   wrapperEl.insertAdjacentElement('beforeend', imgGainIs2);
@@ -676,8 +677,8 @@ export const getMapProcessingGainGammaCheckTransparency = () => {
 
     const getMapParams = {
       bbox: bbox3857,
-      fromTime: new Date(Date.UTC(2020, 5 - 1, 20, 0, 0, 0)),
-      toTime: new Date(Date.UTC(2020, 5 - 1, 20, 23, 59, 59)),
+      fromTime: new Date(Date.UTC(2020, 4 - 1, 15, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 4 - 1, 15, 23, 59, 59)),
       width: 512,
       height: 512,
       format: MimeTypes.PNG,

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -1,6 +1,6 @@
 import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
-import { S2L2ALayer, CRS_EPSG4326, BBox, MimeTypes, ApiType } from '../dist/sentinelHub.esm';
+import { S2L2ALayer, CRS_EPSG4326, BBox, MimeTypes, ApiType, CRS_EPSG3857 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -13,6 +13,13 @@ if (!process.env.S2L2A_LAYER_ID) {
 const instanceId = process.env.INSTANCE_ID;
 const layerId = process.env.S2L2A_LAYER_ID;
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+const bbox3857 = new BBox(
+  CRS_EPSG3857,
+  1174072.7544603075,
+  5009377.085697314,
+  1252344.2714243277,
+  5087648.602661333,
+);
 const geometryPolygon = {
   type: 'Polygon',
   coordinates: [
@@ -587,6 +594,93 @@ export const getMapProcessingGainGamma = () => {
       width: 512,
       height: 512,
       format: MimeTypes.JPEG,
+    };
+
+    const getMapParamsGainIs2 = { ...getMapParams, gain: gain };
+    const getMapParamsGammaIs2 = { ...getMapParams, gamma: gamma };
+    const getMapParamsGainGammaAre2 = { ...getMapParams, gain: gain, gamma: gamma };
+
+    try {
+      const imageBlobNoGainGamma = await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
+      imgNoGainGamma.src = URL.createObjectURL(imageBlobNoGainGamma);
+
+      const imageBlobGainIs2 = await layerS2L2A.getMap(getMapParamsGainIs2, ApiType.PROCESSING);
+      imgGainIs2.src = URL.createObjectURL(imageBlobGainIs2);
+
+      const imageBlobGammaIs2 = await layerS2L2A.getMap(getMapParamsGammaIs2, ApiType.PROCESSING);
+      imgGammaIs2.src = URL.createObjectURL(imageBlobGammaIs2);
+
+      const imageBlobGainGamaAre2 = await layerS2L2A.getMap(getMapParamsGainGammaAre2, ApiType.PROCESSING);
+      imgGainGammaAre2.src = URL.createObjectURL(imageBlobGainGamaAre2);
+    } catch (err) {
+      wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';
+    }
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const getMapProcessingGainGammaCheckTransparency = () => {
+  const imgNoGainGamma = document.createElement('img');
+  imgNoGainGamma.width = '256';
+  imgNoGainGamma.height = '256';
+
+  const imgGainIs2 = document.createElement('img');
+  imgGainIs2.width = '256';
+  imgGainIs2.height = '256';
+
+  const imgGammaIs2 = document.createElement('img');
+  imgGammaIs2.width = '256';
+  imgGammaIs2.height = '256';
+
+  const imgGainGammaAre2 = document.createElement('img');
+  imgGainGammaAre2.width = '256';
+  imgGainGammaAre2.height = '256';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>S2L2A getMapProcessingGainGamma; Check transparency</h2>';
+  wrapperEl.innerHTML += '<h4>no gain/gamma | gain | gamma | gain and gamma</h4>';
+  wrapperEl.style.backgroundColor = 'lightgreen';
+  wrapperEl.insertAdjacentElement('beforeend', imgNoGainGamma);
+  wrapperEl.insertAdjacentElement('beforeend', imgGainIs2);
+  wrapperEl.insertAdjacentElement('beforeend', imgGammaIs2);
+  wrapperEl.insertAdjacentElement('beforeend', imgGainGammaAre2);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    const layerS2L2A = new S2L2ALayer({
+      instanceId,
+      layerId,
+      maxCloudCoverPercent: 0,
+      evalscript: `
+        //VERSION=3
+        let minVal = 0.0;
+        let maxVal = 0.4;
+        
+        let viz = new HighlightCompressVisualizer(minVal, maxVal);
+        
+        function setup() {
+          return {
+            input: ["B04", "B03", "B02","dataMask"],
+            output: { bands: 4 }
+          };
+        }
+        
+        function evaluatePixel(samples) {
+          let val = [samples.B04, samples.B03, samples.B02,samples.dataMask];
+          return viz.processList(val);
+        }`,
+    });
+
+    const getMapParams = {
+      bbox: bbox3857,
+      fromTime: new Date(Date.UTC(2020, 5 - 1, 20, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2020, 5 - 1, 20, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.PNG,
     };
 
     const getMapParamsGainIs2 = { ...getMapParams, gain: gain };


### PR DESCRIPTION
2 small fixes:

- makeLayersSHv12 only checked if maxCloudCoverPercent from  overrideConstructorParams is not null but not if overrideConstructorParams is not null

- mapDataManipulation returned `image/jpeg` instead of the type that the provided blob had.