### PR TITLE
Only apply effects if params gain or gamma are set

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -41,21 +41,12 @@ export class AbstractLayer {
         //    to deceive the users with returning the image where gain and gamma were ignored
         // - if they are supported on the services, gain and gamma would be applied twice in getMap() if they
         //    were sent to the services in getMapUrl()
-        // This is a dirty fix, but gain and gamma need to be removed from the parameters in getMap() so the
+        // In other words, gain and gamma need to be removed from the parameters in getMap() so the
         //   errors in getMapUrl() are not triggered.
-
-        let predefinedEffects: PredefinedEffects = {};
-
-        if (params.gain) {
-          predefinedEffects.gain = params.gain;
-          params.gain = undefined;
-        }
-        if (params.gamma) {
-          predefinedEffects.gamma = params.gamma;
-          params.gamma = undefined;
-        }
-
-        const url = this.getMapUrl(params, api);
+        const paramsWithoutEffects = { ...params };
+        delete paramsWithoutEffects.gain;
+        delete paramsWithoutEffects.gamma;
+        const url = this.getMapUrl(paramsWithoutEffects, api);
         const requestConfig: AxiosRequestConfig = {
           // 'blob' responseType does not work with Node.js:
           responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
@@ -64,7 +55,12 @@ export class AbstractLayer {
         };
         const response = await axios.get(url, requestConfig);
         let blob = response.data;
-        blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
+
+        // apply effects:
+        if (params.gain || params.gamma) {
+          let predefinedEffects: PredefinedEffects = { gain: params.gain, gamma: params.gamma };
+          blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
+        }
 
         return blob;
       default:

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -57,7 +57,7 @@ export class AbstractLayer {
         let blob = response.data;
 
         // apply effects:
-        if (params.gain || params.gamma) {
+        if (params.gain !== undefined || params.gamma !== undefined) {
           let predefinedEffects: PredefinedEffects = { gain: params.gain, gamma: params.gamma };
           blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
         }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -213,7 +213,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
       let blob = await processingGetMap(shServiceHostname, updatedPayload, reqConfig);
 
-      if (params.gain || params.gamma) {
+      if (params.gain !== undefined || params.gamma !== undefined) {
         let predefinedEffects: PredefinedEffects = { gain: params.gain, gamma: params.gamma };
         blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
       }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -213,8 +213,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
       let blob = await processingGetMap(shServiceHostname, updatedPayload, reqConfig);
 
-      let predefinedEffects: PredefinedEffects = { gain: params.gain, gamma: params.gamma };
-      blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
+      if (params.gain || params.gamma) {
+        let predefinedEffects: PredefinedEffects = { gain: params.gain, gamma: params.gamma };
+        blob = await runPredefinedEffectFunctions(blob, predefinedEffects);
+      }
 
       return blob;
     }


### PR DESCRIPTION
The original issue was that `console.error` message was being output when running tests. The reason was that node.js doesn't support Canvas natively, so the image manipulation methods failed. Still, they shouldn't have been run in the first place, because parameters `gain` and `gamma` were not set in tests. 

This MR fixes the simplest of the problems above - image manipulation should not happen if parameters `gain` and `gamma` are not set.

Additionally, we avoid changing the input structure (`params`) in `AbstractLayer::getMap()`.