### PR TITLE
Add test for parseLegacyWmsGetMapParams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import {
   parseLegacyWmsGetMapParams,
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
-import { LocationIdSHv3 } from 'src/layer/const';
+import { LocationIdSHv3, GetMapParams } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
 
@@ -100,6 +100,7 @@ export {
   isAuthTokenSet,
   requestAuthToken,
   // other:
+  GetMapParams,
   ApiType,
   SUPPORTED_CRS_OBJ,
   CRS_EPSG4326,

--- a/src/layer/__tests__/legacy.ts
+++ b/src/layer/__tests__/legacy.ts
@@ -24,6 +24,8 @@ test('parseLegacyWmsGetMapParams with evalscripturl', () => {
     transparent: '1',
     bgcolor: '00000000',
     preview: 3,
+    gain: 0.7,
+    gamma: 0.9,
   };
   const {
     layers,
@@ -57,6 +59,8 @@ test('parseLegacyWmsGetMapParams with evalscripturl', () => {
     showlogo: false,
     bgcolor: '00000000',
     transparent: true,
+    gain: 0.7,
+    gamma: 0.9,
     // we are not testing unknown params field:
     unknown: getMapParams.unknown,
   };

--- a/src/layer/__tests__/legacy.ts
+++ b/src/layer/__tests__/legacy.ts
@@ -1,0 +1,72 @@
+import 'jest-setup';
+import moment from 'moment';
+
+import { parseLegacyWmsGetMapParams, BBox, CRS_EPSG3857, GetMapParams, PreviewMode } from 'src';
+
+test('parseLegacyWmsGetMapParams with evalscripturl', () => {
+  const evalscriptUrlOriginal =
+    'https://gist.githubusercontent.com/sinergise-anze/33fe78d9b1fd24d656882d7916a83d4d/raw/295b9d9f033c7e3f1e533363322d84846808564c/data-fusion-evalscript.js';
+  const wmsParams = {
+    service: 'WMS',
+    request: 'GetMap',
+    showlogo: 'false',
+    maxcc: '70',
+    time: '2019-12-22/2019-12-22',
+    crs: 'EPSG:3857',
+    format: 'image/jpeg',
+    bbox: [1282655, 5053636, 1500575, 5238596],
+    evalscripturl: evalscriptUrlOriginal,
+    evalsource: 'S2',
+    layers: '1_TRUE_COLOR',
+    width: 1700,
+    height: 605,
+    nicename: 'Sentinel-2+L1C+from+2019-12-22.jpg',
+    transparent: '1',
+    bgcolor: '00000000',
+    preview: 3,
+  };
+  const {
+    layers,
+    evalscript,
+    evalscriptUrl,
+    evalsource,
+    getMapParams,
+    otherLayerParams,
+  } = parseLegacyWmsGetMapParams(wmsParams);
+
+  expect(evalscript).toEqual(null);
+  expect(evalscriptUrl).toEqual(evalscriptUrlOriginal);
+  expect(evalsource).toEqual('S2');
+  expect(layers).toEqual('1_TRUE_COLOR');
+
+  const expectedGetMapParams: GetMapParams = {
+    bbox: new BBox(CRS_EPSG3857, 1282655, 5053636, 1500575, 5238596),
+    fromTime: moment
+      .utc('2019-12-22')
+      .startOf('day')
+      .toDate(),
+    toTime: moment
+      .utc('2019-12-22')
+      .endOf('day')
+      .toDate(),
+    format: 'image/jpeg',
+    width: 1700,
+    height: 605,
+    preview: PreviewMode.EXTENDED_PREVIEW,
+    nicename: 'Sentinel-2+L1C+from+2019-12-22.jpg',
+    showlogo: false,
+    bgcolor: '00000000',
+    transparent: true,
+    // this might not be correct - it is just how it is at the moment. Fix as needed:
+    unknown: {
+      evalscripturl:
+        'https://gist.githubusercontent.com/sinergise-anze/33fe78d9b1fd24d656882d7916a83d4d/raw/295b9d9f033c7e3f1e533363322d84846808564c/data-fusion-evalscript.js',
+      evalsource: 'S2',
+      maxcc: '70',
+    },
+  };
+  expect(getMapParams).toStrictEqual(expectedGetMapParams);
+  expect(otherLayerParams).toStrictEqual({
+    maxCloudCoverPercent: 70,
+  });
+});

--- a/src/layer/__tests__/legacy.ts
+++ b/src/layer/__tests__/legacy.ts
@@ -57,13 +57,8 @@ test('parseLegacyWmsGetMapParams with evalscripturl', () => {
     showlogo: false,
     bgcolor: '00000000',
     transparent: true,
-    // this might not be correct - it is just how it is at the moment. Fix as needed:
-    unknown: {
-      evalscripturl:
-        'https://gist.githubusercontent.com/sinergise-anze/33fe78d9b1fd24d656882d7916a83d4d/raw/295b9d9f033c7e3f1e533363322d84846808564c/data-fusion-evalscript.js',
-      evalsource: 'S2',
-      maxcc: '70',
-    },
+    // we are not testing unknown params field:
+    unknown: getMapParams.unknown,
   };
   expect(getMapParams).toStrictEqual(expectedGetMapParams);
   expect(otherLayerParams).toStrictEqual({

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -26,7 +26,7 @@ export type GetMapParams = {
   nicename?: string;
   showlogo?: boolean;
   bgcolor?: string;
-  transparent?: boolean | number;
+  transparent?: boolean;
   temporal?: boolean;
   upsampling?: Interpolator;
   downsampling?: Interpolator;

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -401,7 +401,7 @@ function previewFromParams(params: any): number {
     // (this parameter was set directly on layers for the old instances)
     return 2;
   }
-  return Math.min(Math.max(Number.parseInt(params.preview), 0), 3);
+  return Math.min(Math.max(Number.parseInt(params.preview), 0), 2);
 }
 
 function bgcolorFromParams(params: any): string {


### PR DESCRIPTION
Also fixes: 
- `GetMapParams` should be exported
- limit preview to max `2` (`3` is allowed for compatibility reason, but we should change it to `2`)
- fix data type for transparent (always boolean internally)

Note: `unknown` might not have correct content (it should probably be empty), but this is a bigger issue and I didn't want to dive into it ATM, so I have just left a comment to warn future readers.