### PR TITLE
fix gain/gamma being set to 1 if passed arguments are 0

### DIFF
--- a/src/mapDataManipulation/predefinedEffectFunctions.ts
+++ b/src/mapDataManipulation/predefinedEffectFunctions.ts
@@ -8,7 +8,7 @@ export function runGainEffectFunction(
   // change the values according to the algorithm (gain)
   const minValue = 0.0;
   const maxValue = 1.0;
-  const gain = predefinedEffects.gain ? predefinedEffects.gain : 1.0;
+  const gain = predefinedEffects.gain !== undefined ? predefinedEffects.gain : 1.0;
   const factor = gain / (maxValue - minValue);
   let offset = 0.0;
   offset = offset - factor * minValue;
@@ -23,7 +23,7 @@ export function runGammaEffectFunction(
   predefinedEffects: PredefinedEffects,
 ): RgbMappingArrays {
   // change the values according to the algorithm (gamma)
-  const gamma = predefinedEffects.gamma ? predefinedEffects.gamma : 1.0;
+  const gamma = predefinedEffects.gamma !== undefined ? predefinedEffects.gamma : 1.0;
 
   if (gamma != 1.0) {
     const transformValueWithGamma = (x: number): number => Math.pow(x, gamma);


### PR DESCRIPTION
`const gain = predefinedEffects.gain ? predefinedEffects.gain : 1.0;`
`const gamma = predefinedEffects.gamma ? predefinedEffects.gamma : 1.0;`

These two lines in `predefinedEffectFunctions.ts` needed to be corrected because they set `gain` and `gamma` to 1 if the passed arguments are 0