### PR TITLE
Fix/auth token in reqs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Getting the authentication token by calling `requestAuthToken()` with the OAuth 
   const after = isAuthTokenSet(); // true
 ```
 
-Alternatively, authentication token can be set on a per-request basis, which also overrides any global (`setAuthToken()`) token:
+Alternatively, authentication token can be set on a per-request basis, which also overrides any global token that was set by `setAuthToken`:
 
 ```javascript
   const requestsConfig = {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 - [Usage](#usage)
   - [Layers](#layers)
   - [Fetching images](#fetching-images)
+    - [Effects](#effects)
   - [Searching for data](#searching-for-data)
+  - [Requests configuration](#requests-configuration)
+  - [Getting basic statistics and histogram](#getting-basic-statistics-and-histogram)
   - [Backwards compatibility](#backwards-compatibility)
   - [Authentication for Processing API](#authentication-for-processing-api)
   - [Debugging](#debugging)
@@ -116,17 +119,7 @@ Some additional layer information can be passed to `makeLayer` and `makeLayers` 
   const layers = await LayersFactory.makeLayers('https://services.sentinel-hub.com/ogc/wms/<your-instance-id>', null, { maxCloudCoverPercent: 30 });
   ```
 
-Some information about the layer is only accessible to authenticated users. In case of Playground and EO Browser, ReCaptcha auth token is sufficient to fetch layer information (such as evalscript / dataProduct). To avoid updating every layer when auth token changes, we have a global function for updating it:
-
-```javascript
-  import { isAuthTokenSet, setAuthToken } from '@sentinel-hub/sentinelhub-js';
-
-  const before = isAuthTokenSet(); // false
-  setAuthToken(newAuthToken);
-  const after = isAuthTokenSet(); // true
-```
-
-The process of getting the authentication token is described in [Authentication for Processing API](#authentication-for-processing-api).
+Some information about the layer is only accessible to authenticated users. The process of getting the authentication token and authenticating is described in [Authentication for Processing API](#authentication-for-processing-api).
 
 ## Fetching images
 
@@ -171,8 +164,8 @@ It is also possible to determine whether a layer supports a specific ApiType:
 
 When requesting an image, effects can be applied to visually improve the image.
 To apply the effects, the `effects` param in `getMapParams` should be present, containing the desired effects.
-Supported effects are `gain`, `gamma`, `redRange`, `greenRange` and `blueRange`. 
-Effects `gain` and `gamma` accept values equal or greater than 0. 
+Supported effects are `gain`, `gamma`, `redRange`, `greenRange` and `blueRange`.
+Effects `gain` and `gamma` accept values equal or greater than 0.
 Effects `redRange`, `greenRange` and `blueRange` accept the values between 0 and 1, including both 0 and 1.
 Setting values to `redRange`, `greenRange` and `blueRange` limits the values that pixels can have for red, green and blue color component respectively.
 
@@ -350,7 +343,19 @@ Getting the authentication token by calling `requestAuthToken()` with the OAuth 
   const clientId = /* OAuth Client's id, best to put it in .env file and use it from there */;
   const clientSecret = /* OAuth client's secret, best to put it in .env file and use it from there */;
   const authToken = await requestAuthToken(clientId, clientSecret);
+
+  const before = isAuthTokenSet(); // false
   setAuthToken(authToken);
+  const after = isAuthTokenSet(); // true
+```
+
+Alternatively, authentication token can be set on a per-request basis, which also overrides any global (`setAuthToken()`) token:
+
+```javascript
+  const requestsConfig = {
+    authToken: authToken,
+  };
+  const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestsConfig);
 ```
 
 ## Debugging

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,10 +6,7 @@ export function getAuthToken(): string | null {
   return authToken;
 }
 
-export function setAuthToken(newAuthToken: string): void {
-  if (!newAuthToken) {
-    throw new Error('Parameter newAuthToken must be a non-empty string');
-  }
+export function setAuthToken(newAuthToken: string | null): void {
   authToken = newAuthToken;
 }
 

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -119,7 +119,7 @@ export class LayersFactory {
   public static async makeLayers(
     baseUrl: string,
     filterLayers: Function | null = null,
-    overrideConstructorParams?: Record<string, any>,
+    overrideConstructorParams?: Record<string, any> | null,
     reqConfig?: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const returnValue = await ensureTimeout(async innerReqConfig => {

--- a/src/layer/__tests__/auth.fixtures.ts
+++ b/src/layer/__tests__/auth.fixtures.ts
@@ -1,0 +1,22 @@
+import { S2L2ALayer, BBox, CRS_EPSG4326 } from 'src';
+import { MimeTypes } from '../const';
+
+export function constructFixtureGetMap(): Record<any, any> {
+  const layer = new S2L2ALayer({
+    evalscript: '//VERSION=3\nreturn [B02, B02, B02];',
+    maxCloudCoverPercent: 100,
+  });
+  const getMapParams = {
+    bbox: new BBox(CRS_EPSG4326, 18, 20, 20, 22),
+    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG,
+  };
+
+  return {
+    layer: layer,
+    getMapParams: getMapParams,
+  };
+}

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -1,0 +1,61 @@
+import 'jest-setup';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import { constructFixtureGetMap } from './auth.fixtures';
+import { ApiType, setAuthToken } from 'src';
+
+const mockNetwork = new MockAdapter(axios);
+
+const EXAMPLE_TOKEN1 = 'TOKEN111';
+const EXAMPLE_TOKEN2 = 'TOKEN222';
+
+test('getMap + Processing throws an exception if authToken is not set', async () => {
+  const { layer, getMapParams } = constructFixtureGetMap();
+  setAuthToken(null);
+  await expect(layer.getMap(getMapParams, ApiType.PROCESSING)).rejects.toThrow();
+});
+
+test('setAuthToken sets the Authorization header', async () => {
+  const { layer, getMapParams } = constructFixtureGetMap();
+  setAuthToken(null);
+
+  mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(200, ''); // we don't care about response, we just inspect the request
+
+  setAuthToken(EXAMPLE_TOKEN1);
+  await layer.getMap(getMapParams, ApiType.PROCESSING);
+
+  expect(mockNetwork.history.post.length).toBe(1);
+  const req = mockNetwork.history.post[0];
+  expect(req.headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN1}`);
+});
+
+test('reqConfig sets the Authorization header', async () => {
+  const { layer, getMapParams } = constructFixtureGetMap();
+  setAuthToken(null);
+
+  mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(200, ''); // we don't care about response, we just inspect the request
+
+  await layer.getMap(getMapParams, ApiType.PROCESSING, { authToken: EXAMPLE_TOKEN2 });
+
+  expect(mockNetwork.history.post.length).toBe(1);
+  const req = mockNetwork.history.post[0];
+  expect(req.headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN2}`);
+});
+
+test('reqConfig overrides setAuthToken', async () => {
+  const { layer, getMapParams } = constructFixtureGetMap();
+  setAuthToken(null);
+
+  mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(200, ''); // we don't care about response, we just inspect the request
+
+  setAuthToken(EXAMPLE_TOKEN1);
+  await layer.getMap(getMapParams, ApiType.PROCESSING, { authToken: EXAMPLE_TOKEN2 });
+
+  expect(mockNetwork.history.post.length).toBe(1);
+  const req = mockNetwork.history.post[0];
+  expect(req.headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN2}`);
+});

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -161,7 +161,7 @@ export async function processingGetMap(
   payload: ProcessingPayload,
   reqConfig: RequestConfiguration,
 ): Promise<Blob> {
-  const authToken = getAuthToken();
+  const authToken = reqConfig && reqConfig.authToken ? reqConfig.authToken : getAuthToken();
   if (!authToken) {
     throw new Error('Must be authenticated to use Processing API');
   }

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,9 +1,10 @@
 import axios, { CancelTokenSource, AxiosRequestConfig, CancelToken as CancelTokenAxios } from 'axios';
 
 export type RequestConfiguration = {
-  cancelToken?: CancelToken;
+  authToken?: string | null;
   retries?: number;
   timeout?: number | null;
+  cancelToken?: CancelToken;
 };
 
 export class CancelToken {


### PR DESCRIPTION
Sometimes apps manage more than a single auth token at a time, in which case having a single global setting is cumbersome to use. This PR adds an `authToken` setting to `RequestsConfig`, which is then used instead of global auth token.

Additional changes:
- updated README and added relevant tests
- fixed table of contents in README
- `setAuthToken` now allows `null` as token (to allow resetting of auth token)
- `overrideConstructorParams` param of `LayersFactory.makeLayers()` is explicitly allowed to be `null` (we expected `null` even before, just the definition was missing)
 