### PR TITLE
Fix: requestAuthToken() should encode URI params (client_secret)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -15,11 +15,13 @@ export function isAuthTokenSet(): boolean {
 }
 
 export async function requestAuthToken(clientId: string, clientSecret: string): Promise<any> {
-  let response = await axios({
+  const response = await axios({
     method: 'post',
     url: 'https://services.sentinel-hub.com/oauth/token',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    data: `grant_type=client_credentials&client_id=${clientId}&client_secret=${clientSecret}`,
+    data: `grant_type=client_credentials&client_id=${encodeURIComponent(
+      clientId,
+    )}&client_secret=${encodeURIComponent(clientSecret)}`,
   });
   return response.data.access_token;
 }

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { constructFixtureGetMap } from './auth.fixtures';
-import { ApiType, setAuthToken } from 'src';
+import { ApiType, setAuthToken, requestAuthToken } from 'src';
 
 const mockNetwork = new MockAdapter(axios);
 
@@ -58,4 +58,15 @@ test('reqConfig overrides setAuthToken', async () => {
   expect(mockNetwork.history.post.length).toBe(1);
   const req = mockNetwork.history.post[0];
   expect(req.headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN2}`);
+});
+
+test('requestAuthToken correctly encodes URI parameters', async () => {
+  mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(200, ''); // we only check the request
+
+  await requestAuthToken('asd,321', './*&');
+
+  expect(mockNetwork.history.post.length).toBe(1);
+  const req = mockNetwork.history.post[0];
+  expect(req.data).toBe('grant_type=client_credentials&client_id=asd%2C321&client_secret=.%2F*%26');
 });


### PR DESCRIPTION
The newly created client secrets use characters which need to be encoded properly.