### PR TITLE
Feature/list supported data products

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -16,6 +16,8 @@ import {
   Interpolator,
   Link,
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
+  SUPPORTED_DATA_PRODUCTS_PROCESSING,
+  DataProduct,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
@@ -32,7 +34,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
@@ -47,7 +49,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected layerId: string | null;
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
-  protected dataProduct: string | null;
+  protected dataProduct: DataProduct | null;
   public legend?: any[] | null;
   protected evalscriptWasConvertedToV3: boolean | null;
   public mosaickingOrder: MosaickingOrder | null; // public because ProcessingDataFusionLayer needs to read it directly
@@ -232,7 +234,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   public supportsApiType(api: ApiType): boolean {
-    if (this.dataProduct) {
+    if (this.dataProduct && !SUPPORTED_DATA_PRODUCTS_PROCESSING.includes(this.dataProduct['@id'])) {
       return api === ApiType.WMS;
     }
     return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import { PaginatedTiles, MosaickingOrder } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder, DataProduct } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 import { RequestConfiguration } from 'src/utils/cancelRequests';
@@ -13,7 +13,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -12,6 +12,7 @@ import {
   ApiType,
   GetStatsParams,
   Stats,
+  DataProduct,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -24,7 +25,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   title?: string | null;
   description?: string | null;
   collectionId?: string | null;

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -2,7 +2,14 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
+import {
+  BackscatterCoeff,
+  PaginatedTiles,
+  OrbitDirection,
+  Link,
+  LinkType,
+  DataProduct,
+} from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -34,7 +41,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection, Link, LinkType } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection, Link, LinkType, DataProduct } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -13,7 +13,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
+import { PaginatedTiles, Link, LinkType, DataProduct } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -30,7 +30,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: string | null;
+  dataProduct?: DataProduct | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/__tests__/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/__tests__/AbstractSentinelHubV3Layer.ts
@@ -1,0 +1,18 @@
+import 'jest-setup';
+
+import { AbstractSentinelHubV3Layer } from '../AbstractSentinelHubV3Layer';
+
+import { ApiType } from 'src';
+
+test.each([
+  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999' }, false],
+  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/644' }, true],
+])(
+  'AbstractSentinelHubV3Layer.supportsApiType correctly handles DataProducts supported by Processing API',
+  (dataProduct, expectedResult) => {
+    const layer = new AbstractSentinelHubV3Layer({
+      dataProduct: dataProduct,
+    });
+    expect(layer.supportsApiType(ApiType.PROCESSING)).toBe(expectedResult);
+  },
+);

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -4,7 +4,7 @@ import { ApiType, S2L1CLayer } from 'src';
 
 test.each([
   [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999' }, false],
-  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/644' }, true],
+  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643' }, true],
 ])(
   'AbstractSentinelHubV3Layer.supportsApiType correctly handles DataProducts supported by Processing API',
   (dataProduct, expectedResult) => {

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -1,8 +1,6 @@
 import 'jest-setup';
 
-import { AbstractSentinelHubV3Layer } from '../AbstractSentinelHubV3Layer';
-
-import { ApiType } from 'src';
+import { ApiType, S2L1CLayer } from 'src';
 
 test.each([
   [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999' }, false],
@@ -10,7 +8,7 @@ test.each([
 ])(
   'AbstractSentinelHubV3Layer.supportsApiType correctly handles DataProducts supported by Processing API',
   (dataProduct, expectedResult) => {
-    const layer = new AbstractSentinelHubV3Layer({
+    const layer = new S2L1CLayer({
       dataProduct: dataProduct,
     });
     expect(layer.supportsApiType(ApiType.PROCESSING)).toBe(expectedResult);

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -193,3 +193,11 @@ export type Stats = {
 };
 
 export const DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER = 50;
+
+export const SUPPORTED_DATA_PRODUCTS_PROCESSING = [
+  'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/644',
+];
+
+export type DataProduct = {
+  '@id': string;
+};

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -195,7 +195,7 @@ export type Stats = {
 export const DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER = 50;
 
 export const SUPPORTED_DATA_PRODUCTS_PROCESSING = [
-  'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/644',
+  'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643',
 ];
 
 export type DataProduct = {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -3,7 +3,14 @@ import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
 import { getAuthToken } from 'src/auth';
 
-import { MimeType, GetMapParams, Interpolator, PreviewMode, MosaickingOrder } from 'src/layer/const';
+import {
+  MimeType,
+  GetMapParams,
+  Interpolator,
+  PreviewMode,
+  MosaickingOrder,
+  DataProduct,
+} from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
@@ -37,7 +44,7 @@ export type ProcessingPayload = {
     ];
   };
   evalscript?: string;
-  dataProduct?: string;
+  dataProduct?: DataProduct;
 };
 
 export type ProcessingPayloadDatasource = {
@@ -86,7 +93,7 @@ export function createProcessingPayload(
   dataset: Dataset,
   params: GetMapParams,
   evalscript: string | null = null,
-  dataProduct: string | null = null,
+  dataProduct: DataProduct | null = null,
   mosaickingOrder: MosaickingOrder | null = null,
   upsampling: Interpolator | null = null,
   downsampling: Interpolator | null = null,


### PR DESCRIPTION
List data products, which are supported by Processing API. This means they also have transparency.

https://trello.com/c/Dh2wEqd7/520-use-v3-dataproducts

I only added S2L1C True Colour (ID:644), since we don't use `s2cloudless`.