### PR TITLE
Fix/mosaicking order failure

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -195,9 +195,15 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
           if (!layerParams) {
             layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);
           }
-          this.mosaickingOrder = layerParams.mosaickingOrder;
-          this.upsampling = layerParams.upsampling;
-          this.downsampling = layerParams.downsampling;
+          if (!this.mosaickingOrder && layerParams && layerParams.mosaickingOrder) {
+            this.mosaickingOrder = layerParams.mosaickingOrder;
+          }
+          if (!this.upsampling && layerParams && layerParams.upsampling) {
+            this.upsampling = layerParams.upsampling;
+          }
+          if (!this.downsampling && layerParams && layerParams.downsampling) {
+            this.downsampling = layerParams.downsampling;
+          }
         }
 
         await this.convertEvalscriptToV3IfNeeded(innerReqConfig);

--- a/src/layer/__tests__/mosaickingOrder.fixtures.ts
+++ b/src/layer/__tests__/mosaickingOrder.fixtures.ts
@@ -13,8 +13,7 @@ const getMapParams: GetMapParams = {
 
 const mockedLayersResponse = [
   {
-    '@id':
-      'https://services.sentinel-hub.com/configuration/v1/wms/instances/bd86bcc0-f318-402b-a145-015f85b9427e/layers/1_TRUE_COLOR',
+    '@id': 'https://services.sentinel-hub.com/configuration/v1/wms/instances/INSTANCE_ID/layers/LAYER_ID',
     id: 'LAYER_ID',
     title: 'Title',
     description: 'Description',
@@ -28,8 +27,7 @@ const mockedLayersResponse = [
     ],
     orderHint: 0,
     instance: {
-      '@id':
-        'https://services.sentinel-hub.com/configuration/v1/wms/instances/bd86bcc0-f318-402b-a145-015f85b9427e',
+      '@id': 'https://services.sentinel-hub.com/configuration/v1/wms/instances/INSTANCE_ID',
     },
     dataset: { '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L2A' },
     datasetSource: { '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L2A/sources/2' },

--- a/src/layer/__tests__/mosaickingOrder.fixtures.ts
+++ b/src/layer/__tests__/mosaickingOrder.fixtures.ts
@@ -43,9 +43,9 @@ const mockedLayersResponse = [
   },
 ];
 
-export const constructFixtureMosaickingOrder = () => {
+export function constructFixtureMosaickingOrder(): Record<any, any> {
   return {
     getMapParams: getMapParams,
     mockedLayersResponse: mockedLayersResponse,
   };
-};
+}

--- a/src/layer/__tests__/mosaickingOrder.fixtures.ts
+++ b/src/layer/__tests__/mosaickingOrder.fixtures.ts
@@ -1,0 +1,53 @@
+import { BBox, CRS_EPSG4326, GetMapParams, MimeTypes } from 'src';
+
+const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
+
+const getMapParams: GetMapParams = {
+  bbox: bbox4326,
+  fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+  toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+  width: 256,
+  height: 256,
+  format: MimeTypes.JPEG,
+};
+
+const mockedLayersResponse = [
+  {
+    '@id':
+      'https://services.sentinel-hub.com/configuration/v1/wms/instances/bd86bcc0-f318-402b-a145-015f85b9427e/layers/1_TRUE_COLOR',
+    id: 'LAYER_ID',
+    title: 'Title',
+    description: 'Description',
+    styles: [
+      {
+        name: 'default',
+        description: 'Default layer style',
+        evalScript:
+          '//VERSION=3\nlet minVal = 0.0;\nlet maxVal = 0.4;\n\nlet viz = new HighlightCompressVisualizer(minVal, maxVal);\n\nfunction setup() {\n   return {\n    input: ["B04", "B03", "B02","dataMask"],\n    output: { bands: 4 }\n  };\n}\n\nfunction evaluatePixel(samples) {\n    let val = [samples.B04, samples.B03, samples.B02,samples.dataMask];\n    return viz.processList(val);\n}',
+      },
+    ],
+    orderHint: 0,
+    instance: {
+      '@id':
+        'https://services.sentinel-hub.com/configuration/v1/wms/instances/bd86bcc0-f318-402b-a145-015f85b9427e',
+    },
+    dataset: { '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L2A' },
+    datasetSource: { '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L2A/sources/2' },
+    defaultStyleName: 'default',
+    datasourceDefaults: {
+      upsampling: 'BICUBIC',
+      mosaickingOrder: 'mostRecent',
+      temporal: false,
+      maxCloudCoverage: 100.0,
+      previewMode: 'EXTENDED_PREVIEW',
+      type: 'S2L2A',
+    },
+  },
+];
+
+export const constructFixtureMosaickingOrder = () => {
+  return {
+    getMapParams: getMapParams,
+    mockedLayersResponse: mockedLayersResponse,
+  };
+};

--- a/src/layer/__tests__/mosaickingOrder.ts
+++ b/src/layer/__tests__/mosaickingOrder.ts
@@ -1,0 +1,96 @@
+import 'jest-setup';
+import { ApiType, MosaickingOrder, S2L2ALayer, setAuthToken } from '../../../src';
+import { ProcessingPayload, ProcessingPayloadDatasource } from '../processing';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { constructFixtureMosaickingOrder } from './mosaickingOrder.fixtures';
+
+const extractDataFilterFromPayload = (payload: ProcessingPayload): any => {
+  const data: ProcessingPayloadDatasource[] = payload.input.data;
+  const processingPayloadDatasource: ProcessingPayloadDatasource = data.find(ppd => ppd.dataFilter);
+  return processingPayloadDatasource.dataFilter;
+};
+
+test('Mosaicking order is not set in constructor', async () => {
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+  });
+
+  expect(layerS2L2A.mosaickingOrder).toBeNull();
+});
+
+test('Mosaicking order is set in constructor', async () => {
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+    mosaickingOrder: MosaickingOrder.LEAST_CC,
+  });
+
+  expect(layerS2L2A.mosaickingOrder).toBe(MosaickingOrder.LEAST_CC);
+});
+
+test('Mosaicking order can be changed', async () => {
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+    mosaickingOrder: MosaickingOrder.LEAST_CC,
+  });
+  expect(layerS2L2A.mosaickingOrder).toBe(MosaickingOrder.LEAST_CC);
+  layerS2L2A.mosaickingOrder = MosaickingOrder.MOST_RECENT;
+  expect(layerS2L2A.mosaickingOrder).toBe(MosaickingOrder.MOST_RECENT);
+});
+
+test('Mosaicking order is set on instance/layer in dashboard WMS', async () => {
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+  });
+
+  const { getMapParams } = constructFixtureMosaickingOrder();
+
+  const mockNetwork = new MockAdapter(axios);
+  mockNetwork.reset();
+  mockNetwork.onGet().reply(200);
+
+  expect(layerS2L2A.mosaickingOrder).toBeNull();
+  await layerS2L2A.getMap(getMapParams, ApiType.WMS);
+  expect(mockNetwork.history.get.length).toBe(1);
+  expect(mockNetwork.history.get[0].url).not.toHaveQueryParams(['priority']);
+
+  layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+  await layerS2L2A.getMap(getMapParams, ApiType.WMS);
+  expect(mockNetwork.history.get.length).toBe(2);
+  const { url } = mockNetwork.history.get[1];
+  expect(url).toHaveQueryParams(['priority']);
+  expect(url).toHaveQueryParamsValues({ priority: MosaickingOrder.LEAST_RECENT });
+});
+
+test('Mosaicking order is set from instance/layer in dashboard processing', async () => {
+  const layerS2L2A = new S2L2ALayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+  });
+
+  const { getMapParams, mockedLayersResponse } = constructFixtureMosaickingOrder();
+
+  const mockNetwork = new MockAdapter(axios);
+  mockNetwork.reset();
+  mockNetwork.onGet().reply(200, mockedLayersResponse);
+  mockNetwork.onPost().reply(200);
+  setAuthToken('Token');
+  expect(layerS2L2A.mosaickingOrder).toBeNull();
+  await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
+  expect(mockNetwork.history.post.length).toBe(1);
+  let dataFilter = extractDataFilterFromPayload(JSON.parse(mockNetwork.history.post[0].data));
+  expect(dataFilter.mosaickingOrder).toBe(MosaickingOrder.MOST_RECENT);
+  expect(layerS2L2A.mosaickingOrder).toBe(MosaickingOrder.MOST_RECENT);
+
+  dataFilter = null;
+  layerS2L2A.mosaickingOrder = MosaickingOrder.LEAST_RECENT;
+  await layerS2L2A.getMap(getMapParams, ApiType.PROCESSING);
+  dataFilter = extractDataFilterFromPayload(JSON.parse(mockNetwork.history.post[1].data));
+  expect(mockNetwork.history.post.length).toBe(2);
+  expect(dataFilter.mosaickingOrder).toBe(MosaickingOrder.LEAST_RECENT);
+  expect(layerS2L2A.mosaickingOrder).toBe(MosaickingOrder.LEAST_RECENT);
+});


### PR DESCRIPTION
As described in these two cards [Processing mosaicking order failure](https://trello.com/c/T7QL8i4T/54-processing-mosaicking-order-failure) and [AbstractSentinelHubV3Layer::getMap() - additional params retrieved from services should be used only if they are not set](https://trello.com/c/U9qKqjmJ/60-abstractsentinelhubv3layergetmap-additional-params-retrieved-from-services-should-be-used-only-if-they-are-not-set) in some cases layer properties got always overwritten by default values retrieved from service. 
For example
- in storybook Demo-Mosaicking Order processing

Further cleanup is needed related to this issue. GetMap in AbstractSentinelHubV3Layer fetches some parameters from service. That code should be moved to `updateLayerFromServiceIfNeeded`