### PR TITLE
Use data product ID directly (do not rely on form with @id object)

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -17,7 +17,7 @@ import {
   Link,
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
   SUPPORTED_DATA_PRODUCTS_PROCESSING,
-  DataProduct,
+  DataProductId,
 } from 'src/layer/const';
 import { wmsGetMapUrl } from 'src/layer/wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
@@ -34,7 +34,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;
@@ -49,7 +49,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   protected layerId: string | null;
   protected evalscript: string | null;
   protected evalscriptUrl: string | null;
-  protected dataProduct: DataProduct | null;
+  protected dataProduct: DataProductId | null;
   public legend?: any[] | null;
   protected evalscriptWasConvertedToV3: boolean | null;
   public mosaickingOrder: MosaickingOrder | null; // public because ProcessingDataFusionLayer needs to read it directly
@@ -240,7 +240,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   public supportsApiType(api: ApiType): boolean {
-    if (this.dataProduct && !SUPPORTED_DATA_PRODUCTS_PROCESSING.includes(this.dataProduct['@id'])) {
+    if (this.dataProduct && !SUPPORTED_DATA_PRODUCTS_PROCESSING.includes(this.dataProduct)) {
       return api === ApiType.WMS;
     }
     return api === ApiType.WMS || (api === ApiType.PROCESSING && !!this.dataset);

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import { BBox } from 'src/bbox';
 
-import { PaginatedTiles, MosaickingOrder, DataProduct } from 'src/layer/const';
+import { PaginatedTiles, MosaickingOrder, DataProductId } from 'src/layer/const';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
 import { RequestConfiguration } from 'src/utils/cancelRequests';
@@ -13,7 +13,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   mosaickingOrder?: MosaickingOrder | null;
   title?: string | null;
   description?: string | null;

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -12,7 +12,7 @@ import {
   ApiType,
   GetStatsParams,
   Stats,
-  DataProduct,
+  DataProductId,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -25,7 +25,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   title?: string | null;
   description?: string | null;
   collectionId?: string | null;

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -8,7 +8,7 @@ import {
   OrbitDirection,
   Link,
   LinkType,
-  DataProduct,
+  DataProductId,
 } from 'src/layer/const';
 import { ProcessingPayload } from 'src/layer/processing';
 import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
@@ -41,7 +41,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection, Link, LinkType, DataProduct } from 'src/layer/const';
+import { PaginatedTiles, OrbitDirection, Link, LinkType, DataProductId } from 'src/layer/const';
 import { DATASET_S3SLSTR } from 'src/layer/dataset';
 import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -13,7 +13,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link, LinkType, DataProduct } from 'src/layer/const';
+import { PaginatedTiles, Link, LinkType, DataProductId } from 'src/layer/const';
 import { DATASET_S5PL2 } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
 import { ProcessingPayload } from 'src/layer/processing';
@@ -30,7 +30,7 @@ interface ConstructorParameters {
   layerId?: string | null;
   evalscript?: string | null;
   evalscriptUrl?: string | null;
-  dataProduct?: DataProduct | null;
+  dataProduct?: DataProductId | null;
   title?: string | null;
   description?: string | null;
   legendUrl?: string | null;

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -3,8 +3,8 @@ import 'jest-setup';
 import { ApiType, S2L1CLayer } from 'src';
 
 test.each([
-  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999' }, false],
-  [{ '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643' }, true],
+  ['https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999', false],
+  ['https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643', true],
 ])(
   'AbstractSentinelHubV3Layer.supportsApiType correctly handles DataProducts supported by Processing API',
   (dataProduct, expectedResult) => {

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -194,10 +194,8 @@ export type Stats = {
 
 export const DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER = 50;
 
-export const SUPPORTED_DATA_PRODUCTS_PROCESSING = [
+export type DataProductId = string;
+
+export const SUPPORTED_DATA_PRODUCTS_PROCESSING: DataProductId[] = [
   'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643',
 ];
-
-export type DataProduct = {
-  '@id': string;
-};

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -9,7 +9,7 @@ import {
   Interpolator,
   PreviewMode,
   MosaickingOrder,
-  DataProduct,
+  DataProductId,
 } from 'src/layer/const';
 import { Dataset } from 'src/layer/dataset';
 import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
@@ -19,6 +19,10 @@ enum PreviewModeString {
   PREVIEW = 'PREVIEW',
   EXTENDED_PREVIEW = 'EXTENDED_PREVIEW',
 }
+
+type DataProduct = {
+  '@id': DataProductId;
+};
 
 export type ProcessingPayload = {
   input: {
@@ -93,7 +97,7 @@ export function createProcessingPayload(
   dataset: Dataset,
   params: GetMapParams,
   evalscript: string | null = null,
-  dataProduct: DataProduct | null = null,
+  dataProduct: DataProductId | null = null,
   mosaickingOrder: MosaickingOrder | null = null,
   upsampling: Interpolator | null = null,
   downsampling: Interpolator | null = null,
@@ -154,7 +158,9 @@ export function createProcessingPayload(
   if (evalscript) {
     payload.evalscript = evalscript;
   } else if (dataProduct) {
-    payload.dataProduct = dataProduct;
+    payload.dataProduct = {
+      '@id': dataProduct,
+    };
     payload.evalscript = ''; // evalscript must not be null
   } else {
     throw new Error('Either evalscript or dataProduct should be defined with Processing API');


### PR DESCRIPTION
Having a basic data type instead of an object is beneficial in many cases (for example, serialization is not needed). Also, relying on service representation of an ID might not be a best idea. This PR makes sure that `DataProductId` is used internally.