### PR TITLE
Feature/huge maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,29 @@ Alternatively, authentication token can be set on a per-request basis, which als
   const img = await layer.getMap(getMapParams, ApiType.PROCESSING, requestsConfig);
 ```
 
+## Utility functions
+
+### Async conversion between Blob and Canvas
+
+Function `drawBlobOnCanvas` allows drawing a Blob on existing canvas element:
+
+```javascript
+  const blob = await layer.getMap(params, ApiType.WMS);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = params.width;
+  canvas.height = params.height;
+  const ctx = canvas.getContext('2d');
+
+  await drawBlobOnCanvas(ctx, blob, 0, 0);
+```
+
+Function `canvasToBlob` converts an existing canvas to Blob:
+
+```javascript
+  const blob = await canvasToBlob(canvas);
+```
+
 ## Debugging
 
 This library is an abstraction layer that provides nice interface for accessing the underlying services, which simplifies development - but when requests fail, it is sometimes difficult to understand why. To enable easier debugging, `setDebugEnabled` can be used:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ When retrieving an image URL (via `getMapUrl()`) with effects applied, an error 
   const imageBlob2 = await layer.getMap(getMapParamsWithEffects, ApiType.PROCESSING);
 ```
 
+### Stitching images
+
+Services limit the size of the output image per request (5000px for OGC and 2500px for Processing API). If we need a bigger image, we can issue multiple requests and stitch the results together in a canvas. A utility method `getHugeMap` allows us to do that seemlessly.
+
+IMPORTANT: be careful with the image sizes as a big image could consume a lot of processing units. There is no limit imposed by this method.
+
+```javascript
+  const imageBlob = await layer.getHugeMap(getMapParams, ApiType.PROCESSING, reqConfig);
+```
+
 ## Searching for data
 
 Searching for the data is a domain either of a _layer_ or its _dataset_ (if available). This library supports different services, some of which (ProbaV and GIBS for example) specify availability dates _per layer_ and not dataset.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ When retrieving an image URL (via `getMapUrl()`) with effects applied, an error 
 
 ### Stitching images
 
-Services limit the size of the output image per request (5000px for OGC and 2500px for Processing API). If we need a bigger image, we can issue multiple requests and stitch the results together in a canvas. A utility method `getHugeMap` allows us to do that seemlessly.
+Services limit the size of the output image per request (5000px for OGC and 2500px for Processing API). If we need a bigger image, we can issue multiple requests and stitch the results together in a canvas. A utility method `getHugeMap` allows us to do that seamlessly.
 
 IMPORTANT: be careful with the image sizes as a big image could consume a lot of processing units. There is no limit imposed by this method.
 
@@ -372,7 +372,7 @@ Alternatively, authentication token can be set on a per-request basis, which als
 
 ### Async conversion between Blob and Canvas
 
-Function `drawBlobOnCanvas` allows drawing a Blob on existing canvas element:
+Function `drawBlobOnCanvas` allows drawing a `Blob` on existing canvas element:
 
 ```javascript
   const blob = await layer.getMap(params, ApiType.WMS);
@@ -385,7 +385,7 @@ Function `drawBlobOnCanvas` allows drawing a Blob on existing canvas element:
   await drawBlobOnCanvas(ctx, blob, 0, 0);
 ```
 
-Function `canvasToBlob` converts an existing canvas to Blob:
+Function `canvasToBlob` converts an existing canvas to `Blob`:
 
 ```javascript
   const blob = await canvasToBlob(canvas);

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ When retrieving an image URL (via `getMapUrl()`) with effects applied, an error 
 
 ### Stitching images
 
-Services limit the size of the output image per request (5000px for OGC and 2500px for Processing API). If we need a bigger image, we can issue multiple requests and stitch the results together in a canvas. A utility method `getHugeMap` allows us to do that seamlessly.
+Services limit the size of the output image per request (2500px in each direction). If we need a bigger image, we can issue multiple requests and stitch the results together in a canvas. A utility method `getHugeMap` allows us to do that seamlessly.
 
 IMPORTANT: be careful with the image sizes as a big image could consume a lot of processing units. There is no limit imposed by this method.
 
@@ -385,7 +385,7 @@ Function `drawBlobOnCanvas` allows drawing a `Blob` on existing canvas element:
   await drawBlobOnCanvas(ctx, blob, 0, 0);
 ```
 
-Function `canvasToBlob` converts an existing canvas to `Blob`:
+Function `canvasToBlob` converts the provided canvas to `Blob`:
 
 ```javascript
   const blob = await canvasToBlob(canvas);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { LocationIdSHv3, GetMapParams, LinkType } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
 import { wmsGetMapUrl as _wmsGetMapUrl } from 'src/layer/wms';
+import { drawBlobOnCanvas, canvasToBlob } from 'src/utils/canvas';
 
 import { Effects, ColorRange } from 'src/mapDataManipulation/const';
 
@@ -125,6 +126,8 @@ export {
   CancelToken,
   isCancelled,
   RequestConfiguration,
+  drawBlobOnCanvas,
+  canvasToBlob,
   // legacy:
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -106,8 +106,8 @@ export class AbstractLayer {
       const chunkHeight = Math.ceil(height / ySplitBy);
 
       const { minX: lng0, minY: lat0, maxX: lng1, maxY: lat1 } = bbox;
-      const xToLng = (x: number) => Math.min(lng0, lng1) + (x / width) * Math.abs(lng1 - lng0);
-      const yToLat = (y: number) => Math.max(lat0, lat1) - (y / height) * Math.abs(lat1 - lat0);
+      const xToLng = (x: number): number => Math.min(lng0, lng1) + (x / width) * Math.abs(lng1 - lng0);
+      const yToLat = (y: number): number => Math.max(lat0, lat1) - (y / height) * Math.abs(lat1 - lat0);
 
       for (let x = 0; x < width; x += chunkWidth) {
         const xTo = Math.min(x + chunkWidth, width);

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3, MimeType } from 'src/layer/const';
 import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 export type GetCapabilitiesXml = {

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3, MimeType } from 'src/layer/const';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
 import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
 
 export type GetCapabilitiesXml = {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,0 +1,26 @@
+import { MimeType } from 'src/layer/const';
+
+export async function drawBlobOnCanvas(
+  ctx: CanvasRenderingContext2D,
+  blob: Blob,
+  x: number = 0,
+  y: number = 0,
+) {
+  const objectURL = URL.createObjectURL(blob);
+  try {
+    // wait until objectUrl is drawn on the image, so you can safely draw img on canvas:
+    const imgDrawn: HTMLImageElement = await new Promise((resolve, reject) => {
+      const img = document.createElement('img');
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = objectURL;
+    });
+    ctx.drawImage(imgDrawn, x, y);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
+}
+
+export async function canvasToBlob(canvas: HTMLCanvasElement, mimeFormat: MimeType): Promise<Blob> {
+  return await new Promise(resolve => canvas.toBlob(resolve, mimeFormat));
+}

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -5,7 +5,7 @@ export async function drawBlobOnCanvas(
   blob: Blob,
   x: number = 0,
   y: number = 0,
-) {
+): Promise<void> {
   const objectURL = URL.createObjectURL(blob);
   try {
     // wait until objectUrl is drawn on the image, so you can safely draw img on canvas:


### PR DESCRIPTION
- added `getHugeMap` which allows us to seamlessly request images which are bigger than what service provides (useful for high-res print image download and for pins story builder, both in EO Browser)
- exposed `canvasToBlob` and `drawBlobOnCanvas` functions (needed by `getHugeMap`; these methods are duplicated in numerous other places in EO Browser and other apps - hoping this to be the implementation that will be used everywhere)