### PR TITLE
Fix / legacyGetMap... functions additional params

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,11 +379,14 @@ If we already have a WMS GetMap URL, we can use it directly:
   const imageBlob4 = await legacyGetMapFromUrl(fullUrlWithWmsQueryString, ApiType.PROCESSING);
 ```
 
-Gain and gamma effects are also supported in these two functions as a part of `wmsParams` or `fullUrlWithWmsQueryString`.
+`legacyGetMapFromParams` and `legacyGetMapFromUrl` accept all parameters that are supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) or [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/), either as a property inside `wmsParams` object or as a substring of the `fullUrlWithWmsQueryString`.
+Example params: `gain`, `gamma`, `upsampling`, `downsampling`, etc.
 
-`legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are not supported in WMS GetMap URL but are supported.
-Parameters that are needed when instantiating a `Layer` can be passed inside of `overrideLayerConstructorParams`.
-Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`.
+`legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are used for creating a dataset-specific layer object or for getting the data with `getMap()` function but are not supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) or [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/).
+- Parameters that are used for instantiating a `Layer` can be passed inside of `overrideLayerConstructorParams`. 
+Example params: dataset-specific params for  creating [layers](#Layers)
+- Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`. 
+Example params: [effects](#Effects)
 
 ```javascript
   const imageBlob5 = await legacyGetMapFromParams(

--- a/README.md
+++ b/README.md
@@ -379,14 +379,14 @@ If we already have a WMS GetMap URL, we can use it directly:
   const imageBlob4 = await legacyGetMapFromUrl(fullUrlWithWmsQueryString, ApiType.PROCESSING);
 ```
 
-`legacyGetMapFromParams` and `legacyGetMapFromUrl` accept all parameters that are supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) or [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/), either as a property inside `wmsParams` object or as a substring of the `fullUrlWithWmsQueryString`.
+`legacyGetMapFromParams` and `legacyGetMapFromUrl` accept all parameters that are supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) and [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/), either as a property inside `wmsParams` object or as a substring of the `fullUrlWithWmsQueryString`.
 Example params: `gain`, `gamma`, `upsampling`, `downsampling`, etc.
 
-`legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are used for creating a dataset-specific layer object or for getting the data with `getMap()` function but are not supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) or [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/).
+`legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are used for creating a dataset-specific layer object or for getting the data with `getMap()` function but are not supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) and [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/).
 - Parameters that are used for instantiating a `Layer` can be passed inside of `overrideLayerConstructorParams`. 
-Example params: dataset-specific params for  creating [layers](#Layers)
+Example params: dataset-specific params for  creating [layers](#layers)
 - Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`. 
-Example params: [effects](#Effects)
+Example params: [effects](#effects)
 
 ```javascript
   const imageBlob5 = await legacyGetMapFromParams(

--- a/README.md
+++ b/README.md
@@ -325,6 +325,21 @@ If we already have a WMS GetMap URL, we can use it directly:
 
 Gain and gamma effects are also supported in these two functions as a part of `wmsParams` or `fullUrlWithWmsQueryString`.
 
+`legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are not supported in WMS GetMap URL but are supported.
+Parameters that are needed when instantiating a `Layer` can be passed inside of `overrideLayerConstructorParams`.
+Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`.
+
+```javascript
+  const imageBlob5 = await legacyGetMapFromParams(
+    rootUrl, 
+    wmsParams, 
+    ApiType.PROCESSING
+    fallbackToWmsApi,
+    overrideLayerConstructorParams,
+    overrideGetMapParams,
+  );
+```
+
 ## Authentication for Processing API
 
 Requests to Processing API need to be authenticated.

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ If we already have a WMS GetMap URL, we can use it directly:
 Example params: `gain`, `gamma`, `upsampling`, `downsampling`, etc.
 
 `legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are used for creating a dataset-specific layer object or for getting the data with `getMap()` function but are not supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) and [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/).
-- Parameters that are used for instantiating a `Layer` can be passed inside of `overrideLayerConstructorParams`. 
-Example params: dataset-specific params for  creating [layers](#layers)
+- Parameters which would be used for creating a `Layer` can be passed inside of `overrideLayerConstructorParams`. 
+Example params: dataset-specific params for creating [layers](#layers)
 - Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`. 
 Example params: [effects](#effects)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import {
   parseLegacyWmsGetMapParams,
 } from 'src/legacyCompat';
 import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
-import { LocationIdSHv3, GetMapParams, LinkType } from 'src/layer/const';
+import { LocationIdSHv3, GetMapParams, LinkType, OverrideGetMapParams } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
 import { wmsGetMapUrl as _wmsGetMapUrl } from 'src/layer/wms';
@@ -104,6 +104,7 @@ export {
   requestAuthToken,
   // other:
   GetMapParams,
+  OverrideGetMapParams,
   LinkType,
   ApiType,
   SUPPORTED_CRS_OBJ,

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -38,6 +38,8 @@ export type GetMapParams = {
   };
 };
 
+export type OverrideGetMapParams = Partial<GetMapParams>;
+
 export enum Interpolator {
   BILINEAR = 'BILINEAR',
   BICUBIC = 'BICUBIC',

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -34,8 +34,8 @@ export async function legacyGetMapFromParams(
   wmsParams: Record<string, any>,
   api: ApiType = ApiType.WMS,
   fallbackToWmsApi: boolean = false,
-  overrideGetMapParams?: OverrideGetMapParams,
   overrideLayerConstructorParams?: Record<string, any>,
+  overrideGetMapParams?: OverrideGetMapParams,
 ): Promise<Blob> {
   const {
     layers,

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -13,6 +13,8 @@ export async function legacyGetMapFromUrl(
   urlWithQueryParams: string,
   api: ApiType = ApiType.WMS,
   fallbackToWmsApi: boolean = false,
+  overrideLayerConstructorParams?: Record<string, any>,
+  overrideGetMapParams?: OverrideGetMapParams,
 ): Promise<Blob> {
   const url = new URL(urlWithQueryParams);
   let params: Record<string, any> = {};
@@ -20,7 +22,14 @@ export async function legacyGetMapFromUrl(
     params[key] = value;
   });
   const baseUrl = `${url.origin}${url.pathname}`;
-  return legacyGetMapFromParams(baseUrl, params, api, fallbackToWmsApi);
+  return legacyGetMapFromParams(
+    baseUrl,
+    params,
+    api,
+    fallbackToWmsApi,
+    overrideLayerConstructorParams,
+    overrideGetMapParams,
+  );
 }
 
 export function legacyGetMapWmsUrlFromParams(baseUrl: string, wmsParams: Record<string, any>): string {

--- a/stories/legacyGetMapFromParams.stories.js
+++ b/stories/legacyGetMapFromParams.stories.js
@@ -54,6 +54,7 @@ const basicParams = {
   crs: 'EPSG:3857',
   preview: 2,
   bgcolor: '000000',
+  evalscript: 'cmV0dXJuIFtCMDQqMi41LEIwMyoyLjUsQjAyKjIuNV07',
 };
 // EOBrowser example:
 // https://apps.sentinel-hub.com/eo-browser/?lat=40.5486&lng=-3.7824&zoom=12&time=2020-02-23&preset=1_TRUE_COLOR&gainOverride=1&gammaOverride=1&redRangeOverride=[0,1]&greenRangeOverride=[0,1]&blueRangeOverride=[0,1]&datasource=Sentinel-2%20L2A
@@ -197,17 +198,17 @@ export const ProcessingLegacyGetMapFromParamsRGB = () => {
       const imageBlobNoRGB = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING);
       imgNoRGB.src = URL.createObjectURL(imageBlobNoRGB);
 
-      const imageBlobR = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+      const imageBlobR = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, null, {
         effects: { redRange: redRange },
       });
       imgR.src = URL.createObjectURL(imageBlobR);
 
-      const imageBlobG = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+      const imageBlobG = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, null, {
         effects: { greenRange: greenRange },
       });
       imgG.src = URL.createObjectURL(imageBlobG);
 
-      const imageBlobB = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+      const imageBlobB = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, null, {
         effects: { blueRange: blueRange },
       });
       imgB.src = URL.createObjectURL(imageBlobB);
@@ -324,24 +325,14 @@ export const ProcessingLegacyGetMapFromParamsMinQaS5p = () => {
       const imageBlobDefaultMinQa = await legacyGetMapFromParams(baseUrl, paramsS5P, ApiType.PROCESSING);
       imgDefaultMinQa.src = URL.createObjectURL(imageBlobDefaultMinQa);
 
-      const imageBlobMinQa0 = await legacyGetMapFromParams(
-        baseUrl,
-        paramsS5P,
-        ApiType.PROCESSING,
-        null,
-        null,
-        { minQa: 0 },
-      );
+      const imageBlobMinQa0 = await legacyGetMapFromParams(baseUrl, paramsS5P, ApiType.PROCESSING, null, {
+        minQa: 0,
+      });
       imgMinQa0.src = URL.createObjectURL(imageBlobMinQa0);
 
-      const imageBlobMinQa100 = await legacyGetMapFromParams(
-        baseUrl,
-        paramsS5P,
-        ApiType.PROCESSING,
-        null,
-        null,
-        { minQa: 100 },
-      );
+      const imageBlobMinQa100 = await legacyGetMapFromParams(baseUrl, paramsS5P, ApiType.PROCESSING, null, {
+        minQa: 100,
+      });
       imgMinQa100.src = URL.createObjectURL(imageBlobMinQa100);
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';

--- a/stories/legacyGetMapFromParams.stories.js
+++ b/stories/legacyGetMapFromParams.stories.js
@@ -36,10 +36,9 @@ const upsamplingNearest = Interpolator.NEAREST;
 const upsamplingBilinear = Interpolator.BILINEAR;
 const upsamplingBicubic = Interpolator.BICUBIC;
 
-const redRange = [0.2, 0.8];
-const greenRange = [0.2, 0.8];
-const blueRange = [0.2, 0.8];
-const minQa = 25;
+const redRange = { from: 0.2, to: 0.8 };
+const greenRange = { from: 0.2, to: 0.8 };
+const blueRange = { from: 0.2, to: 0.8 };
 
 const timeString = '2019-10-01/2020-04-23';
 
@@ -78,7 +77,6 @@ const paramsS5P = {
   showlogo: false,
   width: 512,
   height: 512,
-  bbox: [1400000, 5100000, 1600000, 5300000],
   format: 'image/jpeg',
   crs: 'EPSG:3857',
   preview: 2,
@@ -163,6 +161,65 @@ export const ProcessingLegacyGetMapFromParamsGainGamma = () => {
   return wrapperEl;
 };
 
+export const ProcessingLegacyGetMapFromParamsRGB = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+
+  const imgNoRGB = document.createElement('img');
+  imgNoRGB.width = '256';
+  imgNoRGB.height = '256';
+
+  const imgR = document.createElement('img');
+  imgR.width = '256';
+  imgR.height = '256';
+
+  const imgG = document.createElement('img');
+  imgG.width = '256';
+  imgG.height = '256';
+
+  const imgB = document.createElement('img');
+  imgB.width = '256';
+  imgB.height = '256';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>Processing LegacyGetMapFromUrl With WMS Fallback</h2>';
+  wrapperEl.innerHTML += '<h4>no RGB | R | G | B</h4>';
+  wrapperEl.insertAdjacentElement('beforeend', imgNoRGB);
+  wrapperEl.insertAdjacentElement('beforeend', imgR);
+  wrapperEl.insertAdjacentElement('beforeend', imgG);
+  wrapperEl.insertAdjacentElement('beforeend', imgB);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    try {
+      const imageBlobNoRGB = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING);
+      imgNoRGB.src = URL.createObjectURL(imageBlobNoRGB);
+
+      const imageBlobR = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+        effects: { redRange: redRange },
+      });
+      imgR.src = URL.createObjectURL(imageBlobR);
+
+      const imageBlobG = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+        effects: { greenRange: greenRange },
+      });
+      imgG.src = URL.createObjectURL(imageBlobG);
+
+      const imageBlobB = await legacyGetMapFromParams(baseUrl, basicParams, ApiType.PROCESSING, null, {
+        effects: { blueRange: blueRange },
+      });
+      imgB.src = URL.createObjectURL(imageBlobB);
+    } catch (err) {
+      wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';
+    }
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
 export const ProcessingLegacyGetMapFromParamsUpsamplingS5p = () => {
   if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
     return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
@@ -195,6 +252,7 @@ export const ProcessingLegacyGetMapFromParamsUpsamplingS5p = () => {
   const perform = async () => {
     await setAuthTokenWithOAuthCredentials();
 
+    paramsS5P.bbox = [1400000, 5100000, 1600000, 5300000];
     paramsS5P.evalscript =
       'dmFyIHZhbCA9IENMT1VEX0JBU0VfUFJFU1NVUkU7CiAgICAgIHZhciBtaW5WYWwgPSAxMDAwMC4wOwogICAgICB2YXIgbWF4VmFsID0gMTEwMDAwLjA7CiAgICAgIHZhciBkaWZmID0gbWF4VmFsIC0gbWluVmFsOwogICAgICB2YXIgbGltaXRzID0gW21pblZhbCwgbWluVmFsICsgMC4xMjUgKiBkaWZmLCBtaW5WYWwgKyAwLjM3NSAqIGRpZmYsIG1pblZhbCArIDAuNjI1ICogZGlmZiwgbWluVmFsICsgMC44NzUgKiBkaWZmLCBtYXhWYWxdOwogICAgICB2YXIgY29sb3JzID0gW1swLCAwLCAwLjVdLCBbMCwgMCwgMV0sIFswLCAxLCAxXSwgWzEsIDEsIDBdLCBbMSwgMCwgMF0sIFswLjUsIDAsIDBdXTsKICAgICAgcmV0dXJuIGNvbG9yQmxlbmQodmFsLCBsaW1pdHMsIGNvbG9ycyk7';
 
@@ -272,9 +330,7 @@ export const ProcessingLegacyGetMapFromParamsMinQaS5p = () => {
         ApiType.PROCESSING,
         null,
         null,
-        {
-          minQa: 0,
-        },
+        { minQa: 0 },
       );
       imgMinQa0.src = URL.createObjectURL(imageBlobMinQa0);
 
@@ -284,9 +340,7 @@ export const ProcessingLegacyGetMapFromParamsMinQaS5p = () => {
         ApiType.PROCESSING,
         null,
         null,
-        {
-          minQa: 100,
-        },
+        { minQa: 100 },
       );
       imgMinQa100.src = URL.createObjectURL(imageBlobMinQa100);
     } catch (err) {

--- a/stories/legacyGetMapFromUrl.stories.js
+++ b/stories/legacyGetMapFromUrl.stories.js
@@ -1,5 +1,5 @@
 import { setAuthTokenWithOAuthCredentials } from './storiesUtils';
-import { legacyGetMapFromUrl, ApiType } from '../dist/sentinelHub.esm';
+import { legacyGetMapFromUrl, ApiType, Interpolator } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
   throw new Error('INSTANCE_ID environment variable is not defined!');
@@ -15,13 +15,17 @@ const s2l2aLayerId = process.env.S2L2A_LAYER_ID;
 const gain = 2;
 const gamma = 2;
 
+const redRange = { from: 0.2, to: 0.8 };
+const greenRange = { from: 0.2, to: 0.8 };
+const blueRange = { from: 0.2, to: 0.8 };
+
 export default {
   title: 'legacyGetMapFromUrl',
 };
 
 const baseUrl = `https://services.sentinel-hub.com/ogc/wms/${instanceId}`;
 
-const queryParams = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01T00%3A00%3A00.000Z%2F2020-01-15T23%3A59%3A59.000Z&width=512&height=512&showlogo=false&transparent=true&maxcc=20&preview=3&bgcolor=000000`;
+const queryParams = `version=1.1.1&service=WMS&request=GetMap&format=image%2Fjpeg&crs=EPSG%3A3857&layers=${s2l2aLayerId}&bbox=-430493.3433021127%2C4931105.568733289%2C-410925.4640611076%2C4950673.447974297&time=2019-07-01T00%3A00%3A00.000Z%2F2020-01-15T23%3A59%3A59.000Z&width=512&height=512&showlogo=false&transparent=true&maxcc=20&preview=3&bgcolor=000000&evalscript=cmV0dXJuIFtCMDQqMi41LEIwMyoyLjUsQjAyKjIuNV07`;
 const queryParamsGain = queryParams + `&gain=${gain}`;
 const queryParamsGamma = queryParams + `&gamma=${gamma}`;
 const queryParamsGainGamma = queryParams + `&gain=${gain}` + `&gamma=${gamma}`;
@@ -112,6 +116,77 @@ export const ProcessingLegacyGetMapFromUrlGainGamma = () => {
         true,
       );
       imgGainGammaAre2.src = URL.createObjectURL(imageBlobGainGamaAre2);
+    } catch (err) {
+      wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';
+    }
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const ProcessingLegacyGetMapFromUrlRGB = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+
+  const imgNoRGB = document.createElement('img');
+  imgNoRGB.width = '256';
+  imgNoRGB.height = '256';
+
+  const imgR = document.createElement('img');
+  imgR.width = '256';
+  imgR.height = '256';
+
+  const imgG = document.createElement('img');
+  imgG.width = '256';
+  imgG.height = '256';
+
+  const imgB = document.createElement('img');
+  imgB.width = '256';
+  imgB.height = '256';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>Processing LegacyGetMapFromUrl With WMS Fallback</h2>';
+  wrapperEl.innerHTML += '<h4>no RGB | R | G | B</h4>';
+  wrapperEl.insertAdjacentElement('beforeend', imgNoRGB);
+  wrapperEl.insertAdjacentElement('beforeend', imgR);
+  wrapperEl.insertAdjacentElement('beforeend', imgG);
+  wrapperEl.insertAdjacentElement('beforeend', imgB);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+
+    try {
+      const imageBlobNoRGB = await legacyGetMapFromUrl(`${baseUrl}?${queryParams}`, ApiType.PROCESSING, true);
+      imgNoRGB.src = URL.createObjectURL(imageBlobNoRGB);
+
+      const imageBlobR = await legacyGetMapFromUrl(
+        `${baseUrl}?${queryParams}`,
+        ApiType.PROCESSING,
+        true,
+        null,
+        { effects: { redRange: redRange } },
+      );
+      imgR.src = URL.createObjectURL(imageBlobR);
+
+      const imageBlobG = await legacyGetMapFromUrl(
+        `${baseUrl}?${queryParams}`,
+        ApiType.PROCESSING,
+        true,
+        null,
+        { effects: { greenRange: greenRange } },
+      );
+      imgG.src = URL.createObjectURL(imageBlobG);
+
+      const imageBlobB = await legacyGetMapFromUrl(
+        `${baseUrl}?${queryParams}`,
+        ApiType.PROCESSING,
+        true,
+        null,
+        { effects: { blueRange: blueRange } },
+      );
+      imgB.src = URL.createObjectURL(imageBlobB);
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';
     }


### PR DESCRIPTION
Adding support for params in `legacyGetMapFromParams`, `legacyGetMapFromUrl` which are not supported in `wmsParams`.

Currently divided to 2 params:
- `overrideLayerConstructorParams`: params that are used when constructing the `Layer` (or changing the `Layer`'s property)
- `overrideGetMapParams`: params that are supported in `GetMapParams` for `Layer.getMap()`

