### PR TITLE
set return type for BYOCLayer.getAvailableBands()

### DIFF
--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -13,6 +13,7 @@ import {
   GetStatsParams,
   Stats,
   DataProductId,
+  BYOCBand,
 } from 'src/layer/const';
 import { DATASET_BYOC } from 'src/layer/dataset';
 import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
@@ -194,7 +195,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return `${super.getConvertEvalscriptBaseUrl()}&byocCollectionId=${this.collectionId}`;
   }
 
-  public async getAvailableBands(reqConfig?: RequestConfiguration): Promise<void> {
+  public async getAvailableBands(reqConfig?: RequestConfiguration): Promise<BYOCBand[]> {
     const bandsResponseData = await ensureTimeout(async innerReqConfig => {
       if (this.collectionId === null) {
         throw new Error('Parameter collectionId is not set');

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -199,3 +199,8 @@ export type DataProductId = string;
 export const SUPPORTED_DATA_PRODUCTS_PROCESSING: DataProductId[] = [
   'https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/643',
 ];
+
+export type BYOCBand = {
+  name: string;
+  sampleType: string;
+};

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -510,3 +510,29 @@ export const findDatesUTCAuth = () => {
 
   return wrapperEl;
 };
+
+export const getAvailableBandsAuth = () => {
+  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
+    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
+  }
+  if (!process.env.BYOC_COLLECTION_ID) {
+    throw new Error('BYOC_COLLECTION_ID environment variable is not defined!');
+  }
+
+  const containerEl = document.createElement('pre');
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>getAvailableBands for BYOC</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', containerEl);
+
+  const perform = async () => {
+    await setAuthTokenWithOAuthCredentials();
+    const layer = new BYOCLayer({ instanceId, layerId, collectionId: process.env.BYOC_COLLECTION_ID });
+
+    const availableBands = await layer.getAvailableBands();
+    renderTilesList(containerEl, availableBands);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};


### PR DESCRIPTION
`BYOCLayer.getAvailableBands()` had return type `Promise<void>` although it returned an array of objects that represent the bands of the BYOC layer.

This MR fixes the return type of `BYOCLayer.getAvailableBands()`

The type is set according to the [SH docs](https://docs.sentinel-hub.com/api/latest/reference/#operation/metadata_byoc_id)