### PR TITLE
Feature/cache targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,33 @@ const requestsConfig = {
 };
 ```
 
+Requests can be cached to [CACHE_API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) or to memory, where the target can be specified with.
+```
+  const requestsConfig = {
+    cache: {
+      expiresIn: 5000,
+      targets: [CacheTarget.CACHE_API],
+    },
+  };
+```
+```
+  const requestsConfig = {
+    cache: {
+      expiresIn: 5000,
+      targets: [CacheTarget.MEMORY],
+    },
+  };
+```
+A list of targets can be provided which is ordered by priority, and the first available target in the list will be used. This example will fallback to caching to memory if [CACHE_API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) is not available:
+
+```
+  const requestsConfig = {
+    cache: {
+      expiresIn: 5000,
+      targets: [CacheTarget.CACHE_API, CacheTarget.MEMORY],
+    },
+  };
+```
 ## Getting basic statistics and histogram
 
 Getting basic statistics (mean, min, max, standard deviation) and a histogram for a geometry (Polygon or MultiPolygon).

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEUL
 import { LocationIdSHv3, GetMapParams, LinkType } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
-import { CacheTarget } from 'src/utils/Cache';
+import { CacheTarget, invalidateCaches } from 'src/utils/Cache';
 import { wmsGetMapUrl as _wmsGetMapUrl } from 'src/layer/wms';
 
 import { Effects, ColorRange } from 'src/mapDataManipulation/const';
@@ -126,6 +126,7 @@ export {
   CancelToken,
   isCancelled,
   CacheTarget,
+  invalidateCaches,
   RequestConfiguration,
   // legacy:
   legacyGetMapFromUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEUL
 import { LocationIdSHv3, GetMapParams, LinkType } from 'src/layer/const';
 import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
 import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
+import { CacheTarget } from 'src/utils/Cache';
 import { wmsGetMapUrl as _wmsGetMapUrl } from 'src/layer/wms';
 
 import { Effects, ColorRange } from 'src/mapDataManipulation/const';
@@ -124,6 +125,7 @@ export {
   setDebugEnabled,
   CancelToken,
   isCancelled,
+  CacheTarget,
   RequestConfiguration,
   // legacy:
   legacyGetMapFromUrl,

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -3,8 +3,13 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmsLayer, setAuthToken } from 'src';
+import { invalidateCaches } from 'src/utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
+
+beforeEach(async () => {
+  await invalidateCaches();
+});
 
 test('WmsLayer.getMapUrl returns an URL', () => {
   const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -4,11 +4,16 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { constructFixtureGetMap } from './fixtures.auth';
 import { ApiType, setAuthToken } from 'src';
+import { invalidateCaches } from 'src/utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 
 const EXAMPLE_TOKEN1 = 'TOKEN111';
 const EXAMPLE_TOKEN2 = 'TOKEN222';
+
+beforeEach(async () => {
+  await invalidateCaches();
+});
 
 test('getMap + Processing throws an exception if authToken is not set', async () => {
   const { layer, getMapParams } = constructFixtureGetMap();

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -8,16 +8,17 @@ import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { constructFixtureGetMap } from './fixtures.getMap';
 import { ApiType } from 'src';
 import { setAuthToken } from 'src/auth';
-import { invalidateCaches, memoryCache, CacheTarget } from 'src/utils/Cache';
+import { invalidateCaches, CacheTarget } from 'src/utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 
 const EXAMPLE_TOKEN = 'TOKEN111';
 
 describe('Testing caching', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     Object.assign(global, makeServiceWorkerEnv(), fetch);
     jest.resetModules();
+    await invalidateCaches();
   });
 
   it('should fetch a request and cache it, where 2nd request is served from the cache', async () => {
@@ -115,10 +116,10 @@ describe('Testing caching', () => {
 });
 
 describe('Testing cache targets', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     Object.assign(global, makeServiceWorkerEnv(), fetch);
     jest.resetModules();
-    memoryCache.clear();
+    await invalidateCaches();
   });
 
   it('should cache to cache api', async () => {
@@ -259,10 +260,10 @@ describe('Testing cache targets', () => {
 });
 
 describe('Testing cache targets when cache_api is not available', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     Object.assign(global, { caches: undefined }, fetch);
     jest.resetModules();
-    memoryCache.clear();
+    await invalidateCaches();
   });
 
   it('should default to memory if window.caches is undefined and no targets were defined', async () => {

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -8,7 +8,7 @@ import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { constructFixtureGetMap } from './fixtures.getMap';
 import { ApiType } from 'src';
 import { setAuthToken } from 'src/auth';
-import { invalidateCaches, memoryCache, CacheTarget, CACHE_API_KEY } from 'src/utils/Cache';
+import { invalidateCaches, memoryCache, CacheTarget } from 'src/utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -16,7 +16,7 @@ const EXAMPLE_TOKEN = 'TOKEN111';
 
 describe('Testing caching', () => {
   beforeEach(async () => {
-    Object.assign(global, makeServiceWorkerEnv(), fetch);
+    Object.assign(global, makeServiceWorkerEnv(), fetch); // adds these functions to the global object
     await invalidateCaches();
   });
 
@@ -116,7 +116,7 @@ describe('Testing caching', () => {
 
 describe('Testing cache targets', () => {
   beforeEach(async () => {
-    Object.assign(global, makeServiceWorkerEnv(), fetch);
+    Object.assign(global, makeServiceWorkerEnv(), fetch); // adds these functions to the global object
     await invalidateCaches();
   });
 
@@ -259,7 +259,7 @@ describe('Testing cache targets', () => {
 
 describe('Testing cache targets when cache_api is not available', () => {
   beforeEach(async () => {
-    Object.assign(global, { caches: undefined }, fetch);
+    Object.assign(global, { caches: undefined }, fetch); // adds these functions to the global object and removes caches from global object
     await invalidateCaches();
   });
 

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -17,7 +17,6 @@ const EXAMPLE_TOKEN = 'TOKEN111';
 describe('Testing caching', () => {
   beforeEach(async () => {
     Object.assign(global, makeServiceWorkerEnv(), fetch);
-    jest.resetModules();
     await invalidateCaches();
   });
 
@@ -118,7 +117,6 @@ describe('Testing caching', () => {
 describe('Testing cache targets', () => {
   beforeEach(async () => {
     Object.assign(global, makeServiceWorkerEnv(), fetch);
-    jest.resetModules();
     await invalidateCaches();
   });
 
@@ -262,7 +260,6 @@ describe('Testing cache targets', () => {
 describe('Testing cache targets when cache_api is not available', () => {
   beforeEach(async () => {
     Object.assign(global, { caches: undefined }, fetch);
-    jest.resetModules();
     await invalidateCaches();
   });
 

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -9,6 +9,7 @@ import { constructFixtureGetMap } from './fixtures.getMap';
 import { ApiType } from 'src';
 import { setAuthToken } from 'src/auth';
 import { invalidateCaches, CacheTarget } from 'src/utils/Cache';
+import { cacheStillValid, EXPIRY_HEADER_KEY } from '../../utils/cacheHandlers';
 
 const mockNetwork = new MockAdapter(axios);
 
@@ -412,5 +413,23 @@ describe('Reading from cache twice', () => {
 
     expect(mockNetwork.history.post.length).toBe(1);
     expect(fromCacheResponse2.tiles).toStrictEqual(expectedResultTiles);
+  });
+});
+
+describe('Unit test for cacheStillValid', () => {
+  it('It should be valid', async () => {
+    const header = {
+      [EXPIRY_HEADER_KEY]: new Date().getTime() + 100,
+    };
+    const isValid = cacheStillValid(header);
+    expect(isValid).toBeTruthy();
+  });
+
+  it('It should be invalid', async () => {
+    const header = {
+      [EXPIRY_HEADER_KEY]: new Date().getTime() - 100,
+    };
+    const isValid = cacheStillValid(header);
+    expect(isValid).toBeFalsy();
   });
 });

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -229,7 +229,7 @@ describe('Testing cache targets', () => {
     expect(responseFromMockNetwork.tiles).toStrictEqual(expectedResultTiles);
     expect(fromCacheResponse.tiles).toStrictEqual(expectedResultTiles);
 
-    invalidateCaches();
+    invalidateCaches(reqConfig.cache.targets);
 
     const responseFromMockNetwork2 = await layer.findTiles(bbox, fromTime, toTime, null, null, reqConfig);
     expect(mockNetwork.history.post.length).toBe(1);

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -211,7 +211,7 @@ describe('Testing cache targets', () => {
 
 describe('Testing cache targets when cache_api is not available', () => {
   beforeEach(() => {
-    Object.assign(global, fetch);
+    Object.assign(global, { caches: undefined }, fetch);
     jest.resetModules();
     memoryCache.clear();
   });
@@ -228,7 +228,6 @@ describe('Testing cache targets when cache_api is not available', () => {
     mockNetwork.reset();
     mockNetwork.onPost().replyOnce(200, mockedResponse);
     mockNetwork.onPost().replyOnce(200, mockedResponse);
-
     const responseFromMockNetwork = await layer.findTiles(bbox, fromTime, toTime, null, null, requestsConfig);
     const fromCacheResponse = await layer.findTiles(bbox, fromTime, toTime, null, null, requestsConfig);
     const cacheFromMemoryItem = memoryCache.has(mockNetwork.history.post[0].cacheKey);

--- a/src/layer/__tests__/retries.ts
+++ b/src/layer/__tests__/retries.ts
@@ -3,8 +3,13 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { constructFixtureFindTiles } from './fixtures.findTiles';
+import { invalidateCaches } from 'src/utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
+
+beforeEach(async () => {
+  await invalidateCaches();
+});
 
 test('Retries correctly on network errors', async () => {
   // we need to adjust jest timeout until we have support for setting the delay when retrying,

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -102,9 +102,9 @@ class CacheApi implements ShCache {
   public async invalidate(): Promise<void> {
     const cache = await this.cache;
     const cacheKeys = await cache.keys();
-    cacheKeys.forEach(async (key: string) => {
-      this.cache.delete(key);
-    });
+    for (let key of cacheKeys) {
+      await cache.delete(key);
+    }
   }
 }
 

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -14,7 +14,7 @@ export type CacheResponse = {
 
 export const CACHE_API_KEY = 'sentinelhub-v1';
 export const SUPPORTED_TARGETS = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
-const DEFAULT_TARGET = CacheTarget.MEMORY;
+const FALLBACK_TARGET = CacheTarget.MEMORY;
 
 export const memoryCache = new Map();
 
@@ -25,7 +25,7 @@ export function cacheFactory(optionalTargets: CacheTargets): ShCache {
 }
 
 function getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
-  let firstTargetToUse = DEFAULT_TARGET; // default to memory if target is not supported
+  let firstTargetToUse = FALLBACK_TARGET; // default to memory if target is not supported
   for (const key of targets) {
     if (doesTargetExist(key)) {
       firstTargetToUse = key;

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -97,8 +97,9 @@ class CacheApi implements ShCache {
   }
 }
 
-export async function invalidateCaches(): Promise<void> {
-  for (const target of DEFAULT_TARGETS) {
+export async function invalidateCaches(optionalTargets?: CacheTargets): Promise<void> {
+  const targets = optionalTargets || DEFAULT_TARGETS;
+  for (const target of targets) {
     switch (target) {
       case CacheTarget.CACHE_API:
         await new CacheApi().invalidate();

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -50,6 +50,7 @@ function constructCache(target: CacheTarget): ShCache {
 interface ShCache {
   set(key: string, value: Response): void;
   get(key: string): Promise<Response>;
+  has(key: string): Promise<boolean>;
   invalidate(): void;
 }
 
@@ -65,6 +66,10 @@ class MemoryCache implements ShCache {
 
   public get(key: string): any {
     return this.cache.get(key);
+  }
+
+  public has(key: string): any {
+    return this.cache.has(key);
   }
 
   public invalidate(): void {
@@ -86,6 +91,12 @@ class CacheApi implements ShCache {
   public async get(key: string): Promise<Response> {
     const cache = await this.cache;
     return await cache.match(key);
+  }
+
+  public async has(key: string): Promise<boolean> {
+    const cache = await this.cache;
+    const response = await cache.match(key);
+    return Boolean(response);
   }
 
   public async invalidate(): Promise<void> {

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -24,11 +24,11 @@ const memoryCache = new Map();
 // If user provides a CacheTarget.CACHE_API and cache_api is not availble we will fallback to memory
 export function cacheFactory(optionalTargets: CacheTargets): ShCache {
   const targets = optionalTargets || SUPPORTED_TARGETS;
-  const target = getFirstUsuableTarget(targets);
+  const target = getFirstUseableTarget(targets);
   return constructCache(target);
 }
 
-function getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
+function getFirstUseableTarget(targets: CacheTargets): CacheTarget {
   let firstTargetToUse = undefined; // default to memory if target is not supported
   for (const key of targets) {
     if (doesTargetExist(key)) {

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -15,7 +15,7 @@ export type CacheResponse = {
 export const CACHE_API_KEY = 'sentinelhub-v1';
 export const SUPPORTED_TARGETS = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
 
-export const memoryCache = new Map();
+const memoryCache = new Map();
 
 // Factory will return an instance of a Cache interface.
 // The first availble target will be used

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -96,3 +96,16 @@ class CacheApi implements ShCache {
     });
   }
 }
+
+export async function invalidateCaches(): Promise<void> {
+  for (const target of DEFAULT_TARGETS) {
+    switch (target) {
+      case CacheTarget.CACHE_API:
+        await new CacheApi().invalidate();
+      case CacheTarget.MEMORY:
+        await new MemoryCache().invalidate();
+      default:
+        break;
+    }
+  }
+}

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -14,7 +14,6 @@ export type CacheResponse = {
 
 export const CACHE_API_KEY = 'sentinelhub-v1';
 export const SUPPORTED_TARGETS = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
-const FALLBACK_TARGET = CacheTarget.MEMORY;
 
 export const memoryCache = new Map();
 

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -142,7 +142,7 @@ class CacheApi implements ShCache {
       data: await this.deSerializeResponseData(response, responseType),
       status: response.status,
       statusText: response.statusText,
-      headers: await this.deSeriarialeHeaders(response.headers),
+      headers: await this.deserializeHeaders(response.headers),
     };
   }
 
@@ -168,7 +168,7 @@ class CacheApi implements ShCache {
     if (!response) {
       return null;
     }
-    return await this.deSeriarialeHeaders(response.headers);
+    return await this.deserializeHeaders(response.headers);
   }
 
   public async invalidate(): Promise<void> {
@@ -218,7 +218,7 @@ class CacheApi implements ShCache {
     }
   }
 
-  private async deSeriarialeHeaders(headers: Response['headers']): Promise<Record<string, any>> {
+  private async deserializeHeaders(headers: Response['headers']): Promise<Record<string, any>> {
     const newHeaders: Record<string, any> = {};
     for (let key of headers.keys()) {
       newHeaders[key] = headers.get(key);

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -1,0 +1,101 @@
+export type CacheTargets = CacheTarget[];
+export enum CacheTarget {
+  CACHE_API = 'CACHE_API',
+  MEMORY = 'MEMORY',
+}
+export const CACHE_API_KEY = 'sentinelhub-v1';
+export const memoryCache = new Map();
+const defaultTargets = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
+
+export class CacheFactory {
+  public target: CacheTarget;
+  public cacheWrapper: ShCache;
+  public constructor(optionalTargets?: CacheTargets) {
+    const targets = optionalTargets || defaultTargets;
+    this.target = this.getFirstUsuableTarget(targets);
+    this.cacheWrapper = this.constructCache(this.target);
+  }
+
+  private constructCache(target: CacheTarget): ShCache {
+    switch (target) {
+      case CacheTarget.CACHE_API:
+        return new CacheApi();
+      case CacheTarget.MEMORY:
+        return new MemoryCache();
+      default:
+        throw new Error('Target not supported');
+    }
+  }
+
+  private getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
+    let firstTargetToUse = CacheTarget.MEMORY;
+    for (const key of targets) {
+      if (this.doesTargetExist(key)) {
+        firstTargetToUse = key;
+        break;
+      }
+    }
+    return firstTargetToUse;
+  }
+
+  private doesTargetExist(target: CacheTarget): boolean {
+    switch (target) {
+      case CacheTarget.CACHE_API:
+        return Boolean(window.caches);
+      case CacheTarget.MEMORY:
+        return true;
+      default:
+        return false;
+    }
+  }
+}
+
+interface ShCache {
+  set(key: string, value: Response): void;
+  get(key: string): Promise<Response>;
+  invalidate(): void;
+}
+
+class MemoryCache implements ShCache {
+  private cache: Record<string, any>;
+  public constructor() {
+    this.cache = memoryCache;
+  }
+
+  public set(key: string, value: Response): void {
+    this.cache.set(key, value);
+  }
+
+  public get(key: string): any {
+    return this.cache.get(key);
+  }
+
+  public invalidate(): void {
+    this.cache.clear();
+  }
+}
+
+class CacheApi implements ShCache {
+  private cache: Record<string, any>;
+  public constructor() {
+    this.cache = caches.open(CACHE_API_KEY);
+  }
+
+  public async set(key: string, value: Response): Promise<void> {
+    const cache = await this.cache;
+    cache.put(key, value);
+  }
+
+  public async get(key: string): Promise<Response> {
+    const cache = await this.cache;
+    return await cache.match(key);
+  }
+
+  public async invalidate(): Promise<void> {
+    const cache = await this.cache;
+    const cacheKeys = await cache.keys();
+    cacheKeys.forEach(async (key: string) => {
+      this.cache.delete(key);
+    });
+  }
+}

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -30,7 +30,7 @@ export function cacheFactory(optionalTargets: CacheTargets): ShCache {
 }
 
 function getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
-  let firstTargetToUse = FALLBACK_TARGET; // default to memory if target is not supported
+  let firstTargetToUse = undefined; // default to memory if target is not supported
   for (const key of targets) {
     if (doesTargetExist(key)) {
       firstTargetToUse = key;
@@ -58,7 +58,7 @@ function constructCache(target: CacheTarget): ShCache {
     case CacheTarget.MEMORY:
       return new MemoryCache();
     default:
-      throw new Error('Target not supported');
+      return null;
   }
 }
 

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -5,48 +5,44 @@ export enum CacheTarget {
 }
 export const CACHE_API_KEY = 'sentinelhub-v1';
 export const memoryCache = new Map();
-const defaultTargets = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
 
-export class CacheFactory {
-  public target: CacheTarget;
-  public cacheWrapper: ShCache;
-  public constructor(optionalTargets?: CacheTargets) {
-    const targets = optionalTargets || defaultTargets;
-    this.target = this.getFirstUsuableTarget(targets);
-    this.cacheWrapper = this.constructCache(this.target);
-  }
+export function cacheFactory(optionalTargets: CacheTargets): ShCache {
+  const defaultTargets = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
+  const targets = optionalTargets || defaultTargets;
+  const target = getFirstUsuableTarget(targets);
+  return constructCache(target);
+}
 
-  private constructCache(target: CacheTarget): ShCache {
-    switch (target) {
-      case CacheTarget.CACHE_API:
-        return new CacheApi();
-      case CacheTarget.MEMORY:
-        return new MemoryCache();
-      default:
-        throw new Error('Target not supported');
+function getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
+  let firstTargetToUse = CacheTarget.MEMORY;
+  for (const key of targets) {
+    if (doesTargetExist(key)) {
+      firstTargetToUse = key;
+      break;
     }
   }
+  return firstTargetToUse;
+}
 
-  private getFirstUsuableTarget(targets: CacheTargets): CacheTarget {
-    let firstTargetToUse = CacheTarget.MEMORY;
-    for (const key of targets) {
-      if (this.doesTargetExist(key)) {
-        firstTargetToUse = key;
-        break;
-      }
-    }
-    return firstTargetToUse;
+function doesTargetExist(target: CacheTarget): boolean {
+  switch (target) {
+    case CacheTarget.CACHE_API:
+      return Boolean(window.caches);
+    case CacheTarget.MEMORY:
+      return true;
+    default:
+      return false;
   }
+}
 
-  private doesTargetExist(target: CacheTarget): boolean {
-    switch (target) {
-      case CacheTarget.CACHE_API:
-        return Boolean(window.caches);
-      case CacheTarget.MEMORY:
-        return true;
-      default:
-        return false;
-    }
+function constructCache(target: CacheTarget): ShCache {
+  switch (target) {
+    case CacheTarget.CACHE_API:
+      return new CacheApi();
+    case CacheTarget.MEMORY:
+      return new MemoryCache();
+    default:
+      throw new Error('Target not supported');
   }
 }
 

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -18,6 +18,11 @@ const FALLBACK_TARGET = CacheTarget.MEMORY;
 
 export const memoryCache = new Map();
 
+// Factory will return an instance of a Cache interface.
+// The first availble target will be used
+// By default we will use cache_api if availble, if not we will cache in memory
+// user can also specify to just use in memory caching
+// If user provides a CacheTarget.CACHE_API and cache_api is not availble we will fallback to memory
 export function cacheFactory(optionalTargets: CacheTargets): ShCache {
   const targets = optionalTargets || SUPPORTED_TARGETS;
   const target = getFirstUsuableTarget(targets);

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -111,6 +111,9 @@ class CacheApi implements ShCache {
 export async function invalidateCaches(optionalTargets?: CacheTargets): Promise<void> {
   const targets = optionalTargets || DEFAULT_TARGETS;
   for (const target of targets) {
+    if (!doesTargetExist(target)) {
+      continue;
+    }
     switch (target) {
       case CacheTarget.CACHE_API:
         await new CacheApi().invalidate();

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -4,11 +4,12 @@ export enum CacheTarget {
   MEMORY = 'MEMORY',
 }
 export const CACHE_API_KEY = 'sentinelhub-v1';
+const DEFAULT_TARGETS = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
+
 export const memoryCache = new Map();
 
 export function cacheFactory(optionalTargets: CacheTargets): ShCache {
-  const defaultTargets = [CacheTarget.CACHE_API, CacheTarget.MEMORY];
-  const targets = optionalTargets || defaultTargets;
+  const targets = optionalTargets || DEFAULT_TARGETS;
   const target = getFirstUsuableTarget(targets);
   return constructCache(target);
 }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -71,12 +71,11 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
   if (!isRequestCachable(response.config)) {
     return response;
   }
-  const shCache = cacheFactory(response.config.cache.targets);
   // resource not cacheable?
   if (!response.config.cacheKey) {
     return response;
   }
-
+  const shCache = cacheFactory(response.config.cache.targets);
   if (await shCache.has(response.config.cacheKey)) {
     return response;
   }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -114,7 +114,7 @@ export const findAndDeleteExpiredCachedItems = async (): Promise<void> => {
       continue;
     }
     const cacheKeys = await shCache.keys();
-    cacheKeys.forEach(async key => {
+    cacheKeys.forEach(async (key: Request | string) => {
       const headers = await shCache.getHeaders(key);
       if (!cacheStillValid(headers)) {
         await shCache.delete(key);

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -17,10 +17,6 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
     return request;
   }
 
-  // do not perform caching if Cache API is not supported:
-  if (typeof window === 'undefined' || !window.caches) {
-    return request;
-  }
   const cacheKey = await generateCacheKey(request);
   // resource not cacheable? It couldn't have been saved to cache:
   if (cacheKey === null) {
@@ -76,10 +72,6 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     return response;
   }
   const shCache = new CacheFactory(response.config.cache.targets);
-  // do not perform caching if Cache API is not supported:
-  if (typeof window === 'undefined' || !window.caches) {
-    return response;
-  }
   // resource not cacheable?
   if (!response.config.cacheKey) {
     return response;

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -72,7 +72,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
   return response;
 };
 
-const cacheStillValid = (headers: Record<string, any>): boolean => {
+export const cacheStillValid = (headers: Record<string, any>): boolean => {
   if (!headers) {
     return true;
   }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { stringify } from 'query-string';
-import { CacheTargets, cacheFactory, DEFAULT_TARGETS } from './Cache';
+import { CacheTargets, cacheFactory, SUPPORTED_TARGETS } from './Cache';
 
 export const CACHE_CONFIG_30MIN = { expiresIn: 1800 };
 export const CACHE_CONFIG_NOCACHE = { expiresIn: 0 };
@@ -103,7 +103,7 @@ const stringToHash = async (message: string): Promise<any> => {
 };
 
 export const findAndDeleteExpiredCachedItems = async (): Promise<void> => {
-  for (const target of DEFAULT_TARGETS) {
+  for (const target of SUPPORTED_TARGETS) {
     const shCache = cacheFactory([target]);
     const cacheKeys = await shCache.keys();
     cacheKeys.forEach(async key => {

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { stringify } from 'query-string';
-import { CacheTargets, CacheFactory } from './Cache';
+import { CacheTargets, cacheFactory } from './Cache';
 
 export const CACHE_CONFIG_30MIN = { expiresIn: 1800 };
 export const CACHE_CONFIG_NOCACHE = { expiresIn: 0 };
@@ -22,9 +22,9 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (cacheKey === null) {
     return request;
   }
-  const shCache = new CacheFactory(request.cache.targets);
+  const shCache = cacheFactory(request.cache.targets);
 
-  const cachedResponse = await shCache.cacheWrapper.get(cacheKey);
+  const cachedResponse = await shCache.get(cacheKey);
   if (!cachedResponse || !cacheStillValid(cachedResponse)) {
     request.cacheKey = cacheKey;
     return request;
@@ -71,7 +71,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
   if (!isRequestCachable(response.config)) {
     return response;
   }
-  const shCache = new CacheFactory(response.config.cache.targets);
+  const shCache = cacheFactory(response.config.cache.targets);
   // resource not cacheable?
   if (!response.config.cacheKey) {
     return response;
@@ -103,7 +103,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     default:
       throw new Error('Unsupported response type: ' + request.responseType);
   }
-  shCache.cacheWrapper.set(response.config.cacheKey, new Response(responseData, response));
+  shCache.set(response.config.cacheKey, new Response(responseData, response));
   return response;
 };
 

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -77,6 +77,10 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     return response;
   }
 
+  if (await shCache.has(response.config.cacheKey)) {
+    return response;
+  }
+
   // before saving response, set an artificial header that tells when it should expire:
   const expiresMs = new Date().getTime() + response.config.cache.expiresIn * 1000;
   response.headers = {

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -22,7 +22,9 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
     return request;
   }
   const shCache = cacheFactory(request.cache.targets);
-
+  if (!shCache) {
+    return request;
+  }
   const cachedResponse = await shCache.get(cacheKey, request.responseType);
   if (!cachedResponse || !cacheStillValid(cachedResponse.headers)) {
     request.cacheKey = cacheKey;
@@ -53,6 +55,9 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     return response;
   }
   const shCache = cacheFactory(response.config.cache.targets);
+  if (!shCache) {
+    return response;
+  }
   if (await shCache.has(response.config.cacheKey)) {
     return response;
   }
@@ -105,6 +110,9 @@ const stringToHash = async (message: string): Promise<any> => {
 export const findAndDeleteExpiredCachedItems = async (): Promise<void> => {
   for (const target of SUPPORTED_TARGETS) {
     const shCache = cacheFactory([target]);
+    if (!shCache) {
+      continue;
+    }
     const cacheKeys = await shCache.keys();
     cacheKeys.forEach(async key => {
       const headers = await shCache.getHeaders(key);

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -38,17 +38,17 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
     let responseData;
     switch (request.responseType) {
       case 'blob':
-        responseData = await cachedResponse.blob();
+        responseData = await cachedResponse.clone().blob();
         break;
       case 'arraybuffer':
-        responseData = await cachedResponse.arrayBuffer();
+        responseData = await cachedResponse.clone().arrayBuffer();
         break;
       case 'text':
-        responseData = await cachedResponse.text();
+        responseData = await cachedResponse.clone().text();
         break;
       case 'json':
       case undefined: // axios defaults to json https://github.com/axios/axios#request-config
-        responseData = await cachedResponse.json();
+        responseData = await cachedResponse.clone().json();
         break;
       default:
         throw new Error('Unsupported response type: ' + request.responseType);

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -10,6 +10,7 @@ import {
   PreviewMode,
   CancelToken,
   isCancelled,
+  CacheTarget,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.INSTANCE_ID) {
@@ -121,6 +122,7 @@ export const GetMapProcessing = () => {
     const reqConfig = {
       cache: {
         expiresIn: 5000,
+        targets: [CacheTarget.MEMORY],
       },
     };
 

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -197,9 +197,38 @@ export const FindTiles = () => {
   const wrapperEl = document.createElement('div');
   wrapperEl.innerHTML = `<h2>findTiles for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
   wrapperEl.insertAdjacentElement('beforeend', containerEl);
+
+  const perform = async () => {
+    const data = await layerS2L1C.findTiles(
+      bbox4326,
+      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+      5,
+      0,
+    );
+    renderTilesList(containerEl, data.tiles);
+  };
+  perform().then(() => {});
+
+  return wrapperEl;
+};
+
+export const FindCachedToMemoryTiles = () => {
+  const maxCloudCoverPercent = 60;
+  const layerS2L1C = new S2L1CLayer({
+    instanceId,
+    layerId,
+    maxCloudCoverPercent,
+  });
+  const containerEl = document.createElement('pre');
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>findTiles for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', containerEl);
   const requestsConfig = {
     cache: {
       expiresIn: 5000,
+      targets: [CacheTarget.MEMORY],
     },
   };
 


### PR DESCRIPTION
* Add support for cache targets in `reqConfig`

Can specify a list of targets that are ordered by priority for checking if the target is available, where caching will always fallback to in memory caching. By default the library will try to use cache-api.
More targets could be added in a separate MR.