### PR TITLE
change object for looking at responseType

### DIFF
--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -177,7 +177,7 @@ class CacheApi implements ShCache {
 
   private serializeResponseData(response: AxiosResponse): any {
     let responseData;
-    switch (response.request.responseType) {
+    switch (response.config.responseType) {
       case 'blob':
       case 'arraybuffer':
       case 'text':


### PR DESCRIPTION
Caching didnt work for some requests because we looked at `responseType` in the wrong object in `AxiosResponse`. 
The tests passed because `responseType` was undefined when running the tests, which is the expected behavior, but outside of tests an undefined `responseType` would be an empty string in `response.request` where `response.config` would have `responseType` as undefined. 