### PR TITLE
Feature/relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
       "fixtures[.].*[.]ts"
     ]
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist",
-    "dist/index.d.ts"
+    "dist/src/index.d.ts"
   ]
 }

--- a/src/bbox.ts
+++ b/src/bbox.ts
@@ -1,4 +1,4 @@
-import { CRS } from 'src/crs';
+import { CRS } from './crs';
 import { Polygon } from '@turf/helpers';
 
 export class BBox {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { BBox } from 'src/bbox';
-import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
-import { setAuthToken, isAuthTokenSet, requestAuthToken } from 'src/auth';
+import { BBox } from './bbox';
+import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from './crs';
+import { setAuthToken, isAuthTokenSet, requestAuthToken } from './auth';
 import {
   ApiType,
   MimeTypes,
@@ -8,10 +8,10 @@ import {
   PreviewMode,
   MosaickingOrder,
   Interpolator,
-} from 'src/layer/const';
-import { setDebugEnabled } from 'src/utils/debug';
+} from './layer/const';
+import { setDebugEnabled } from './utils/debug';
 
-import { LayersFactory } from 'src/layer/LayersFactory';
+import { LayersFactory } from './layer/LayersFactory';
 import {
   DATASET_BYOC,
   DATASET_AWSEU_S1GRD,
@@ -28,40 +28,40 @@ import {
   DATASET_EOCLOUD_ENVISAT_MERIS,
   DATASET_MODIS,
   DATASET_AWS_DEM,
-} from 'src/layer/dataset';
-import { WmsLayer } from 'src/layer/WmsLayer';
-import { S1GRDAWSEULayer } from 'src/layer/S1GRDAWSEULayer';
-import { S1GRDEOCloudLayer } from 'src/layer/S1GRDEOCloudLayer';
-import { S2L2ALayer } from 'src/layer/S2L2ALayer';
-import { S2L1CLayer } from 'src/layer/S2L1CLayer';
-import { S3SLSTRLayer, S3SLSTRView } from 'src/layer/S3SLSTRLayer';
-import { S3OLCILayer } from 'src/layer/S3OLCILayer';
-import { S5PL2Layer } from 'src/layer/S5PL2Layer';
-import { EnvisatMerisEOCloudLayer } from 'src/layer/EnvisatMerisEOCloudLayer';
-import { MODISLayer } from 'src/layer/MODISLayer';
-import { DEMLayer } from 'src/layer/DEMLayer';
-import { Landsat5EOCloudLayer } from 'src/layer/Landsat5EOCloudLayer';
-import { Landsat7EOCloudLayer } from 'src/layer/Landsat7EOCloudLayer';
-import { Landsat8EOCloudLayer } from 'src/layer/Landsat8EOCloudLayer';
-import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
-import { BYOCLayer } from 'src/layer/BYOCLayer';
-import { ProcessingDataFusionLayer } from 'src/layer/ProcessingDataFusionLayer';
+} from './layer/dataset';
+import { WmsLayer } from './layer/WmsLayer';
+import { S1GRDAWSEULayer } from './layer/S1GRDAWSEULayer';
+import { S1GRDEOCloudLayer } from './layer/S1GRDEOCloudLayer';
+import { S2L2ALayer } from './layer/S2L2ALayer';
+import { S2L1CLayer } from './layer/S2L1CLayer';
+import { S3SLSTRLayer, S3SLSTRView } from './layer/S3SLSTRLayer';
+import { S3OLCILayer } from './layer/S3OLCILayer';
+import { S5PL2Layer } from './layer/S5PL2Layer';
+import { EnvisatMerisEOCloudLayer } from './layer/EnvisatMerisEOCloudLayer';
+import { MODISLayer } from './layer/MODISLayer';
+import { DEMLayer } from './layer/DEMLayer';
+import { Landsat5EOCloudLayer } from './layer/Landsat5EOCloudLayer';
+import { Landsat7EOCloudLayer } from './layer/Landsat7EOCloudLayer';
+import { Landsat8EOCloudLayer } from './layer/Landsat8EOCloudLayer';
+import { Landsat8AWSLayer } from './layer/Landsat8AWSLayer';
+import { BYOCLayer } from './layer/BYOCLayer';
+import { ProcessingDataFusionLayer } from './layer/ProcessingDataFusionLayer';
 
 import {
   legacyGetMapFromUrl,
   legacyGetMapWmsUrlFromParams,
   legacyGetMapFromParams,
   parseLegacyWmsGetMapParams,
-} from 'src/legacyCompat';
-import { AcquisitionMode, Polarization, Resolution } from 'src/layer/S1GRDAWSEULayer';
-import { LocationIdSHv3, GetMapParams, LinkType } from 'src/layer/const';
-import { registerAxiosCacheRetryInterceptors } from 'src/utils/axiosInterceptors';
-import { CancelToken, isCancelled, RequestConfiguration } from 'src/utils/cancelRequests';
-import { CacheTarget, invalidateCaches } from 'src/utils/Cache';
-import { wmsGetMapUrl as _wmsGetMapUrl } from 'src/layer/wms';
-import { drawBlobOnCanvas, canvasToBlob } from 'src/utils/canvas';
+} from './legacyCompat';
+import { AcquisitionMode, Polarization, Resolution } from './layer/S1GRDAWSEULayer';
+import { LocationIdSHv3, GetMapParams, LinkType } from './layer/const';
+import { registerAxiosCacheRetryInterceptors } from './utils/axiosInterceptors';
+import { CancelToken, isCancelled, RequestConfiguration } from './utils/cancelRequests';
+import { CacheTarget, invalidateCaches } from './utils/Cache';
+import { wmsGetMapUrl as _wmsGetMapUrl } from './layer/wms';
+import { drawBlobOnCanvas, canvasToBlob } from './utils/canvas';
 
-import { Effects, ColorRange } from 'src/mapDataManipulation/const';
+import { Effects, ColorRange } from './mapDataManipulation/const';
 
 registerAxiosCacheRetryInterceptors();
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -3,16 +3,16 @@ import moment from 'moment';
 import area from '@turf/area';
 import { union, intersection, Geom } from 'polygon-clipping';
 
-import { BBox } from 'src/bbox';
-import { CRS_EPSG4326 } from 'src/crs';
-import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, PreviewMode } from 'src/layer/const';
-import { Dataset } from 'src/layer/dataset';
-import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { BBox } from '../bbox';
+import { CRS_EPSG4326 } from '../crs';
+import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, PreviewMode } from './const';
+import { Dataset } from './dataset';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
-import { Effects } from 'src/mapDataManipulation/const';
-import { runEffectFunctions } from 'src/mapDataManipulation/runEffectFunctions';
-import { drawBlobOnCanvas, canvasToBlob } from 'src/utils/canvas';
+import { Effects } from '../mapDataManipulation/const';
+import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
+import { drawBlobOnCanvas, canvasToBlob } from '../utils/canvas';
 import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 
 interface ConstructorParameters {

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { stringify } from 'query-string';
 import WKT from 'terraformer-wkt-parser';
 
-import { BBox } from 'src/bbox';
+import { BBox } from '../bbox';
 import {
   GetMapParams,
   ApiType,
@@ -16,14 +16,14 @@ import {
   Interpolator,
   Link,
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
-} from 'src/layer/const';
-import { wmsGetMapUrl } from 'src/layer/wms';
-import { AbstractLayer } from 'src/layer/AbstractLayer';
-import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
-import { fetchGetCapabilitiesXml } from 'src/layer/utils';
-import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
-import { CACHE_CONFIG_NOCACHE } from 'src/utils/cacheHandlers';
+} from './const';
+import { wmsGetMapUrl } from './wms';
+import { AbstractLayer } from './AbstractLayer';
+import { CRS_EPSG4326, findCrsFromUrn } from '../crs';
+import { fetchGetCapabilitiesXml } from './utils';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
+import { CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2WithCCLayer.ts
@@ -1,5 +1,5 @@
-import { MosaickingOrder } from 'src/layer/const';
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { MosaickingOrder } from './const';
+import { AbstractSentinelHubV1OrV2Layer } from './AbstractSentinelHubV1OrV2Layer';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -2,8 +2,8 @@ import axios, { AxiosRequestConfig } from 'axios';
 import moment, { Moment } from 'moment';
 import WKT from 'terraformer-wkt-parser';
 
-import { getAuthToken } from 'src/auth';
-import { BBox } from 'src/bbox';
+import { getAuthToken } from '../auth';
+import { BBox } from '../bbox';
 import {
   GetMapParams,
   ApiType,
@@ -18,17 +18,17 @@ import {
   DEFAULT_FIND_TILES_MAX_COUNT_PARAMETER,
   SUPPORTED_DATA_PRODUCTS_PROCESSING,
   DataProductId,
-} from 'src/layer/const';
-import { wmsGetMapUrl } from 'src/layer/wms';
-import { processingGetMap, createProcessingPayload, ProcessingPayload } from 'src/layer/processing';
-import { AbstractLayer } from 'src/layer/AbstractLayer';
-import { CRS_EPSG4326, findCrsFromUrn } from 'src/crs';
+} from './const';
+import { wmsGetMapUrl } from './wms';
+import { processingGetMap, createProcessingPayload, ProcessingPayload } from './processing';
+import { AbstractLayer } from './AbstractLayer';
+import { CRS_EPSG4326, findCrsFromUrn } from '../crs';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
-import { Effects } from 'src/mapDataManipulation/const';
-import { runEffectFunctions } from 'src/mapDataManipulation/runEffectFunctions';
-import { CACHE_CONFIG_30MIN, CACHE_CONFIG_NOCACHE } from 'src/utils/cacheHandlers';
+import { Effects } from '../mapDataManipulation/const';
+import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
+import { CACHE_CONFIG_30MIN, CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
 
-import { BBox } from 'src/bbox';
+import { BBox } from '../bbox';
 
-import { PaginatedTiles, MosaickingOrder, DataProductId } from 'src/layer/const';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { ProcessingPayload } from 'src/layer/processing';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { PaginatedTiles, MosaickingOrder, DataProductId } from './const';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from './processing';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -2,8 +2,8 @@ import { AxiosRequestConfig } from 'axios';
 import moment from 'moment';
 import axios from 'axios';
 
-import { getAuthToken } from 'src/auth';
-import { BBox } from 'src/bbox';
+import { getAuthToken } from '../auth';
+import { BBox } from '../bbox';
 import {
   PaginatedTiles,
   LocationIdSHv3,
@@ -14,13 +14,13 @@ import {
   Stats,
   DataProductId,
   BYOCBand,
-} from 'src/layer/const';
-import { DATASET_BYOC } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { ProcessingPayload } from 'src/layer/processing';
-import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
-import { CACHE_CONFIG_30MIN } from 'src/utils/cacheHandlers';
+} from './const';
+import { DATASET_BYOC } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from './processing';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
+import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/DEMLayer.ts
+++ b/src/layer/DEMLayer.ts
@@ -1,5 +1,5 @@
-import { DATASET_AWS_DEM } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { DATASET_AWS_DEM } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
 
 export class DEMLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_AWS_DEM;

--- a/src/layer/EnvisatMerisEOCloudLayer.ts
+++ b/src/layer/EnvisatMerisEOCloudLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_EOCLOUD_ENVISAT_MERIS } from 'src/layer/dataset';
-import { Link, LinkType } from 'src/layer/const';
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
+import { DATASET_EOCLOUD_ENVISAT_MERIS } from './dataset';
+import { Link, LinkType } from './const';
+import { AbstractSentinelHubV1OrV2Layer } from './AbstractSentinelHubV1OrV2Layer';
 
 export class EnvisatMerisEOCloudLayer extends AbstractSentinelHubV1OrV2Layer {
   public readonly dataset = DATASET_EOCLOUD_ENVISAT_MERIS;

--- a/src/layer/Landsat5EOCloudLayer.ts
+++ b/src/layer/Landsat5EOCloudLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_EOCLOUD_LANDSAT5 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link, LinkType } from 'src/layer/const';
+import { DATASET_EOCLOUD_LANDSAT5 } from './dataset';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from './AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link, LinkType } from './const';
 
 export class Landsat5EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT5;

--- a/src/layer/Landsat7EOCloudLayer.ts
+++ b/src/layer/Landsat7EOCloudLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_EOCLOUD_LANDSAT7 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link, LinkType } from 'src/layer/const';
+import { DATASET_EOCLOUD_LANDSAT7 } from './dataset';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from './AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link, LinkType } from './const';
 
 export class Landsat7EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT7;

--- a/src/layer/Landsat8AWSLayer.ts
+++ b/src/layer/Landsat8AWSLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_AWS_L8L1C } from 'src/layer/dataset';
+import { DATASET_AWS_L8L1C } from './dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { Link, LinkType } from 'src/layer/const';
+import { Link, LinkType } from './const';
 
 export class Landsat8AWSLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_AWS_L8L1C;

--- a/src/layer/Landsat8EOCloudLayer.ts
+++ b/src/layer/Landsat8EOCloudLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_EOCLOUD_LANDSAT8 } from 'src/layer/dataset';
-import { AbstractSentinelHubV1OrV2WithCCLayer } from 'src/layer/AbstractSentinelHubV1OrV2WithCCLayer';
-import { Link, LinkType } from 'src/layer/const';
+import { DATASET_EOCLOUD_LANDSAT8 } from './dataset';
+import { AbstractSentinelHubV1OrV2WithCCLayer } from './AbstractSentinelHubV1OrV2WithCCLayer';
+import { Link, LinkType } from './const';
 
 export class Landsat8EOCloudLayer extends AbstractSentinelHubV1OrV2WithCCLayer {
   public readonly dataset = DATASET_EOCLOUD_LANDSAT8;

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -3,9 +3,9 @@ import {
   fetchGetCapabilitiesJsonV1,
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
-} from 'src/layer/utils';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
+} from './utils';
+import { ensureTimeout } from '../utils/ensureTimeout';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
 import {
   DATASET_S2L2A,
   DATASET_AWS_L8L1C,
@@ -23,25 +23,25 @@ import {
   DATASET_EOCLOUD_LANDSAT8,
   DATASET_EOCLOUD_ENVISAT_MERIS,
   Dataset,
-} from 'src/layer/dataset';
-import { AbstractLayer } from 'src/layer/AbstractLayer';
-import { WmsLayer } from 'src/layer/WmsLayer';
-import { S1GRDAWSEULayer } from 'src/layer/S1GRDAWSEULayer';
-import { S2L2ALayer } from 'src/layer/S2L2ALayer';
-import { S2L1CLayer } from 'src/layer/S2L1CLayer';
-import { S3SLSTRLayer } from 'src/layer/S3SLSTRLayer';
-import { S3OLCILayer } from 'src/layer/S3OLCILayer';
-import { S5PL2Layer } from 'src/layer/S5PL2Layer';
-import { MODISLayer } from 'src/layer/MODISLayer';
-import { DEMLayer } from 'src/layer/DEMLayer';
-import { Landsat8AWSLayer } from 'src/layer/Landsat8AWSLayer';
-import { BYOCLayer } from 'src/layer/BYOCLayer';
-import { S1GRDEOCloudLayer } from 'src/layer/S1GRDEOCloudLayer';
-import { Landsat5EOCloudLayer } from 'src/layer/Landsat5EOCloudLayer';
-import { Landsat7EOCloudLayer } from 'src/layer/Landsat7EOCloudLayer';
-import { Landsat8EOCloudLayer } from 'src/layer/Landsat8EOCloudLayer';
-import { EnvisatMerisEOCloudLayer } from 'src/layer/EnvisatMerisEOCloudLayer';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
+} from './dataset';
+import { AbstractLayer } from './AbstractLayer';
+import { WmsLayer } from './WmsLayer';
+import { S1GRDAWSEULayer } from './S1GRDAWSEULayer';
+import { S2L2ALayer } from './S2L2ALayer';
+import { S2L1CLayer } from './S2L1CLayer';
+import { S3SLSTRLayer } from './S3SLSTRLayer';
+import { S3OLCILayer } from './S3OLCILayer';
+import { S5PL2Layer } from './S5PL2Layer';
+import { MODISLayer } from './MODISLayer';
+import { DEMLayer } from './DEMLayer';
+import { Landsat8AWSLayer } from './Landsat8AWSLayer';
+import { BYOCLayer } from './BYOCLayer';
+import { S1GRDEOCloudLayer } from './S1GRDEOCloudLayer';
+import { Landsat5EOCloudLayer } from './Landsat5EOCloudLayer';
+import { Landsat7EOCloudLayer } from './Landsat7EOCloudLayer';
+import { Landsat8EOCloudLayer } from './Landsat8EOCloudLayer';
+import { EnvisatMerisEOCloudLayer } from './EnvisatMerisEOCloudLayer';
+import { RequestConfiguration } from '../utils/cancelRequests';
 
 export class LayersFactory {
   /*

--- a/src/layer/MODISLayer.ts
+++ b/src/layer/MODISLayer.ts
@@ -1,5 +1,5 @@
-import { DATASET_MODIS } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
+import { DATASET_MODIS } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
 
 export class MODISLayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_MODIS;

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -1,24 +1,17 @@
-import { BBox } from 'src/bbox';
-import {
-  GetMapParams,
-  Interpolator,
-  PreviewMode,
-  ApiType,
-  PaginatedTiles,
-  MosaickingOrder,
-} from 'src/layer/const';
+import { BBox } from '../bbox';
+import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles, MosaickingOrder } from './const';
 import {
   createProcessingPayload,
   convertPreviewToString,
   processingGetMap,
   ProcessingPayloadDatasource,
-} from 'src/layer/processing';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+} from './processing';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
-import { Effects } from 'src/mapDataManipulation/const';
-import { runEffectFunctions } from 'src/mapDataManipulation/runEffectFunctions';
+import { Effects } from '../mapDataManipulation/const';
+import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
 
 /*
   This layer allows using Processing API "data fusion". It takes a list of layers and

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -1,20 +1,13 @@
 import moment from 'moment';
 
-import { BBox } from 'src/bbox';
+import { BBox } from '../bbox';
 
-import {
-  BackscatterCoeff,
-  PaginatedTiles,
-  OrbitDirection,
-  Link,
-  LinkType,
-  DataProductId,
-} from 'src/layer/const';
-import { ProcessingPayload } from 'src/layer/processing';
-import { DATASET_AWSEU_S1GRD } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { BackscatterCoeff, PaginatedTiles, OrbitDirection, Link, LinkType, DataProductId } from './const';
+import { ProcessingPayload } from './processing';
+import { DATASET_AWSEU_S1GRD } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.
 */

--- a/src/layer/S1GRDEOCloudLayer.ts
+++ b/src/layer/S1GRDEOCloudLayer.ts
@@ -1,9 +1,9 @@
-import { DATASET_EOCLOUD_S1GRD } from 'src/layer/dataset';
+import { DATASET_EOCLOUD_S1GRD } from './dataset';
 
-import { AbstractSentinelHubV1OrV2Layer } from 'src/layer/AbstractSentinelHubV1OrV2Layer';
-import { AcquisitionMode, Polarization } from 'src/layer/S1GRDAWSEULayer';
-import { OrbitDirection, MosaickingOrder, Link, LinkType } from 'src/layer/const';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
+import { AbstractSentinelHubV1OrV2Layer } from './AbstractSentinelHubV1OrV2Layer';
+import { AcquisitionMode, Polarization } from './S1GRDAWSEULayer';
+import { OrbitDirection, MosaickingOrder, Link, LinkType } from './const';
+import { RequestConfiguration } from '../utils/cancelRequests';
 
 /*
   Note: the usual combinations are IW + DV/SV + HIGH and EW + DH/SH + MEDIUM.

--- a/src/layer/S2L1CLayer.ts
+++ b/src/layer/S2L1CLayer.ts
@@ -1,6 +1,6 @@
-import { DATASET_S2L1C } from 'src/layer/dataset';
+import { DATASET_S2L1C } from './dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { Link, LinkType } from 'src/layer/const';
+import { Link, LinkType } from './const';
 
 export class S2L1CLayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L1C;

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -1,7 +1,7 @@
-import { DATASET_S2L2A } from 'src/layer/dataset';
+import { DATASET_S2L2A } from './dataset';
 import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
-import { ProcessingPayload } from 'src/layer/processing';
-import { Link, LinkType } from 'src/layer/const';
+import { ProcessingPayload } from './processing';
+import { Link, LinkType } from './const';
 
 export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L2A;

--- a/src/layer/S3OLCILayer.ts
+++ b/src/layer/S3OLCILayer.ts
@@ -1,11 +1,11 @@
 import moment from 'moment';
 
-import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link, LinkType } from 'src/layer/const';
-import { DATASET_S3OLCI } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { BBox } from '../bbox';
+import { PaginatedTiles, Link, LinkType } from './const';
+import { DATASET_S3OLCI } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
 export class S3OLCILayer extends AbstractSentinelHubV3Layer {
   public readonly dataset = DATASET_S3OLCI;

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
 
-import { BBox } from 'src/bbox';
-import { PaginatedTiles, OrbitDirection, Link, LinkType, DataProductId } from 'src/layer/const';
-import { DATASET_S3SLSTR } from 'src/layer/dataset';
-import { AbstractSentinelHubV3WithCCLayer } from 'src/layer/AbstractSentinelHubV3WithCCLayer';
-import { ProcessingPayload } from 'src/layer/processing';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { BBox } from '../bbox';
+import { PaginatedTiles, OrbitDirection, Link, LinkType, DataProductId } from './const';
+import { DATASET_S3SLSTR } from './dataset';
+import { AbstractSentinelHubV3WithCCLayer } from './AbstractSentinelHubV3WithCCLayer';
+import { ProcessingPayload } from './processing';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
 interface ConstructorParameters {
   instanceId?: string | null;

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
 
-import { BBox } from 'src/bbox';
-import { PaginatedTiles, Link, LinkType, DataProductId } from 'src/layer/const';
-import { DATASET_S5PL2 } from 'src/layer/dataset';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { ProcessingPayload } from 'src/layer/processing';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { BBox } from '../bbox';
+import { PaginatedTiles, Link, LinkType, DataProductId } from './const';
+import { DATASET_S5PL2 } from './dataset';
+import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
+import { ProcessingPayload } from './processing';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
 /*
   S-5P is a bit special in that we need to supply productType when searching

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -1,12 +1,12 @@
 import moment, { Moment } from 'moment';
 
-import { BBox } from 'src/bbox';
-import { GetMapParams, ApiType } from 'src/layer/const';
-import { wmsGetMapUrl } from 'src/layer/wms';
-import { AbstractLayer } from 'src/layer/AbstractLayer';
+import { BBox } from '../bbox';
+import { GetMapParams, ApiType } from './const';
+import { wmsGetMapUrl } from './wms';
+import { AbstractLayer } from './AbstractLayer';
 import { fetchGetCapabilitiesXml } from './utils';
-import { RequestConfiguration } from 'src/utils/cancelRequests';
-import { ensureTimeout } from 'src/utils/ensureTimeout';
+import { RequestConfiguration } from '../utils/cancelRequests';
+import { ensureTimeout } from '../utils/ensureTimeout';
 
 interface ConstructorParameters {
   baseUrl?: string;

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -1,4 +1,3 @@
-import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -12,6 +11,7 @@ import {
   OrbitDirection,
   LinkType,
 } from '../../index';
+import '../../../jest-setup';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -1,4 +1,4 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -11,7 +11,7 @@ import {
   Resolution,
   OrbitDirection,
   LinkType,
-} from 'src';
+} from '../../index';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -1,6 +1,7 @@
-import 'jest-setup';
+import '../../../jest-setup';
 
-import { ApiType, S2L1CLayer } from 'src';
+import { S2L1CLayer } from '../S2L1CLayer';
+import { ApiType } from '../const';
 
 test.each([
   ['https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999', false],

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -1,5 +1,4 @@
-import { S2L1CLayer } from '../S2L1CLayer';
-import { ApiType } from '../const';
+import { S2L1CLayer, ApiType } from '../../index';
 import '../../../jest-setup';
 
 test.each([

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -1,7 +1,6 @@
-import '../../../jest-setup';
-
 import { S2L1CLayer } from '../S2L1CLayer';
 import { ApiType } from '../const';
+import '../../../jest-setup';
 
 test.each([
   ['https://services.sentinel-hub.com/configuration/v1/datasets/S2L1C/dataproducts/99999', false],

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -1,9 +1,17 @@
-import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmsLayer, setAuthToken } from '../../index';
-import { invalidateCaches } from '../../utils/Cache';
+import {
+  BBox,
+  CRS_EPSG4326,
+  ApiType,
+  MimeTypes,
+  WmsLayer,
+  setAuthToken,
+  invalidateCaches,
+} from '../../index';
+
+import '../../../jest-setup';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/WmsLayer.ts
+++ b/src/layer/__tests__/WmsLayer.ts
@@ -1,9 +1,9 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmsLayer, setAuthToken } from 'src';
-import { invalidateCaches } from 'src/utils/Cache';
+import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmsLayer, setAuthToken } from '../../index';
+import { invalidateCaches } from '../../utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -1,10 +1,10 @@
-import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
+import { ApiType, setAuthToken, requestAuthToken, invalidateCaches } from '../../index';
+
+import '../../../jest-setup';
 import { constructFixtureGetMap } from './fixtures.auth';
-import { ApiType, setAuthToken, requestAuthToken } from '../../index';
-import { invalidateCaches } from '../../utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -1,10 +1,10 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { constructFixtureGetMap } from './fixtures.auth';
-import { ApiType, setAuthToken, requestAuthToken } from 'src';
-import { invalidateCaches } from 'src/utils/Cache';
+import { ApiType, setAuthToken, requestAuthToken } from '../../index';
+import { invalidateCaches } from '../../utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -1,15 +1,14 @@
-import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import makeServiceWorkerEnv from 'service-worker-mock';
 import fetch from 'node-fetch';
 
+import { ApiType, setAuthToken, invalidateCaches, CacheTarget } from '../../index';
+import { cacheStillValid, EXPIRY_HEADER_KEY } from '../../utils/cacheHandlers';
+
+import '../../../jest-setup';
 import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { constructFixtureGetMap } from './fixtures.getMap';
-import { ApiType } from '../../index';
-import { setAuthToken } from '../../auth';
-import { invalidateCaches, CacheTarget } from '../../utils/Cache';
-import { cacheStillValid, EXPIRY_HEADER_KEY } from '../../utils/cacheHandlers';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/cache.ts
+++ b/src/layer/__tests__/cache.ts
@@ -1,4 +1,4 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import makeServiceWorkerEnv from 'service-worker-mock';
@@ -6,9 +6,9 @@ import fetch from 'node-fetch';
 
 import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { constructFixtureGetMap } from './fixtures.getMap';
-import { ApiType } from 'src';
-import { setAuthToken } from 'src/auth';
-import { invalidateCaches, CacheTarget } from 'src/utils/Cache';
+import { ApiType } from '../../index';
+import { setAuthToken } from '../../auth';
+import { invalidateCaches, CacheTarget } from '../../utils/Cache';
 import { cacheStillValid, EXPIRY_HEADER_KEY } from '../../utils/cacheHandlers';
 
 const mockNetwork = new MockAdapter(axios);

--- a/src/layer/__tests__/fixtures.auth.ts
+++ b/src/layer/__tests__/fixtures.auth.ts
@@ -1,5 +1,4 @@
-import { S2L2ALayer, BBox, CRS_EPSG4326 } from '../../index';
-import { MimeTypes } from '../const';
+import { S2L2ALayer, BBox, CRS_EPSG4326, MimeTypes } from '../../index';
 
 export function constructFixtureGetMap(): Record<any, any> {
   const layer = new S2L2ALayer({

--- a/src/layer/__tests__/fixtures.auth.ts
+++ b/src/layer/__tests__/fixtures.auth.ts
@@ -1,4 +1,4 @@
-import { S2L2ALayer, BBox, CRS_EPSG4326 } from 'src';
+import { S2L2ALayer, BBox, CRS_EPSG4326 } from '../../index';
 import { MimeTypes } from '../const';
 
 export function constructFixtureGetMap(): Record<any, any> {

--- a/src/layer/__tests__/fixtures.findTiles.ts
+++ b/src/layer/__tests__/fixtures.findTiles.ts
@@ -8,8 +8,8 @@ import {
   AcquisitionMode,
   S1GRDAWSEULayer,
   BBox,
-} from 'src';
-import { CRS_EPSG4326 } from 'src/crs';
+} from '../../index';
+import { CRS_EPSG4326 } from '../../crs';
 
 export function constructFixtureFindTiles({
   sensingTime = '2018-11-28T11:12:13Z',

--- a/src/layer/__tests__/fixtures.findTiles.ts
+++ b/src/layer/__tests__/fixtures.findTiles.ts
@@ -8,8 +8,8 @@ import {
   AcquisitionMode,
   S1GRDAWSEULayer,
   BBox,
+  CRS_EPSG4326,
 } from '../../index';
-import { CRS_EPSG4326 } from '../../crs';
 
 export function constructFixtureFindTiles({
   sensingTime = '2018-11-28T11:12:13Z',

--- a/src/layer/__tests__/fixtures.getMap.ts
+++ b/src/layer/__tests__/fixtures.getMap.ts
@@ -1,5 +1,4 @@
-import { S2L2ALayer, BBox, CRS_EPSG4326 } from '../../index';
-import { MimeTypes } from '../const';
+import { S2L2ALayer, BBox, CRS_EPSG4326, MimeTypes } from '../../index';
 
 export function constructFixtureGetMap(): Record<any, any> {
   const layer = new S2L2ALayer({

--- a/src/layer/__tests__/fixtures.getMap.ts
+++ b/src/layer/__tests__/fixtures.getMap.ts
@@ -1,4 +1,4 @@
-import { S2L2ALayer, BBox, CRS_EPSG4326 } from 'src';
+import { S2L2ALayer, BBox, CRS_EPSG4326 } from '../../index';
 import { MimeTypes } from '../const';
 
 export function constructFixtureGetMap(): Record<any, any> {

--- a/src/layer/__tests__/fixtures.mosaickingOrder.ts
+++ b/src/layer/__tests__/fixtures.mosaickingOrder.ts
@@ -1,4 +1,4 @@
-import { BBox, CRS_EPSG4326, GetMapParams, MimeTypes } from 'src';
+import { BBox, CRS_EPSG4326, GetMapParams, MimeTypes } from '../../index';
 
 const bbox4326 = new BBox(CRS_EPSG4326, 11.9, 42.05, 12.95, 43.09);
 

--- a/src/layer/__tests__/legacy.ts
+++ b/src/layer/__tests__/legacy.ts
@@ -1,5 +1,5 @@
-import '../../../jest-setup';
 import moment from 'moment';
+import '../../../jest-setup';
 
 import { parseLegacyWmsGetMapParams, BBox, CRS_EPSG3857, GetMapParams, PreviewMode } from '../../index';
 

--- a/src/layer/__tests__/legacy.ts
+++ b/src/layer/__tests__/legacy.ts
@@ -1,7 +1,7 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import moment from 'moment';
 
-import { parseLegacyWmsGetMapParams, BBox, CRS_EPSG3857, GetMapParams, PreviewMode } from 'src';
+import { parseLegacyWmsGetMapParams, BBox, CRS_EPSG3857, GetMapParams, PreviewMode } from '../../index';
 
 test('parseLegacyWmsGetMapParams with evalscripturl', () => {
   const evalscriptUrlOriginal =

--- a/src/layer/__tests__/mosaickingOrder.ts
+++ b/src/layer/__tests__/mosaickingOrder.ts
@@ -1,8 +1,10 @@
-import '../../../jest-setup';
-import { ApiType, MosaickingOrder, S2L2ALayer, setAuthToken } from '../../index';
-import { ProcessingPayload, ProcessingPayloadDatasource } from '../processing';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+
+import { ApiType, MosaickingOrder, S2L2ALayer, setAuthToken } from '../../index';
+import { ProcessingPayload, ProcessingPayloadDatasource } from '../processing';
+
+import '../../../jest-setup';
 import { constructFixtureMosaickingOrder } from './fixtures.mosaickingOrder';
 
 const extractDataFilterFromPayload = (payload: ProcessingPayload): any => {

--- a/src/layer/__tests__/mosaickingOrder.ts
+++ b/src/layer/__tests__/mosaickingOrder.ts
@@ -1,5 +1,5 @@
-import 'jest-setup';
-import { ApiType, MosaickingOrder, S2L2ALayer, setAuthToken } from '../../../src';
+import '../../../jest-setup';
+import { ApiType, MosaickingOrder, S2L2ALayer, setAuthToken } from '../../index';
 import { ProcessingPayload, ProcessingPayloadDatasource } from '../processing';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';

--- a/src/layer/__tests__/retries.ts
+++ b/src/layer/__tests__/retries.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { invalidateCaches } from '../../utils/Cache';
+import { invalidateCaches } from '../../index';
 
 import '../../../jest-setup';
 import { constructFixtureFindTiles } from './fixtures.findTiles';

--- a/src/layer/__tests__/retries.ts
+++ b/src/layer/__tests__/retries.ts
@@ -1,9 +1,10 @@
-import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { invalidateCaches } from '../../utils/Cache';
+
+import '../../../jest-setup';
+import { constructFixtureFindTiles } from './fixtures.findTiles';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/__tests__/retries.ts
+++ b/src/layer/__tests__/retries.ts
@@ -1,9 +1,9 @@
-import 'jest-setup';
+import '../../../jest-setup';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { constructFixtureFindTiles } from './fixtures.findTiles';
-import { invalidateCaches } from 'src/utils/Cache';
+import { invalidateCaches } from '../../utils/Cache';
 
 const mockNetwork = new MockAdapter(axios);
 

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -1,8 +1,8 @@
 import { Polygon, MultiPolygon } from '@turf/helpers';
 
-import { BBox } from 'src/bbox';
-import { CRS_IDS } from 'src/crs';
-import { Effects } from 'src/mapDataManipulation/const';
+import { BBox } from '../bbox';
+import { CRS_IDS } from '../crs';
+import { Effects } from '../mapDataManipulation/const';
 
 /**
  * Specifies the content that should be fetched (area, time or time interval, modifiers, output format,...).

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -1,19 +1,12 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { Polygon, BBox as BBoxTurf, MultiPolygon } from '@turf/helpers';
 
-import { getAuthToken } from 'src/auth';
+import { getAuthToken } from '../auth';
 
-import {
-  MimeType,
-  GetMapParams,
-  Interpolator,
-  PreviewMode,
-  MosaickingOrder,
-  DataProductId,
-} from 'src/layer/const';
-import { Dataset } from 'src/layer/dataset';
-import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
-import { CACHE_CONFIG_30MIN } from 'src/utils/cacheHandlers';
+import { MimeType, GetMapParams, Interpolator, PreviewMode, MosaickingOrder, DataProductId } from './const';
+import { Dataset } from './dataset';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
+import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 
 enum PreviewModeString {
   DETAIL = 'DETAIL',

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,9 +2,9 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from 'src/layer/const';
-import { getAxiosReqParams, RequestConfiguration } from 'src/utils/cancelRequests';
-import { CACHE_CONFIG_30MIN } from 'src/utils/cacheHandlers';
+import { SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
+import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 
 export type GetCapabilitiesXml = {
   WMS_Capabilities: {

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -2,8 +2,8 @@ import { stringify } from 'query-string';
 import moment from 'moment';
 import WKT from 'terraformer-wkt-parser';
 
-import { CRS_EPSG4326, CRS_IDS } from 'src/crs';
-import { GetMapParams, MimeTypes, MimeType, MosaickingOrder } from 'src/layer/const';
+import { CRS_EPSG4326, CRS_IDS } from '../crs';
+import { GetMapParams, MimeTypes, MimeType, MosaickingOrder } from './const';
 
 export enum ServiceType {
   WMS = 'WMS',

--- a/src/legacyCompat.ts
+++ b/src/legacyCompat.ts
@@ -1,13 +1,13 @@
 import WKT from 'terraformer-wkt-parser';
 import { Polygon } from '@turf/helpers';
 
-import { BBox } from 'src/bbox';
-import { CRS_IDS, CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from 'src/crs';
-import { ApiType, MimeType, GetMapParams } from 'src/layer/const';
-import { ServiceType } from 'src/layer/wms';
-import { AbstractSentinelHubV3Layer } from 'src/layer/AbstractSentinelHubV3Layer';
-import { LayersFactory } from 'src/layer/LayersFactory';
-import { WmsLayer } from 'src/layer/WmsLayer';
+import { BBox } from './bbox';
+import { CRS_IDS, CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from './crs';
+import { ApiType, MimeType, GetMapParams } from './layer/const';
+import { ServiceType } from './layer/wms';
+import { AbstractSentinelHubV3Layer } from './layer/AbstractSentinelHubV3Layer';
+import { LayersFactory } from './layer/LayersFactory';
+import { WmsLayer } from './layer/WmsLayer';
 
 export async function legacyGetMapFromUrl(
   urlWithQueryParams: string,

--- a/src/mapDataManipulation/effectFunctions.ts
+++ b/src/mapDataManipulation/effectFunctions.ts
@@ -1,9 +1,9 @@
-import { Effects, RgbMappingArrays } from 'src/mapDataManipulation/const';
+import { Effects, RgbMappingArrays } from './const';
 import {
   isEffectSet,
   changeRgbMappingArraysWithFunction,
   transformValueToRange,
-} from 'src/mapDataManipulation/mapDataManipulationUtils';
+} from './mapDataManipulationUtils';
 
 export function runGainEffectFunction(
   rgbMappingArrays: RgbMappingArrays,

--- a/src/mapDataManipulation/mapDataManipulationUtils.ts
+++ b/src/mapDataManipulation/mapDataManipulationUtils.ts
@@ -1,4 +1,4 @@
-import { RgbMappingArrays, Effects, ColorRange } from 'src/mapDataManipulation/const';
+import { RgbMappingArrays, Effects, ColorRange } from './const';
 
 export function prepareRgbMappingArrays(): RgbMappingArrays {
   return {

--- a/src/mapDataManipulation/runEffectFunctions.ts
+++ b/src/mapDataManipulation/runEffectFunctions.ts
@@ -1,16 +1,12 @@
-import { mapDataManipulation } from 'src/mapDataManipulation/mapDataManipulation';
-import { Effects } from 'src/mapDataManipulation/const';
+import { mapDataManipulation } from './mapDataManipulation';
+import { Effects } from './const';
 import {
   isAnyEffectSet,
   prepareRgbMappingArrays,
   changeRgbMappingArraysRange,
   prepareManipulatePixel,
-} from 'src/mapDataManipulation/mapDataManipulationUtils';
-import {
-  runGainEffectFunction,
-  runGammaEffectFunction,
-  runColorEffectFunction,
-} from 'src/mapDataManipulation/effectFunctions';
+} from './mapDataManipulationUtils';
+import { runGainEffectFunction, runGammaEffectFunction, runColorEffectFunction } from './effectFunctions';
 
 // The algorithm works with numbers between 0 and 1, so we must:
 // - change the range of the values from [0, 255] to [0, 1]

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -1,12 +1,12 @@
 import axios, { AxiosRequestConfig, CancelToken, AxiosError } from 'axios';
 
-import { isDebugEnabled } from 'src/utils/debug';
+import { isDebugEnabled } from './debug';
 import {
   fetchCachedResponse,
   saveCacheResponse,
   findAndDeleteExpiredCachedItems,
   CacheConfig,
-} from 'src/utils/cacheHandlers';
+} from './cacheHandlers';
 
 const DEFAULT_RETRY_DELAY = 3000;
 const DEFAULT_MAX_RETRIES = 2;

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,5 +1,5 @@
 import axios, { CancelTokenSource, AxiosRequestConfig, CancelToken as CancelTokenAxios } from 'axios';
-import { CacheConfig } from 'src/utils/cacheHandlers';
+import { CacheConfig } from './cacheHandlers';
 
 export type RequestConfiguration = {
   authToken?: string | null;

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import { MimeType } from 'src/layer/const';
+import { MimeType } from '../layer/const';
 
 export async function drawBlobOnCanvas(
   ctx: CanvasRenderingContext2D,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "declaration": true,
     "declarationDir": "./dist",
     "module": "es6",


### PR DESCRIPTION
* Changed absolute paths to relative paths

The reason for this change is that the imports in index.d.ts would not be resolved when the library is consumed. In order for a consumer to load  the modules and declarations correctly each consumer would require a webpack/rollup config to resolve these absolute paths that are defined in tsconfig. 