### PR TITLE
Problem with cacheApi

### DIFF
--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -49,7 +49,7 @@ async function checkIfCacheApiAvailable(): Promise<boolean> {
     await caches.keys();
     return true;
   } catch (err) {
-    console.error('CacheApi is not available', err);
+    console.warn('CacheApi is not available', err);
     return false;
   }
 }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -21,7 +21,7 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (cacheKey === null) {
     return request;
   }
-  const shCache = cacheFactory(request.cache.targets);
+  const shCache = await cacheFactory(request.cache.targets);
   if (!shCache) {
     return request;
   }
@@ -54,7 +54,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
   if (!response.config.cacheKey) {
     return response;
   }
-  const shCache = cacheFactory(response.config.cache.targets);
+  const shCache = await cacheFactory(response.config.cache.targets);
   if (!shCache) {
     return response;
   }
@@ -109,7 +109,7 @@ const stringToHash = async (message: string): Promise<any> => {
 
 export const findAndDeleteExpiredCachedItems = async (): Promise<void> => {
   for (const target of SUPPORTED_TARGETS) {
-    const shCache = cacheFactory([target]);
+    const shCache = await cacheFactory([target]);
     if (!shCache) {
       continue;
     }


### PR DESCRIPTION
[trello](https://trello.com/c/ZS3gSYlX/66-caching-problem)

It turns out that it is not sufficient to check if `window.caches` object exists, but  some request should be made to determine whether cacheApi can be used or not. 
I was able to reproduce this only in firefox private mode.  

