### PR TITLE
Disable storybook webpack (verbose) output

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "TZ=Europe/Ljubljana jest",
     "lint": "eslint --max-warnings 0 --ext .ts,js src/",
     "prettier": "prettier --write \"{src,example,stories}/**/*.{ts,js}\"",
-    "storybook": "concurrently --kill-others \"rollup -c -w\" \"start-storybook -p 6006\"",
+    "storybook": "concurrently --kill-others \"rollup -c -w\" \"start-storybook -p 6006 --quiet\"",
     "build-storybook": "build-storybook",
     "build-doc": "typedoc --excludePrivate --excludeProtected --excludeNotExported --exclude '**/*__*' --out doc/ src/"
   },


### PR DESCRIPTION
Running `npm run storybook` resulted in many pages of output because `concurrently` messed with storybook's webpack progress display.