### PR TITLE
Fix/huge map format dimension limits

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -5,7 +5,7 @@ import { union, intersection, Geom } from 'polygon-clipping';
 
 import { BBox } from '../bbox';
 import { CRS_EPSG4326 } from '../crs';
-import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, PreviewMode } from './const';
+import { GetMapParams, ApiType, PaginatedTiles, FlyoverInterval, PreviewMode, MimeTypes } from './const';
 import { Dataset } from './dataset';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { ensureTimeout } from '../utils/ensureTimeout';
@@ -88,6 +88,9 @@ export class AbstractLayer {
         throw new Error(
           'Method getHugeMap() requests that width and height of resulting image are specified',
         );
+      }
+      if (params.format !== MimeTypes.JPEG || params.format !== MimeTypes.PNG) {
+        throw new Error('getHugeMap does not support' + params.format + 'only PNG and JPEG are supported');
       }
 
       const LIMIT_DIM = 2000;

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -93,7 +93,7 @@ export class AbstractLayer {
         throw new Error('getHugeMap does not support' + params.format + 'only PNG and JPEG are supported');
       }
 
-      const LIMIT_DIM = 2000;
+      const LIMIT_DIM = 2500;
       if (width <= LIMIT_DIM && height <= LIMIT_DIM) {
         return await this.getMap(params, api, innerReqConfig);
       }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -90,7 +90,7 @@ export class AbstractLayer {
         );
       }
       if (params.format !== MimeTypes.JPEG && params.format !== MimeTypes.PNG) {
-        throw new Error('getHugeMap does not support' + params.format + 'only PNG and JPEG are supported');
+        throw new Error('getHugeMap does not support ' + params.format + ' only PNG and JPEG are supported');
       }
 
       const LIMIT_DIM = 2500;

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -90,7 +90,15 @@ export class AbstractLayer {
         );
       }
       if (params.format !== MimeTypes.JPEG && params.format !== MimeTypes.PNG) {
-        throw new Error('getHugeMap does not support ' + params.format + ' only PNG and JPEG are supported');
+        throw new Error(
+          'Format ' +
+            params.format +
+            ' not supported, only ' +
+            MimeTypes.PNG +
+            ' and ' +
+            MimeTypes.JPEG +
+            ' are allowed',
+        );
       }
 
       const LIMIT_DIM = 2500;

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -89,7 +89,7 @@ export class AbstractLayer {
           'Method getHugeMap() requests that width and height of resulting image are specified',
         );
       }
-      if (params.format !== MimeTypes.JPEG || params.format !== MimeTypes.PNG) {
+      if (params.format !== MimeTypes.JPEG && params.format !== MimeTypes.PNG) {
         throw new Error('getHugeMap does not support' + params.format + 'only PNG and JPEG are supported');
       }
 

--- a/src/layer/__tests__/fixtures.getHugeMap.ts
+++ b/src/layer/__tests__/fixtures.getHugeMap.ts
@@ -1,0 +1,21 @@
+import { S2L2ALayer, BBox, CRS_EPSG4326 } from '../../index';
+
+export function constructFixtureGetMapTiff(): Record<any, any> {
+  const layer = new S2L2ALayer({
+    evalscript: '//VERSION=3\nreturn [B02, B02, B02];',
+    maxCloudCoverPercent: 100,
+  });
+  const getMapParams = {
+    bbox: new BBox(CRS_EPSG4326, 18, 20, 20, 22),
+    fromTime: new Date(Date.UTC(2019, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2019, 12 - 1, 22, 23, 59, 59)),
+    width: 2501,
+    height: 2501,
+    format: 'image/tiff',
+  };
+
+  return {
+    layer: layer,
+    getMapParams: getMapParams,
+  };
+}

--- a/src/layer/__tests__/getHugeMap.ts
+++ b/src/layer/__tests__/getHugeMap.ts
@@ -1,5 +1,3 @@
-import 'jest-canvas-mock';
-
 import { ApiType, setAuthToken, invalidateCaches } from '../../index';
 
 import '../../../jest-setup';

--- a/src/layer/__tests__/getHugeMap.ts
+++ b/src/layer/__tests__/getHugeMap.ts
@@ -17,6 +17,6 @@ test('getHugeMap should throw an error when format is not supported', async () =
   try {
     await layer.getHugeMap(getMapParams, ApiType.PROCESSING);
   } catch (e) {
-    expect(e.message).toBe('getHugeMap does not support image/tiff only PNG and JPEG are supported');
+    expect(e.message).toBe('Format image/tiff not supported, only image/png and image/jpeg are allowed');
   }
 });

--- a/src/layer/__tests__/getHugeMap.ts
+++ b/src/layer/__tests__/getHugeMap.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import 'jest-canvas-mock';
+
+import { ApiType, setAuthToken, invalidateCaches } from '../../index';
+
+import '../../../jest-setup';
+import { constructFixtureGetMapTiff, constructFixtureGetMapJPEG } from './fixtures.getHugeMap';
+
+const mockNetwork = new MockAdapter(axios);
+
+const EXAMPLE_TOKEN = 'TOKEN111';
+
+beforeEach(async () => {
+  await invalidateCaches();
+});
+
+test('getHugeMap should throw an error when format is not supported', async () => {
+  const { layer, getMapParams } = constructFixtureGetMapTiff();
+  setAuthToken(EXAMPLE_TOKEN);
+  try {
+    await layer.getHugeMap(getMapParams, ApiType.PROCESSING);
+  } catch (e) {
+    expect(e.message).toBe('getHugeMap does not support image/tiff only PNG and JPEG are supported');
+  }
+});

--- a/src/layer/__tests__/getHugeMap.ts
+++ b/src/layer/__tests__/getHugeMap.ts
@@ -1,13 +1,9 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 import 'jest-canvas-mock';
 
 import { ApiType, setAuthToken, invalidateCaches } from '../../index';
 
 import '../../../jest-setup';
-import { constructFixtureGetMapTiff, constructFixtureGetMapJPEG } from './fixtures.getHugeMap';
-
-const mockNetwork = new MockAdapter(axios);
+import { constructFixtureGetMapTiff } from './fixtures.getHugeMap';
 
 const EXAMPLE_TOKEN = 'TOKEN111';
 


### PR DESCRIPTION
* throw error if image format is not supported by `getHugeMap`
* Change image dimension limits according to docs