### PR TITLE
Fix/effects one array with pixel data

### DIFF
--- a/src/mapDataManipulation/const.ts
+++ b/src/mapDataManipulation/const.ts
@@ -12,13 +12,6 @@ export type Effects = {
   customEffect?: Function;
 };
 
-export type RgbaArrays = {
-  red: number[];
-  green: number[];
-  blue: number[];
-  alpha: number[];
-};
-
 export type ImageProperties = {
   imageData: Uint8ClampedArray;
   imageWidth: number;

--- a/src/mapDataManipulation/mapDataManipulationUtils.ts
+++ b/src/mapDataManipulation/mapDataManipulationUtils.ts
@@ -1,4 +1,4 @@
-import { RgbaArrays, Effects, ColorRange, ImageProperties } from './const';
+import { Effects, ColorRange, ImageProperties } from './const';
 
 export async function getImageData(originalBlob: Blob): Promise<ImageProperties> {
   let imgObjectUrl: any;
@@ -28,35 +28,6 @@ export async function getImageData(originalBlob: Blob): Promise<ImageProperties>
       window.URL.revokeObjectURL(imgObjectUrl);
     }
   }
-}
-
-export function prepareRgbaArrays(imgData: Uint8ClampedArray): RgbaArrays {
-  let red = [],
-    green = [],
-    blue = [],
-    alpha = [];
-
-  for (let i = 0; i < imgData.length; i += 4) {
-    red.push(imgData[i]);
-    green.push(imgData[i + 1]);
-    blue.push(imgData[i + 2]);
-    alpha.push(imgData[i + 3]);
-  }
-
-  return { red, green, blue, alpha };
-}
-
-export function prepareImageData(rgbArrays: RgbaArrays, imageData: Uint8ClampedArray): Uint8ClampedArray {
-  let newImgData: Uint8ClampedArray = new Uint8ClampedArray(imageData.length);
-
-  for (let i = 0; i < newImgData.length; i += 4) {
-    newImgData[i] = rgbArrays.red[i / 4];
-    newImgData[i + 1] = rgbArrays.green[i / 4];
-    newImgData[i + 2] = rgbArrays.blue[i / 4];
-    newImgData[i + 3] = rgbArrays.alpha[i / 4];
-  }
-
-  return newImgData;
 }
 
 export async function getBlob(imageProperties: ImageProperties): Promise<Blob> {
@@ -100,25 +71,6 @@ export function transformValueToRange(
   newX = Math.max(newX, newMin);
   newX = Math.min(newX, newMax);
   return newX;
-}
-
-export function changeRgbaArraysRange(
-  rgbaArrays: RgbaArrays,
-  oldMin: number,
-  oldMax: number,
-  newMin: number,
-  newMax: number,
-): RgbaArrays {
-  const newRgbaArrays = { ...rgbaArrays };
-  newRgbaArrays.red = newRgbaArrays.red.map(x => transformValueToRange(x, oldMin, oldMax, newMin, newMax));
-  newRgbaArrays.green = newRgbaArrays.green.map(x =>
-    transformValueToRange(x, oldMin, oldMax, newMin, newMax),
-  );
-  newRgbaArrays.blue = newRgbaArrays.blue.map(x => transformValueToRange(x, oldMin, oldMax, newMin, newMax));
-  newRgbaArrays.alpha = newRgbaArrays.alpha.map(x =>
-    transformValueToRange(x, oldMin, oldMax, newMin, newMax),
-  );
-  return newRgbaArrays;
 }
 
 export function isEffectSet(effect: number | ColorRange | Function): boolean {


### PR DESCRIPTION
This MR branches off from `fix/effects-refactor-3arrays`, MR https://github.com/sentinel-hub/sentinelhub-js/pull/136.

It uses 1 array (R, G, B, A values following sequentially) - cloned [imageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) array.

The execution time for the effects is between 200 and 300 ms (512 * 512 px)