### PR TITLE
Feature/use catalog for findDatesUTC

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -607,7 +607,13 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     fromTime: Date,
     toTime: Date,
   ): Promise<Date[]> {
-    const findDatesUTCAdditionalParameters = await this.getFindDatesUTCAdditionalParameters();
+    const { maxCloudCoverage, datasetParameters } = await this.getFindDatesUTCAdditionalParameters();
+
+    let findTilesAdditionalParameters: Record<string, any> = { datasetParameters: datasetParameters };
+    if (maxCloudCoverage !== null && maxCloudCoverage !== undefined) {
+      findTilesAdditionalParameters.maxCloudCoverPercent = maxCloudCoverage * 100;
+    }
+
     const response = await this.findTilesUsingCatalog(
       authToken,
       bbox,
@@ -616,7 +622,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       10000,
       0,
       innerReqConfig,
-      findDatesUTCAdditionalParameters,
+      findTilesAdditionalParameters,
       'date',
     );
     return response.data.features

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -488,7 +488,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     offset: number | null = null,
     reqConfig: RequestConfiguration,
     findTilesAdditionalParameters: FindTilesAdditionalParameters,
-    distinct: string | null = null,
   ): Promise<Record<string, any>> {
     if (!authToken) {
       throw new Error('Must be authenticated to use Catalog service');
@@ -508,7 +507,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       ...getAxiosReqParams(reqConfig, CACHE_CONFIG_30MIN),
     };
 
-    const { maxCloudCoverPercent, datasetParameters } = findTilesAdditionalParameters;
+    const { maxCloudCoverPercent, datasetParameters, distinct } = findTilesAdditionalParameters;
 
     const payload: any = {
       bbox: [bbox.minX, bbox.minY, bbox.maxX, bbox.maxY],
@@ -613,6 +612,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (maxCloudCoverage !== null && maxCloudCoverage !== undefined) {
       findTilesAdditionalParameters.maxCloudCoverPercent = maxCloudCoverage * 100;
     }
+    findTilesAdditionalParameters.distinct = 'date';
 
     const response = await this.findTilesUsingCatalog(
       authToken,
@@ -623,7 +623,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       0,
       innerReqConfig,
       findTilesAdditionalParameters,
-      'date',
     );
     return response.data.features
       .map((date: Date) => new Date(date))

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -56,9 +56,11 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
   protected async getFindDatesUTCAdditionalParameters(
     reqConfig: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Record<string, any>> {
-    return {
-      maxCloudCoverage: this.maxCloudCoverPercent / 100,
-    };
+    return this.maxCloudCoverPercent !== null && this.maxCloudCoverPercent !== undefined
+      ? {
+          maxCloudCoverage: this.maxCloudCoverPercent / 100,
+        }
+      : {};
   }
   protected getStatsAdditionalParameters(): Record<string, any> {
     return {

--- a/src/layer/__tests__/BYOCLayer.ts
+++ b/src/layer/__tests__/BYOCLayer.ts
@@ -1,4 +1,4 @@
-import { BBox, CRS_EPSG4326, setAuthToken, LocationIdSHv3, BYOCLayer, DATASET_BYOC } from '../../index';
+import { BBox, CRS_EPSG4326, setAuthToken, LocationIdSHv3, BYOCLayer } from '../../index';
 import { SHV3_LOCATIONS_ROOT_URL } from '../const';
 import { constructFixtureFindTilesSearchIndex, constructFixtureFindTilesCatalog } from './fixtures.BYOCLayer';
 

--- a/src/layer/__tests__/Landsat8AWSLayer.ts
+++ b/src/layer/__tests__/Landsat8AWSLayer.ts
@@ -1,4 +1,4 @@
-import { BBox, CRS_EPSG4326, setAuthToken } from '../../index';
+import { BBox, CRS_EPSG4326, setAuthToken, Landsat8AWSLayer, DATASET_AWS_L8L1C } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -11,6 +11,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const SEARCH_INDEX_URL = 'https://services-uswest2.sentinel-hub.com/index/v3/collections/L8L1C/searchIndex';
 const CATALOG_URL = 'https://services-uswest2.sentinel-hub.com/api/v1/catalog/search';
@@ -83,5 +94,88 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_AWS_L8L1C.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new Landsat8AWSLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/MODISLayer.ts
+++ b/src/layer/__tests__/MODISLayer.ts
@@ -1,4 +1,4 @@
-import { BBox, CRS_EPSG4326, setAuthToken } from '../../index';
+import { BBox, CRS_EPSG4326, setAuthToken, MODISLayer, DATASET_MODIS } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -11,6 +11,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const CATALOG_URL = 'https://services-uswest2.sentinel-hub.com/api/v1/catalog/search';
 const SEARCH_INDEX_URL = 'https://services-uswest2.sentinel-hub.com/index/v3/collections/MODIS/searchIndex';
@@ -64,5 +75,85 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_MODIS.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new MODISLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -1,5 +1,5 @@
 import { setAuthToken } from '../../index';
-import { ApiType, BBox, CRS_EPSG4326, S2L1CLayer } from '../../index';
+import { ApiType, BBox, CRS_EPSG4326, S2L1CLayer, DATASET_S2L1C } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -13,6 +13,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const SEARCH_INDEX_URL = 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex';
 
@@ -84,6 +95,89 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_S2L1C.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S2L1CLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });
 

--- a/src/layer/__tests__/S2L2ACLayer.ts
+++ b/src/layer/__tests__/S2L2ACLayer.ts
@@ -1,5 +1,5 @@
 import { setAuthToken } from '../../index';
-import { BBox, CRS_EPSG4326 } from '../../index';
+import { BBox, CRS_EPSG4326, S2L2ALayer, DATASET_S2L2A } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -13,6 +13,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const SEARCH_INDEX_URL = 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/searchIndex';
 
@@ -84,5 +95,88 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_S2L2A.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S2L2ALayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/S3OLCILayer.ts
+++ b/src/layer/__tests__/S3OLCILayer.ts
@@ -1,4 +1,4 @@
-import { BBox, CRS_EPSG4326, setAuthToken } from '../../index';
+import { BBox, CRS_EPSG4326, S3OLCILayer, setAuthToken, DATASET_S3OLCI } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -11,6 +11,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const CATALOG_URL = 'https://creodias.sentinel-hub.com/api/v1/catalog/search';
 const SEARCH_INDEX_URL = 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/searchIndex';
@@ -64,5 +75,82 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_S3OLCI.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S3OLCILayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/S3SLTRLayer.ts
+++ b/src/layer/__tests__/S3SLTRLayer.ts
@@ -1,5 +1,5 @@
 import { setAuthToken } from '../../index';
-import { BBox, CRS_EPSG4326 } from '../../index';
+import { BBox, CRS_EPSG4326, S3SLSTRLayer, DATASET_S3SLSTR } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -12,6 +12,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 const CATALOG_URL = 'https://creodias.sentinel-hub.com/api/v1/catalog/search';
 const SEARCH_INDEX_URL = 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/searchIndex';
@@ -84,5 +95,88 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_S3SLSTR.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams.maxCloudCoverPercent !== null && layerParams.maxCloudCoverPercent !== undefined) {
+      constructorParams.maxCloudCoverPercent = layerParams.maxCloudCoverPercent;
+    }
+
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S3SLSTRLayer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/S5PL2Layer.ts
+++ b/src/layer/__tests__/S5PL2Layer.ts
@@ -1,5 +1,5 @@
 import { setAuthToken } from '../../index';
-import { BBox, CRS_EPSG4326 } from '../../index';
+import { BBox, CRS_EPSG4326, S5PL2Layer, DATASET_S5PL2 } from '../../index';
 import {
   constructFixtureFindTilesSearchIndex,
   constructFixtureFindTilesCatalog,
@@ -12,6 +12,17 @@ import {
   checkResponseFindTiles,
   mockNetwork,
 } from './testUtils.findTiles';
+
+import {
+  checkIfCorrectEndpointIsUsedFindDatesUTC,
+  checkRequestFindDatesUTC,
+  checkResponseFindDatesUTC,
+} from './testUtils.findDatesUTC';
+
+import {
+  constructFixtureFindDatesUTCSearchIndex,
+  constructFixtureFindDatesUTCCatalog,
+} from './fixtures.findDatesUTC';
 
 import { ProductType } from '../S5PL2Layer';
 
@@ -73,5 +84,87 @@ describe('Test findTiles using catalog', () => {
 
   test('response from catalog', async () => {
     await checkResponseFindTiles(constructFixtureFindTilesCatalog({}));
+  });
+});
+
+describe('Test findDatesUTC using searchIndex', () => {
+  beforeEach(async () => {
+    setAuthToken(null);
+    mockNetwork.reset();
+  });
+
+  test('findAvailableData is used if token is not set', async () => {
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      null,
+      constructFixtureFindDatesUTCSearchIndex(layer, {}),
+      DATASET_S5PL2.findDatesUTCUrl,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams && layerParams.productType) {
+      constructorParams.productType = layerParams.productType;
+    }
+
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCSearchIndex(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCSearchIndex(layer, {}));
+  });
+});
+describe('Test findDatesUTC using catalog', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('catalog is used if token is set', async () => {
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkIfCorrectEndpointIsUsedFindDatesUTC(
+      AUTH_TOKEN,
+      constructFixtureFindDatesUTCCatalog(layer, {}),
+      CATALOG_URL,
+    );
+  });
+
+  test.each(layerParamsArr)('check if correct request is constructed', async layerParams => {
+    let constructorParams: Record<string, any> = {};
+    if (layerParams && layerParams.productType) {
+      constructorParams.productType = layerParams.productType;
+    }
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+      ...constructorParams,
+    });
+    const fixtures = constructFixtureFindDatesUTCCatalog(layer, layerParams);
+    await checkRequestFindDatesUTC(fixtures);
+  });
+
+  test('response from service', async () => {
+    const layer = new S5PL2Layer({
+      instanceId: 'INSTANCE_ID',
+      layerId: 'LAYER_ID',
+    });
+    await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
   });
 });

--- a/src/layer/__tests__/fixtures.findDatesUTC.ts
+++ b/src/layer/__tests__/fixtures.findDatesUTC.ts
@@ -1,0 +1,270 @@
+import {
+  AcquisitionMode,
+  BBox,
+  BYOCLayer,
+  CRS_EPSG4326,
+  OrbitDirection,
+  Polarization,
+  Resolution,
+  S1GRDAWSEULayer,
+  S3SLSTRLayer,
+  S5PL2Layer,
+} from '../../index';
+import { AbstractSentinelHubV3Layer } from '../AbstractSentinelHubV3Layer';
+import { AbstractSentinelHubV3WithCCLayer } from '../AbstractSentinelHubV3WithCCLayer';
+
+export function constructFixtureFindDatesUTCSearchIndex(
+  layer: AbstractSentinelHubV3Layer,
+  {
+    fromTime = new Date(Date.UTC(2020, 4 - 1, 1, 0, 0, 0, 0)),
+    toTime = new Date(Date.UTC(2020, 5 - 1, 1, 23, 59, 59, 999)),
+    bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21),
+    maxCloudCoverPercent = null as number,
+    productType = null as string,
+    collectionId = 'mockCollectionId',
+    acquisitionMode = null as AcquisitionMode,
+    polarization = null as Polarization.DV,
+    resolution = null as Resolution.HIGH,
+    orbitDirection = null as OrbitDirection.ASCENDING,
+  },
+): Record<any, any> {
+  const expectedRequest: Record<string, any> = {
+    queryArea: {
+      type: 'Polygon',
+      crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::4326' } },
+      coordinates: [
+        [
+          [bbox.minX, bbox.minY],
+          [bbox.maxX, bbox.minY],
+          [bbox.maxX, bbox.maxY],
+          [bbox.minX, bbox.maxY],
+          [bbox.minX, bbox.minY],
+        ],
+      ],
+    },
+    maxCloudCoverage: maxCloudCoverPercent !== null ? maxCloudCoverPercent / 100 : 1,
+    from: fromTime.toISOString(),
+    to: toTime.toISOString(),
+  };
+  /*
+datasetParameters: {
+      acquisitionMode: acquisitionMode,
+      orbitDirection: orbitDirection,
+      polarization: polarization,
+      resolution: resolution,
+      type: 'S1GRD',
+    },
+
+*/
+  if (layer instanceof S1GRDAWSEULayer) {
+    expectedRequest.datasetParameters = { type: 'S1GRD' };
+  }
+  if (layer instanceof S1GRDAWSEULayer && acquisitionMode) {
+    expectedRequest.datasetParameters['acquisitionMode'] = acquisitionMode;
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && orbitDirection) {
+    expectedRequest.datasetParameters['orbitDirection'] = orbitDirection;
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && polarization) {
+    expectedRequest.datasetParameters['polarization'] = polarization;
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && resolution) {
+    expectedRequest.datasetParameters['resolution'] = resolution;
+  }
+
+  if (layer instanceof S3SLSTRLayer) {
+    expectedRequest.datasetParameters = {
+      orbitDirection: 'DESCENDING',
+      type: 'S3SLSTR',
+      view: 'NADIR',
+    };
+  }
+
+  if (layer instanceof S5PL2Layer) {
+    if (productType) {
+      expectedRequest.datasetParameters = {
+        productType: productType,
+        type: 'S5PL2',
+      };
+    } else {
+      expectedRequest.datasetParameters = {
+        type: 'S5PL2',
+      };
+    }
+  }
+
+  if (layer instanceof BYOCLayer && collectionId) {
+    expectedRequest.datasetParameters = {
+      collectionId: collectionId,
+      type: 'BYOC',
+    };
+  }
+  /*
+  if (layer instanceof BYOCLayer && locationId) {
+    expectedRequest.datasetParameters = {
+      locationId: locationId,
+    };
+  }
+*/
+  if (
+    !(layer instanceof AbstractSentinelHubV3WithCCLayer || layer instanceof S5PL2Layer) &&
+    (maxCloudCoverPercent === null || maxCloudCoverPercent === undefined)
+  ) {
+    delete expectedRequest['maxCloudCoverage'];
+  }
+
+  const mockedResponse = [
+    '2020-04-30',
+    '2020-04-28',
+    '2020-04-26',
+    '2020-04-23',
+    '2020-04-21',
+    '2020-04-18',
+    '2020-04-16',
+    '2020-04-13',
+    '2020-04-11',
+    '2020-04-08',
+    '2020-04-06',
+    '2020-04-03',
+    '2020-04-01',
+  ];
+
+  const expectedResult = [
+    '2020-04-30',
+    '2020-04-28',
+    '2020-04-26',
+    '2020-04-23',
+    '2020-04-21',
+    '2020-04-18',
+    '2020-04-16',
+    '2020-04-13',
+    '2020-04-11',
+    '2020-04-08',
+    '2020-04-06',
+    '2020-04-03',
+    '2020-04-01',
+  ].map(d => new Date(d));
+  return {
+    fromTime: fromTime,
+    toTime: toTime,
+    bbox: bbox,
+    layer: layer,
+    mockedResponse: mockedResponse,
+    expectedRequest: expectedRequest,
+    expectedResult: expectedResult,
+  };
+}
+
+export function constructFixtureFindDatesUTCCatalog(
+  layer: AbstractSentinelHubV3Layer,
+  {
+    fromTime = new Date(Date.UTC(2020, 4 - 1, 1, 0, 0, 0, 0)),
+    toTime = new Date(Date.UTC(2020, 5 - 1, 1, 23, 59, 59, 0)),
+    bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21),
+    maxCloudCoverPercent = null as number,
+    productType = null as string,
+    collectionId = 'mockCollectionId',
+    acquisitionMode = AcquisitionMode.IW,
+    polarization = Polarization.DV,
+    resolution = Resolution.HIGH,
+    orbitDirection = OrbitDirection.ASCENDING,
+  },
+): Record<any, any> {
+  const expectedRequest: Record<string, any> = {
+    bbox: [bbox.minX, bbox.minY, bbox.maxX, bbox.maxY],
+    datetime: `${fromTime.toISOString()}/${toTime.toISOString()}`,
+    collections: [layer.dataset.catalogCollectionId],
+    limit: 10000,
+    distinct: 'date',
+    query: { 'eo:cloud_cover': { lte: maxCloudCoverPercent !== null ? maxCloudCoverPercent : 100 } },
+  };
+
+  if (layer instanceof S1GRDAWSEULayer && acquisitionMode) {
+    expectedRequest['query']['sar:instrument_mode'] = { eq: acquisitionMode };
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && orbitDirection) {
+    expectedRequest['query']['sat:orbit_state'] = { eq: orbitDirection };
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && polarization) {
+    expectedRequest['query']['polarization'] = { eq: polarization };
+  }
+
+  if (layer instanceof S1GRDAWSEULayer && resolution) {
+    expectedRequest['query']['resolution'] = { eq: resolution };
+  }
+
+  if (layer instanceof S5PL2Layer && productType) {
+    expectedRequest['query'] = { type: { eq: productType } };
+  }
+
+  if (layer instanceof BYOCLayer && collectionId) {
+    expectedRequest['collections'] = [collectionId];
+  }
+
+  if (
+    !(layer instanceof AbstractSentinelHubV3WithCCLayer) &&
+    (maxCloudCoverPercent === null || maxCloudCoverPercent === undefined)
+  ) {
+    delete expectedRequest['query']['eo:cloud_cover'];
+  }
+
+  /* eslint-disable */
+  const mockedResponse = {
+    type: 'FeatureCollection',
+    features: [
+      '2020-04-30',
+      '2020-04-28',
+      '2020-04-26',
+      '2020-04-23',
+      '2020-04-21',
+      '2020-04-18',
+      '2020-04-16',
+      '2020-04-13',
+      '2020-04-11',
+      '2020-04-08',
+      '2020-04-06',
+      '2020-04-03',
+      '2020-04-01',
+    ],
+    links: [
+      {
+        href: 'https://services.sentinel-hub.com/api/v1/catalog/search',
+        rel: 'self',
+        type: 'application/json',
+      },
+    ],
+    context: { limit: 10000, returned: 13 },
+  };
+  /* eslint-enable */
+
+  const expectedResult = [
+    '2020-04-30',
+    '2020-04-28',
+    '2020-04-26',
+    '2020-04-23',
+    '2020-04-21',
+    '2020-04-18',
+    '2020-04-16',
+    '2020-04-13',
+    '2020-04-11',
+    '2020-04-08',
+    '2020-04-06',
+    '2020-04-03',
+    '2020-04-01',
+  ].map(d => new Date(d));
+
+  return {
+    fromTime: fromTime,
+    toTime: toTime,
+    bbox: bbox,
+    layer: layer,
+    mockedResponse: mockedResponse,
+    expectedRequest: expectedRequest,
+    expectedResult: expectedResult,
+  };
+}

--- a/src/layer/__tests__/testUtils.findDatesUTC.ts
+++ b/src/layer/__tests__/testUtils.findDatesUTC.ts
@@ -1,0 +1,51 @@
+import { setAuthToken, isAuthTokenSet } from '../../index';
+import { mockNetwork } from './testUtils.findTiles';
+
+export const AUTH_TOKEN = 'AUTH_TOKEN';
+export const CATALOG_URL = 'https://services.sentinel-hub.com/api/v1/catalog/search';
+
+export async function checkIfCorrectEndpointIsUsedFindDatesUTC(
+  token: string,
+  fixture: Record<string, any>,
+  endpoint: string,
+): Promise<void> {
+  setAuthToken(token);
+  expect(isAuthTokenSet()).toBe(!!token);
+
+  const { fromTime, toTime, bbox, layer } = fixture;
+  mockNetwork.onAny().reply(200);
+  try {
+    await layer.findDatesUTC(bbox, fromTime, toTime, { cache: { expiresIn: 0 } });
+  } catch (err) {
+    //we don't care about response
+  }
+  expect(mockNetwork.history.post.length).toBe(1);
+  const request = mockNetwork.history.post[0];
+  expect(request.url).toEqual(endpoint);
+}
+
+export async function checkRequestFindDatesUTC(fixtures: Record<string, any>): Promise<void> {
+  const { bbox, expectedRequest, fromTime, layer, toTime } = fixtures;
+  mockNetwork.onAny().reply(200);
+  try {
+    await layer.findDatesUTC(bbox, fromTime, toTime, { cache: { expiresIn: 0 } });
+  } catch (err) {
+    //we don't care about response here
+  }
+  const request = mockNetwork.history.post[0];
+  expect(request.data).not.toBeNull();
+  expect(JSON.parse(request.data)).toStrictEqual(expectedRequest);
+}
+
+export async function checkResponseFindDatesUTC(fixtures: Record<string, any>): Promise<void> {
+  const { fromTime, toTime, bbox, layer, mockedResponse, expectedRequest, expectedResult } = fixtures;
+
+  mockNetwork.onPost().replyOnce(200, mockedResponse);
+
+  const response = await layer.findDatesUTC(bbox, fromTime, toTime, { cache: { expiresIn: 0 } });
+  expect(mockNetwork.history.post.length).toBe(1);
+  const request = mockNetwork.history.post[0];
+  expect(request.data).not.toBeNull();
+  expect(JSON.parse(request.data)).toStrictEqual(expectedRequest);
+  expect(response).toStrictEqual(expectedResult);
+}

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
 import {
   BYOCLayer,
@@ -433,101 +433,32 @@ export const findTilesCatalog = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  if (!process.env.BYOC_COLLECTION_ID) {
-    throw new Error('BYOC_COLLECTION_ID environment variable is not defined!');
-  }
-  const layer = new BYOCLayer({
-    instanceId,
-    layerId,
-    collectionId: process.env.BYOC_COLLECTION_ID,
-    locationId: LocationIdSHv3.awsEuCentral1,
-  });
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDatesUTC (with collectionId and locationId)</h2>';
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(
-      bbox,
-      new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
-
-export const findDatesUTCAuth = () => {
-  if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
-    return "<div>Please set OAuth Client's id and secret for Processing API (CLIENT_ID, CLIENT_SECRET env vars)</div>";
-  }
-  const layer = new BYOCLayer({ instanceId, layerId });
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDatesUTC (without collectionId and locationId)</h2>';
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    await setAuthTokenWithOAuthCredentials();
-    const dates = await layer.findDatesUTC(
-      bbox,
-      new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new BYOCLayer({
+      instanceId,
+      layerId,
+      collectionId: process.env.BYOC_COLLECTION_ID,
+      locationId: LocationIdSHv3.awsEuCentral1,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new BYOCLayer({
+      instanceId,
+      layerId,
+      collectionId: process.env.BYOC_COLLECTION_ID,
+      locationId: LocationIdSHv3.awsEuCentral1,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2016, 1 - 1, 0, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );
 
 export const getAvailableBandsAuth = () => {
   if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {

--- a/stories/landsat8.aws.stories.js
+++ b/stories/landsat8.aws.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList } from './storiesUtils';
 
 import {
   Landsat8AWSLayer,
@@ -244,47 +244,22 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const maxCloudCoverPercent = 40;
-  const layer = new Landsat8AWSLayer({ instanceId, layerId, maxCloudCoverPercent });
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDatesUTC for Landsat 8 on AWS; maxcc = ${maxCloudCoverPercent}</h2>`;
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
-  const toTime = new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(bbox, fromTime, toTime);
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new Landsat8AWSLayer({ instanceId, layerId, maxCloudCoverPercent: 40 }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new Landsat8AWSLayer({ instanceId, layerId, maxCloudCoverPercent: 40 }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );
 
 export const stats = () => {
   const wrapperEl = document.createElement('div');

--- a/stories/s1grdew.stories.js
+++ b/stories/s1grdew.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 import { setAuthToken } from '../dist/sentinelHub.esm';
 
 import {
@@ -315,52 +315,19 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const layer = new S1GRDAWSEULayer({ instanceId, layerId });
-  const bbox4326 = new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908);
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML =
-    '<h2>findDatesUTC</h2>' +
-    'from: ' +
-    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)) +
-    '<br />' +
-    'to: ' +
-    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(
-      bbox4326,
-      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S1GRDAWSEULayer({ instanceId, layerId }),
+    new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908),
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S1GRDAWSEULayer({ instanceId, layerId }),
+    new BBox(CRS_EPSG4326, 13.359375, 43.0688878, 14.0625, 43.5803908),
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );

--- a/stories/s1grdiw.stories.js
+++ b/stories/s1grdiw.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 import { setAuthToken } from '../dist/sentinelHub.esm';
 
 import {
@@ -431,54 +431,34 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTCEPSG4326 = () => {
-  const layer = new S1GRDAWSEULayer({
-    instanceId,
-    layerId,
-    acquisitionMode: AcquisitionMode.IW,
-    polarization: Polarization.DV,
-    resolution: Resolution.HIGH,
-  });
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = '<h2>findDatesUTC - BBox in EPSG:4326</h2>';
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(
-      bbox4326,
-      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S1GRDAWSEULayer({
+      instanceId,
+      layerId,
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S1GRDAWSEULayer({
+      instanceId,
+      layerId,
+      acquisitionMode: AcquisitionMode.IW,
+      polarization: Polarization.DV,
+      resolution: Resolution.HIGH,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );
 
 export const supportsProcessingAPI = () => {
   const wrapperEl = document.createElement('div');

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 import { setAuthToken } from '../dist/sentinelHub.esm';
 
 import {
@@ -319,53 +319,29 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const maxCloudCoverPercent = 60;
-  const layerS2L1C = new S2L1CLayer({
-    instanceId,
-    layerId,
-    maxCloudCoverPercent,
-  });
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S2L1CLayer({
+      instanceId,
+      layerId,
+      maxCloudCoverPercent: 20,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
 
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDatesUTC for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layerS2L1C.findDatesUTC(
-      bbox4326,
-      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layerS2L1C.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+    false,
+  );
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S2L1CLayer({
+      instanceId,
+      layerId,
+      maxCloudCoverPercent: 20,
+    }),
+    bbox4326,
+    true,
+  );
 
 export const stats = () => {
   const layerS2L1C = new S2L1CLayer({

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
 import {
   setAuthToken,
@@ -1088,53 +1088,31 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const maxCloudCoverPercent = 60;
-  const layerS2L2A = new S2L2ALayer({
-    instanceId,
-    layerId,
-    maxCloudCoverPercent,
-  });
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S2L2ALayer({
+      instanceId,
+      layerId,
+      maxCloudCoverPercent: 60,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
 
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML = `<h2>findDatesUTC for Sentinel-2 L2A; maxcc = ${maxCloudCoverPercent}</h2>`;
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layerS2L2A.findDatesUTC(
-      bbox4326,
-      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layerS2L2A.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S2L2ALayer({
+      instanceId,
+      layerId,
+      maxCloudCoverPercent: 60,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );
 
 export const stats = () => {
   const layerS2L2A = new S2L2ALayer({

--- a/stories/s3olci.stories.js
+++ b/stories/s3olci.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
 import {
   S3OLCILayer,
@@ -259,54 +259,29 @@ export const findFlyoversLinearRingError = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const layer = new S3OLCILayer({ instanceId, layerId });
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S3OLCILayer({
+      instanceId,
+      layerId,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    false,
+  );
 
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML =
-    '<h2>findDatesUTC</h2>' +
-    'from: ' +
-    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)) +
-    '<br />' +
-    'to: ' +
-    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59));
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(
-      bbox4326,
-      new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
-      new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
-    );
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    console.log('imgblob', imageBlob);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S3OLCILayer({
+      instanceId,
+      layerId,
+    }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
+    true,
+  );
 
 export const stats = () => {
   const wrapperEl = document.createElement('div');

--- a/stories/s3slstr.stories.js
+++ b/stories/s3slstr.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
 import {
   S3SLSTRLayer,
@@ -263,48 +263,29 @@ export const findFlyovers = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const layer = new S3SLSTRLayer({ instanceId, layerId });
-  const specialBBox4326 = new BBox(CRS_EPSG4326, 10, 40, 14, 44);
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S3SLSTRLayer({
+      instanceId,
+      layerId,
+    }),
+    new BBox(CRS_EPSG4326, 10, 40, 14, 44),
+    new Date(Date.UTC(2018, 11 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2018, 12 - 1, 1, 23, 59, 59)),
+    false,
+  );
 
-  const fromTime = new Date(Date.UTC(2018, 11 - 1, 1, 0, 0, 0));
-  const toTime = new Date(Date.UTC(2018, 12 - 1, 1, 23, 59, 59));
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML =
-    '<h2>findDatesUTC</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(specialBBox4326, fromTime, toTime);
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: specialBBox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S3SLSTRLayer({
+      instanceId,
+      layerId,
+    }),
+    new BBox(CRS_EPSG4326, 10, 40, 14, 44),
+    new Date(Date.UTC(2018, 11 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2018, 12 - 1, 1, 23, 59, 59)),
+    true,
+  );
 
 export const stats = () => {
   const wrapperEl = document.createElement('div');

--- a/stories/s5pl2.stories.js
+++ b/stories/s5pl2.stories.js
@@ -1,4 +1,4 @@
-import { renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
+import { createFindDatesUTCStory, renderTilesList, setAuthTokenWithOAuthCredentials } from './storiesUtils';
 
 import {
   S5PL2Layer,
@@ -306,47 +306,23 @@ export const findTilesCatalog = () => {
   return wrapperEl;
 };
 
-export const findDatesUTC = () => {
-  const layer = new S5PL2Layer({ instanceId, layerId, productType: 'NO2', maxCloudCoverPercent: 60 });
+export const findDatesUTCSearchIndex = () =>
+  createFindDatesUTCStory(
+    new S5PL2Layer({ instanceId, layerId, productType: 'NO2' }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 2 - 1, 1, 23, 59, 59)),
+    false,
+  );
 
-  const fromTime = new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0));
-  const toTime = new Date(Date.UTC(2020, 2 - 1, 1, 23, 59, 59));
-
-  const wrapperEl = document.createElement('div');
-  wrapperEl.innerHTML =
-    '<h2>findDatesUTC</h2>' + 'from: ' + fromTime.toISOString() + '<br />' + 'to: ' + toTime.toISOString();
-
-  const containerEl = document.createElement('pre');
-  wrapperEl.insertAdjacentElement('beforeend', containerEl);
-
-  const img = document.createElement('img');
-  img.width = '512';
-  img.height = '512';
-  wrapperEl.insertAdjacentElement('beforeend', img);
-
-  const perform = async () => {
-    const dates = await layer.findDatesUTC(bbox4326, fromTime, toTime);
-    containerEl.innerHTML = JSON.stringify(dates, null, true);
-
-    const resDateStartOfDay = new Date(new Date(dates[0]).setUTCHours(0, 0, 0, 0));
-    const resDateEndOfDay = new Date(new Date(dates[0]).setUTCHours(23, 59, 59, 999));
-
-    // prepare an image to show that the number makes sense:
-    const getMapParams = {
-      bbox: bbox4326,
-      fromTime: resDateStartOfDay,
-      toTime: resDateEndOfDay,
-      width: 512,
-      height: 512,
-      format: MimeTypes.JPEG,
-    };
-    const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
-    img.src = URL.createObjectURL(imageBlob);
-  };
-  perform().then(() => {});
-
-  return wrapperEl;
-};
+export const findDatesUTCCatalog = () =>
+  createFindDatesUTCStory(
+    new S5PL2Layer({ instanceId, layerId, productType: 'NO2' }),
+    bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 2 - 1, 1, 23, 59, 59)),
+    true,
+  );
 
 export const stats = () => {
   const wrapperEl = document.createElement('div');


### PR DESCRIPTION
`findDatesUTC` was using `findAvailableDates` which is part of "index" endpoint and needs to be replaced. Similar as with `findTiles` catalog is now used by `findDatesUTC` if authToken is provided. If token is not set it will still use old enpoint (that will of course eventually be replaced with an errror message).  