### PR TITLE
Check if window object exists and don't use window.URL....

### DIFF
--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -40,7 +40,7 @@ async function getFirstUseableTarget(targets: CacheTargets): Promise<CacheTarget
 }
 
 async function checkIfCacheApiAvailable(): Promise<boolean> {
-  if (!window.caches) {
+  if (typeof window === 'undefined' || !window.caches) {
     return false;
   }
   try {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -30,7 +30,7 @@ export async function getImageProperties(originalBlob: Blob): Promise<ImagePrope
   const imgCanvas = document.createElement('canvas');
   try {
     const imgCtx = imgCanvas.getContext('2d');
-    imgObjectUrl = window.URL.createObjectURL(originalBlob);
+    imgObjectUrl = URL.createObjectURL(originalBlob);
     const img: any = await new Promise((resolve, reject) => {
       const img = new Image();
       img.onload = () => resolve(img);
@@ -52,7 +52,7 @@ export async function getImageProperties(originalBlob: Blob): Promise<ImagePrope
   } finally {
     imgCanvas.remove();
     if (imgObjectUrl) {
-      window.URL.revokeObjectURL(imgObjectUrl);
+      URL.revokeObjectURL(imgObjectUrl);
     }
   }
 }


### PR DESCRIPTION
`getImageProperties` used `window.URL.createObjectURL` and `window.URL.revokeObjectURL` 

`checkIfCacheApiAvailable` didn't check if `window` object exists

Both caused which problems when using the library in `node.`