### PR TITLE
Set evalscript in updateLayerFromServiceIfNeeded

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -671,6 +671,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     await ensureTimeout(async innerReqConfig => {
       const layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);
       this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+      this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
       // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
       this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
     }, reqConfig);

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -73,9 +73,10 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
         );
       }
 
-      if (this.collectionId === null) {
+      if (this.collectionId === null || this.evalscript === null) {
         const layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);
         this.collectionId = layerParams['collectionId'];
+        this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
       }
 
       if (this.locationId === null) {

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -117,6 +117,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
       this.orthorectify = layerParams['orthorectify'];
       this.orbitDirection = layerParams['orbitDirection'] ? layerParams['orbitDirection'] : null;
       this.legend = layerParams['legend'] ? layerParams['legend'] : null;
+      this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
       // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
       this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
     }, reqConfig);


### PR DESCRIPTION
This is a necessary change for the evalscript parsing to work in EOB3, but I think there is no harm adding it here.