### PR TITLE
Fix/catalog search limit

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -518,11 +518,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       bbox: [bbox.minX, bbox.minY, bbox.maxX, bbox.maxY],
       datetime: `${moment.utc(fromTime).toISOString()}/${moment.utc(toTime).toISOString()}`,
       collections: [catalogCollectionId],
-      limit: maxCount,
     };
 
-    if (maxCount === null) {
-      delete payload.limit;
+    if (maxCount > 0) {
+      payload.limit = maxCount;
     }
 
     if (offset > 0) {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -20,6 +20,7 @@ import {
   SUPPORTED_DATA_PRODUCTS_PROCESSING,
   DataProductId,
   FindTilesAdditionalParameters,
+  CATALOG_SEARCH_MAX_LIMIT,
 } from './const';
 import { wmsGetMapUrl } from './wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from './processing';
@@ -489,6 +490,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     reqConfig: RequestConfiguration,
     findTilesAdditionalParameters: FindTilesAdditionalParameters,
   ): Promise<Record<string, any>> {
+    if (maxCount !== null && maxCount > CATALOG_SEARCH_MAX_LIMIT) {
+      throw new Error('Parameter maxCount must be less than or equal to 100');
+    }
+
     if (!authToken) {
       throw new Error('Must be authenticated to use Catalog service');
     }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -491,7 +491,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     findTilesAdditionalParameters: FindTilesAdditionalParameters,
   ): Promise<Record<string, any>> {
     if (maxCount !== null && maxCount > CATALOG_SEARCH_MAX_LIMIT) {
-      throw new Error('Parameter maxCount must be less than or equal to 100');
+      throw new Error(`Parameter maxCount must be less than or equal to ${CATALOG_SEARCH_MAX_LIMIT}`);
     }
 
     if (!authToken) {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -520,6 +520,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       collections: [catalogCollectionId],
       limit: maxCount,
     };
+
+    if (maxCount === null) {
+      delete payload.limit;
+    }
+
     if (offset > 0) {
       payload.next = offset;
     }

--- a/src/layer/__tests__/fixtures.findDatesUTC.ts
+++ b/src/layer/__tests__/fixtures.findDatesUTC.ts
@@ -12,6 +12,7 @@ import {
 } from '../../index';
 import { AbstractSentinelHubV3Layer } from '../AbstractSentinelHubV3Layer';
 import { AbstractSentinelHubV3WithCCLayer } from '../AbstractSentinelHubV3WithCCLayer';
+import { CATALOG_SEARCH_MAX_LIMIT } from '../const';
 
 export function constructFixtureFindDatesUTCSearchIndex(
   layer: AbstractSentinelHubV3Layer,
@@ -46,16 +47,7 @@ export function constructFixtureFindDatesUTCSearchIndex(
     from: fromTime.toISOString(),
     to: toTime.toISOString(),
   };
-  /*
-datasetParameters: {
-      acquisitionMode: acquisitionMode,
-      orbitDirection: orbitDirection,
-      polarization: polarization,
-      resolution: resolution,
-      type: 'S1GRD',
-    },
 
-*/
   if (layer instanceof S1GRDAWSEULayer) {
     expectedRequest.datasetParameters = { type: 'S1GRD' };
   }
@@ -177,7 +169,7 @@ export function constructFixtureFindDatesUTCCatalog(
     bbox: [bbox.minX, bbox.minY, bbox.maxX, bbox.maxY],
     datetime: `${fromTime.toISOString()}/${toTime.toISOString()}`,
     collections: [layer.dataset.catalogCollectionId],
-    limit: 10000,
+    limit: CATALOG_SEARCH_MAX_LIMIT,
     distinct: 'date',
     query: { 'eo:cloud_cover': { lte: maxCloudCoverPercent !== null ? maxCloudCoverPercent : 100 } },
   };
@@ -238,7 +230,7 @@ export function constructFixtureFindDatesUTCCatalog(
         type: 'application/json',
       },
     ],
-    context: { limit: 10000, returned: 13 },
+    context: { limit: CATALOG_SEARCH_MAX_LIMIT, returned: 13 },
   };
   /* eslint-enable */
 

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -216,3 +216,7 @@ export type BYOCBand = {
 };
 
 export type FindTilesAdditionalParameters = Record<string, any>;
+
+//catalog search uses optional `limit` parameter that limits the number of items that are presented in the response document
+//CATALOG_SEARCH_MAX_LIMIT represents maximum value for that parameter
+export const CATALOG_SEARCH_MAX_LIMIT = 100;

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -340,6 +340,8 @@ export const findDatesUTCCatalog = () =>
       maxCloudCoverPercent: 20,
     }),
     bbox4326,
+    new Date(Date.UTC(2020, 1 - 1, 1, 0, 0, 0)),
+    new Date(Date.UTC(2020, 1 - 1, 15, 23, 59, 59)),
     true,
   );
 


### PR DESCRIPTION
Catalog service uses `limit` param to limit number of results. This value has been recently significantly decreased   (from 10000 to 100). As a result it is no longer possible to get all results in single request, so iterating over pages was added for findDatesUTC.    