### PR TITLE
Don't override existing evalscript in updateLayerFromServiceIfNeeded

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -744,7 +744,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     await ensureTimeout(async innerReqConfig => {
       const layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);
       this.legend = layerParams['legend'] ? layerParams['legend'] : null;
-      this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+
+      if (!this.evalscript) {
+        this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+      }
       // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
       this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
     }, reqConfig);

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -76,7 +76,9 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       if (this.collectionId === null || this.evalscript === null) {
         const layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);
         this.collectionId = layerParams['collectionId'];
-        this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+        if (!this.evalscript) {
+          this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+        }
       }
 
       if (this.locationId === null) {

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -117,7 +117,9 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
       this.orthorectify = layerParams['orthorectify'];
       this.orbitDirection = layerParams['orbitDirection'] ? layerParams['orbitDirection'] : null;
       this.legend = layerParams['legend'] ? layerParams['legend'] : null;
-      this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+      if (!this.evalscript) {
+        this.evalscript = layerParams['evalscript'] ? layerParams['evalscript'] : null;
+      }
       // this is a hotfix for `supportsApiType()` not having enough information - should be fixed properly later:
       this.dataProduct = layerParams['dataProduct'] ? layerParams['dataProduct'] : null;
     }, reqConfig);


### PR DESCRIPTION
Tries to fix a major problem with https://github.com/sentinel-hub/sentinelhub-js/pull/142/, which resulted in manually set `evalscript`s being overriden with the value from the instance (for example `updateLayerFromServiceIfNeeded` is called in `getMap` of `BYOCLayer`).

Notice that we should probably define  `updateLayerFromServiceIfNeeded` as a function which *never* overrides existing values, but that is out of scope for this MR.

