### PR TITLE
Fix: getMapUrl is not async, fix documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,16 @@ Note that both of the images above should be _exactly_ the same.
 In some cases we can retrieve just the image URL instead of a blob:
 
 ```javascript
-  const imageUrl = await layer.getMapUrl(getMapParams, ApiType.WMS);
-  const imageUrl2 = await layer.getMapUrl(getMapParams, ApiType.PROCESSING); // exception thrown - Processing API does not support HTTP GET method
+  const imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
+  const imageUrl2 = layer.getMapUrl(getMapParams, ApiType.PROCESSING); // exception thrown - Processing API does not support HTTP GET method
 ```
 
 It is also possible to determine whether a layer supports a specific ApiType:
 ```javascript
   if (layer.supportsApiType(ApiType.PROCESSING)) {
-    imageUrl = await layer.getMapUrl(getMapParams, ApiType.PROCESSING);
+    imageUrl = layer.getMapUrl(getMapParams, ApiType.PROCESSING);
   } else {
-    imageUrl = await layer.getMapUrl(getMapParams, ApiType.WMS);
+    imageUrl = layer.getMapUrl(getMapParams, ApiType.WMS);
   };
 ```
 
@@ -388,15 +388,15 @@ If we already have a WMS GetMap URL, we can use it directly:
 Example params: `gain`, `gamma`, `upsampling`, `downsampling`, etc.
 
 `legacyGetMapFromParams` and `legacyGetMapFromUrl` also accept the parameters that are used for creating a dataset-specific layer object or for getting the data with `getMap()` function but are not supported in [OGC WMS GetMap standard](https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/wms/) and [Sentinel hub OGC API](https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/).
-- Parameters which would be used for creating a `Layer` can be passed inside of `overrideLayerConstructorParams`. 
+- Parameters which would be used for creating a `Layer` can be passed inside of `overrideLayerConstructorParams`.
 Example params: dataset-specific params for creating [layers](#layers)
-- Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`. 
+- Parameters which would be passed to `getMap` can be passed inside the `overrideGetMapParams`.
 Example params: [effects](#effects)
 
 ```javascript
   const imageBlob5 = await legacyGetMapFromParams(
-    rootUrl, 
-    wmsParams, 
+    rootUrl,
+    wmsParams,
     ApiType.PROCESSING
     fallbackToWmsApi,
     overrideLayerConstructorParams,

--- a/stories/byoc.stories.js
+++ b/stories/byoc.stories.js
@@ -225,16 +225,16 @@ export const getMapURLGainGamma = () => {
     const getMapParamsGainGammaAre2 = { ...getMapParams, effects: { gain: gain, gamma: gamma } };
 
     try {
-      const imageBlobNoGainGamma = await layer.getMapUrl(getMapParams, ApiType.WMS);
+      const imageBlobNoGainGamma = layer.getMapUrl(getMapParams, ApiType.WMS);
       imgNoGainGamma.src = imageBlobNoGainGamma;
 
-      const imageBlobGainIs2 = await layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
+      const imageBlobGainIs2 = layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
       imgGainIs2.src = imageBlobGainIs2;
 
-      const imageBlobGammaIs2 = await layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
+      const imageBlobGammaIs2 = layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
       imgGammaIs2.src = imageBlobGammaIs2;
 
-      const imageBlobGainGamaAre2 = await layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
+      const imageBlobGainGamaAre2 = layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
       imgGainGammaAre2.src = imageBlobGainGamaAre2;
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';

--- a/stories/envisatmeris.eocloud.stories.js
+++ b/stories/envisatmeris.eocloud.stories.js
@@ -193,16 +193,16 @@ export const getMapURLGainGamma = () => {
     const getMapParamsGainGammaAre2 = { ...getMapParams, effects: { gain: gain, gamma: gamma } };
 
     try {
-      const imageBlobNoGainGamma = await layer.getMapUrl(getMapParams, ApiType.WMS);
+      const imageBlobNoGainGamma = layer.getMapUrl(getMapParams, ApiType.WMS);
       imgNoGainGamma.src = imageBlobNoGainGamma;
 
-      const imageBlobGainIs2 = await layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
+      const imageBlobGainIs2 = layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
       imgGainIs2.src = imageBlobGainIs2;
 
-      const imageBlobGammaIs2 = await layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
+      const imageBlobGammaIs2 = layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
       imgGammaIs2.src = imageBlobGammaIs2;
 
-      const imageBlobGainGamaAre2 = await layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
+      const imageBlobGainGamaAre2 = layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
       imgGainGammaAre2.src = imageBlobGainGamaAre2;
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';

--- a/stories/s2l2a.stories.js
+++ b/stories/s2l2a.stories.js
@@ -469,16 +469,16 @@ export const getMapURLGainGamma = () => {
     const getMapParamsGainGammaAre2 = { ...getMapParams, effects: { gain: gain, gamma: gamma } };
 
     try {
-      const imageBlobNoGainGamma = await layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);
+      const imageBlobNoGainGamma = layerS2L2A.getMapUrl(getMapParams, ApiType.WMS);
       imgNoGainGamma.src = imageBlobNoGainGamma;
 
-      const imageBlobGainIs2 = await layerS2L2A.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
+      const imageBlobGainIs2 = layerS2L2A.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
       imgGainIs2.src = imageBlobGainIs2;
 
-      const imageBlobGammaIs2 = await layerS2L2A.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
+      const imageBlobGammaIs2 = layerS2L2A.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
       imgGammaIs2.src = imageBlobGammaIs2;
 
-      const imageBlobGainGamaAre2 = await layerS2L2A.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
+      const imageBlobGainGamaAre2 = layerS2L2A.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
       imgGainGammaAre2.src = imageBlobGainGamaAre2;
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';

--- a/stories/wms.probav.stories.js
+++ b/stories/wms.probav.stories.js
@@ -179,16 +179,16 @@ export const getMapURLGainGamma = () => {
     const getMapParamsGainGammaAre2 = { ...getMapParams, effects: { gain: gain, gamma: gamma } };
 
     try {
-      const imageBlobNoGainGamma = await layer.getMapUrl(getMapParams, ApiType.WMS);
+      const imageBlobNoGainGamma = layer.getMapUrl(getMapParams, ApiType.WMS);
       imgNoGainGamma.src = imageBlobNoGainGamma;
 
-      const imageBlobGainIs2 = await layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
+      const imageBlobGainIs2 = layer.getMapUrl(getMapParamsGainIs2, ApiType.WMS);
       imgGainIs2.src = imageBlobGainIs2;
 
-      const imageBlobGammaIs2 = await layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
+      const imageBlobGammaIs2 = layer.getMapUrl(getMapParamsGammaIs2, ApiType.WMS);
       imgGammaIs2.src = imageBlobGammaIs2;
 
-      const imageBlobGainGamaAre2 = await layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
+      const imageBlobGainGamaAre2 = layer.getMapUrl(getMapParamsGainGammaAre2, ApiType.WMS);
       imgGainGammaAre2.src = imageBlobGainGamaAre2;
     } catch (err) {
       wrapperEl.innerHTML += '<pre>ERROR OCCURED: ' + err + '</pre>';


### PR DESCRIPTION
Checking the code it seems that there is no reason to ever `await` for `getMapUrl`. All the function(s) signatures are synchronous and return a `string`, not a `Promise`. 

This PR fixes the README and the stories where needed.