### PR TITLE
2 Additional DEM layer properties

### DIFF
--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -48,10 +48,10 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
         if (!this.demInstance) {
           this.demInstance = layerParams['demInstance'] ? layerParams['demInstance'] : DEMInstanceType.MAPZEN;
         }
-        if (isBooleanNull(this.clampNegative)) {
-          this.clampNegative = layerParams['clampNegative'] ? layerParams['clampNegative'] : false;
+        if (!isDefined(this.clampNegative)) {
+          this.clampNegative = layerParams['clampNegative'] ? layerParams['clampNegative'] : null;
         }
-        if (isBooleanNull(this.egm)) {
+        if (!isDefined(this.egm)) {
           //this in not a typo. Configuration service returns `EGM`, process api accepts `egm`
           this.egm = layerParams['EGM'] ? layerParams['EGM'] : false;
         }
@@ -73,14 +73,11 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
     payload = await super.updateProcessingGetMapPayload(payload);
     payload.input.data[0].dataFilter.demInstance = this.demInstance;
 
-    if (!isBooleanNull(this.egm)) {
+    if (isDefined(this.egm)) {
       payload.input.data[0].processing.egm = this.egm;
     }
 
-    if (
-      (!this.demInstance || this.demInstance === DEMInstanceType.MAPZEN) &&
-      !isBooleanNull(this.clampNegative)
-    ) {
+    if ((!this.demInstance || this.demInstance === DEMInstanceType.MAPZEN) && isDefined(this.clampNegative)) {
       payload.input.data[0].processing.clampNegative = this.clampNegative;
     }
 
@@ -147,4 +144,4 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
   }
 }
 
-const isBooleanNull = (value: boolean): boolean => value === null || value == undefined;
+const isDefined = (value: any): boolean => value !== null && value !== undefined;

--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -77,7 +77,10 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
       payload.input.data[0].processing.egm = this.egm;
     }
 
-    if (this.demInstance === DEMInstanceType.MAPZEN && !isBooleanNull(this.clampNegative)) {
+    if (
+      (!this.demInstance || this.demInstance === DEMInstanceType.MAPZEN) &&
+      !isBooleanNull(this.clampNegative)
+    ) {
       payload.input.data[0].processing.clampNegative = this.clampNegative;
     }
 

--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -37,6 +37,11 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
 
   public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {
     await ensureTimeout(async innerReqConfig => {
+      if (!(this.instanceId && this.layerId)) {
+        return;
+      }
+      //update properties defined on parent layer
+      await super.updateLayerFromServiceIfNeeded(innerReqConfig);
       //update DEM specific properties if they're not set
       if (!this.demInstance || isBooleanNull(this.egm) || isBooleanNull(this.clampNegative)) {
         const layerParams = await this.fetchLayerParamsFromSHServiceV3(innerReqConfig);


### PR DESCRIPTION
DEM datasources have 2 additional properties: `egm` and `clampNegative`. They should't be ignored as they can be set in dashboard and can affect visualization (at least `clampNegative`). 