### PR TITLE
Check if canvas exceeds the size limit 

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -114,7 +114,7 @@ export class AbstractLayer {
       const isCanvasValid = await validateCanvasDimensions(canvas);
       if (!isCanvasValid) {
         throw new Error(
-          `Image dimensions (${width}x${height}) exceeds the canvas size limit for this browser.`,
+          `Image dimensions (${width}x${height}) exceed the canvas size limit for this browser.`,
         );
       }
 

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -12,7 +12,7 @@ import { ensureTimeout } from '../utils/ensureTimeout';
 
 import { Effects } from '../mapDataManipulation/const';
 import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
-import { drawBlobOnCanvas, canvasToBlob } from '../utils/canvas';
+import { drawBlobOnCanvas, canvasToBlob, validateCanvasDimensions } from '../utils/canvas';
 import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 
 interface ConstructorParameters {
@@ -110,6 +110,13 @@ export class AbstractLayer {
       canvas.width = width;
       canvas.height = height;
       const ctx = canvas.getContext('2d');
+
+      const isCanvasValid = await validateCanvasDimensions(canvas);
+      if (!isCanvasValid) {
+        throw new Error(
+          `Image dimensions (${width}x${height}) exceeds the canvas size limit for this browser.`,
+        );
+      }
 
       const xSplitBy = Math.ceil(width / LIMIT_DIM);
       const chunkWidth = Math.ceil(width / xSplitBy);

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -75,3 +75,11 @@ export async function getBlob(imageProperties: ImageProperties): Promise<Blob> {
     imgCanvas.remove();
   }
 }
+
+export async function validateCanvasDimensions(canvas: HTMLCanvasElement): Promise<boolean> {
+  const blob = await new Promise(resolve => canvas.toBlob(resolve));
+  if (blob === null) {
+    return false;
+  }
+  return true;
+}

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -77,6 +77,7 @@ export async function getBlob(imageProperties: ImageProperties): Promise<Blob> {
 }
 
 export async function validateCanvasDimensions(canvas: HTMLCanvasElement): Promise<boolean> {
+  // If the canvas exceeds the size limit for the browser, canvas.toBlob returns null.
   const blob = await new Promise(resolve => canvas.toBlob(resolve));
   if (blob === null) {
     return false;


### PR DESCRIPTION
If the canvas exceed the size limit for the browser, `canvas.toBlob` returns `null`. 

Run `canvas.toBlob` before fetching images, to test if it produces a blob.

https://www.npmjs.com/package/canvas-size#test-results