### PR TITLE
Allow users to dynamically rewrite any request URL with callback function

### DIFF
--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -19,6 +19,7 @@ declare module 'axios' {
     cancelToken?: CancelToken;
     cacheKey?: string;
     cache?: CacheConfig;
+    rewriteUrlFunc?: (url: string) => string;
   }
 }
 
@@ -29,7 +30,15 @@ export const registerInitialAxiosInterceptors = (): any => {
   // - some interceptors might also be added in other places (`registerHostnameReplacing()`)
   axios.interceptors.request.use(logCurl, error => Promise.reject(error));
   axios.interceptors.request.use(fetchCachedResponse, error => Promise.reject(error));
+  axios.interceptors.request.use(rewriteUrl, error => Promise.reject(error));
   axios.interceptors.response.use(saveCacheResponse, error => retryRequests(error));
+};
+
+const rewriteUrl = async (config: any): Promise<any> => {
+  if (config.rewriteUrlFunc) {
+    config.url = config.rewriteUrlFunc(config.url);
+  }
+  return config;
 };
 
 const logCurl = async (config: any): Promise<any> => {

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -7,6 +7,7 @@ export type RequestConfiguration = {
   timeout?: number | null;
   cancelToken?: CancelToken;
   cache?: CacheConfig;
+  rewriteUrlFunc?: (url: string) => string;
 };
 
 export class CancelToken {
@@ -48,6 +49,9 @@ export const getAxiosReqParams = (
   axiosReqConfig.retries = reqConfig.retries;
   if (reqConfig.cache) {
     axiosReqConfig.cache = reqConfig.cache;
+  }
+  if (reqConfig.rewriteUrlFunc) {
+    axiosReqConfig.rewriteUrlFunc = reqConfig.rewriteUrlFunc;
   }
   return axiosReqConfig;
 };

--- a/stories/wms.gibs.stories.js
+++ b/stories/wms.gibs.stories.js
@@ -82,7 +82,17 @@ export const getMapWmsLayersFactory = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
 
   const perform = async () => {
-    const layer = (await LayersFactory.makeLayers(baseUrl, (lId, datasetId) => layerId === lId))[0];
+    const layer = await LayersFactory.makeLayer(baseUrl, layerId, null, {
+      rewriteUrlFunc: url => {
+        if (
+          url.startsWith('https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi?') &&
+          url.includes('request=GetCapabilities')
+        ) {
+          return 'https://eob-getcapabilities-cache.s3.eu-central-1.amazonaws.com/gibs.xml';
+        }
+        return url;
+      },
+    });
 
     const getMapParams = {
       bbox: bbox,


### PR DESCRIPTION
This adds `rewriteUrlFunc` to `requestsConfig`.

I didn't add documentation for it as I'm not 100% sure that this should be public. :)

The storybook for GIBS uses this functionality to redirect `GetCapabilities` requests to another URL.