### PR TITLE
Fix/parallel requests caching

### DIFF
--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -11,38 +11,61 @@ export type CacheConfig = {
   targets?: CacheTargets;
 };
 
+// Even though we have caching enabled, if we fire 10 (equal) requests in parallel, they will
+// still all be executed - because by the time first response is saved in cache, the other 9
+// requests are already made too. To combat this, we save cacheKeys of ongoing requests and
+// simply delay new requests with the same cacheKey.
+const cacheableRequestsInProgress = new Set();
+
 export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (!isRequestCachable(request)) {
     return request;
   }
 
-  const cacheKey = await generateCacheKey(request);
+  const cacheKey = generateCacheKey(request);
   // resource not cacheable? It couldn't have been saved to cache:
   if (cacheKey === null) {
     return request;
   }
-  const shCache = await cacheFactory(request.cache.targets);
-  if (!shCache) {
-    return request;
-  }
-  const cachedResponse = await shCache.get(cacheKey, request.responseType);
-  if (!cachedResponse || !cacheStillValid(cachedResponse.headers)) {
-    request.cacheKey = cacheKey;
-    return request;
+
+  // there is a request with the same cacheKey in progress - wait until it
+  // finishes (we might be able to use its response from cache)
+  while (cacheableRequestsInProgress.has(cacheKey)) {
+    await sleep(100);
   }
 
-  // serve from cache:
-  request.adapter = async () => {
-    return Promise.resolve({
-      data: cachedResponse.data,
-      headers: request.headers,
-      request: request,
-      config: request,
-      responseType: request.responseType,
-    });
-  };
+  // it is important that we block any possible parallel requests before we execute
+  // our first await, otherwise other requests will step in before we can stop them:
+  cacheableRequestsInProgress.add(cacheKey);
+  try {
+    const shCache = await cacheFactory(request.cache.targets);
+    if (!shCache) {
+      return request;
+    }
+    const cachedResponse = await shCache.get(cacheKey, request.responseType);
+    if (!cachedResponse || !cacheStillValid(cachedResponse.headers)) {
+      request.cacheKey = cacheKey;
+      return request;
+    }
 
-  return request;
+    // serve from cache:
+    request.adapter = async () => {
+      return Promise.resolve({
+        data: cachedResponse.data,
+        headers: request.headers,
+        request: request,
+        config: request,
+        responseType: request.responseType,
+      });
+    };
+    return request;
+  } finally {
+    // if we have blocked other requests by mistake (we will not be creating a new cache
+    // entry from this request), we should fix this now:
+    if (!request.cacheKey) {
+      cacheableRequestsInProgress.delete(cacheKey);
+    }
+  }
 };
 
 export const saveCacheResponse = async (response: AxiosResponse): Promise<any> => {
@@ -54,25 +77,33 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
   if (!response.config.cacheKey) {
     return response;
   }
-  const shCache = await cacheFactory(response.config.cache.targets);
-  if (!shCache) {
-    return response;
-  }
-  if (
-    (await shCache.has(response.config.cacheKey)) &&
-    cacheStillValid(await shCache.getHeaders(response.config.cacheKey))
-  ) {
-    return response;
-  }
 
-  // before saving response, set an artificial header that tells when it should expire:
-  const expiresMs = new Date().getTime() + response.config.cache.expiresIn * 1000;
-  response.headers = {
-    ...response.headers,
-    [EXPIRY_HEADER_KEY]: expiresMs,
-  };
-  shCache.set(response.config.cacheKey, response);
-  return response;
+  try {
+    const shCache = await cacheFactory(response.config.cache.targets);
+    if (!shCache) {
+      return response;
+    }
+    if (
+      (await shCache.has(response.config.cacheKey)) &&
+      cacheStillValid(await shCache.getHeaders(response.config.cacheKey))
+    ) {
+      return response;
+    }
+
+    // before saving response, set an artificial header that tells when it should expire:
+    const expiresMs = new Date().getTime() + response.config.cache.expiresIn * 1000;
+    response.headers = {
+      ...response.headers,
+      [EXPIRY_HEADER_KEY]: expiresMs,
+    };
+    shCache.set(response.config.cacheKey, response);
+    return response;
+  } finally {
+    // if response.confic.cacheKey was there, we *must* remove it from the list
+    // of requests in progress, otherwise all other requests with the same cacheKey
+    // will wait indefinitely:
+    cacheableRequestsInProgress.delete(response.config.cacheKey);
+  }
 };
 
 export const cacheStillValid = (headers: Record<string, any>): boolean => {
@@ -84,13 +115,13 @@ export const cacheStillValid = (headers: Record<string, any>): boolean => {
   return expirationDate > now.getTime();
 };
 
-const generateCacheKey = async (request: AxiosRequestConfig): Promise<string | null> => {
+const generateCacheKey = (request: AxiosRequestConfig): string | null => {
   switch (request.method) {
     // post requests are not supported, so we mimic a get request, by formatting the body/params to sha256, and constructing a key/url
     // idea taken from https://blog.cloudflare.com/introducing-the-workers-cache-api-giving-you-control-over-how-your-content-is-cached/
     case 'post':
       const body = JSON.stringify(request.data);
-      const hash = await stringToHash(body);
+      const hash = stringToHash(body);
       return `${request.url}?${hash}`;
     case 'get':
       return `${request.url}?${stringify(request.params)}`;
@@ -100,7 +131,7 @@ const generateCacheKey = async (request: AxiosRequestConfig): Promise<string | n
 };
 
 //https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
-const stringToHash = async (message: string): Promise<any> => {
+const stringToHash = (message: string): number => {
   let hash = 0;
   for (let i = 0; i < message.length; i++) {
     let chr = message.charCodeAt(i);
@@ -136,4 +167,10 @@ const isRequestCachable = (request: AxiosRequestConfig): boolean => {
   }
 
   return true;
+};
+
+const sleep = async (sleepTimeMs: number): Promise<void> => {
+  await new Promise(resolve => {
+    setTimeout(resolve, sleepTimeMs);
+  });
 };

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -99,7 +99,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     shCache.set(response.config.cacheKey, response);
     return response;
   } finally {
-    // if response.confic.cacheKey was there, we *must* remove it from the list
+    // if response.config.cacheKey was there, we *must* remove it from the list
     // of requests in progress, otherwise all other requests with the same cacheKey
     // will wait indefinitely:
     cacheableRequestsInProgress.delete(response.config.cacheKey);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -628,7 +628,7 @@ export const CachedParallelRequests = () => {
     const promises = layers.map(l =>
       l.updateLayerFromServiceIfNeeded({
         cache: {
-          expiresIn: 10,
+          expiresIn: 1000,
           targets: [CacheTarget.MEMORY],
         },
       }),


### PR DESCRIPTION
This MR solves a problem when multiple requests to the same resource, issued in parallel at (almost) the same time, didn't use caching mechanism. The problem was that by the time the first response came, the other requests have already started.

The easiest solution was to delay requests if there is an ongoing request with the same cache key.

Apart from that:
- `generateCacheKey` does not need to be `async`