### PR TITLE
Feature/default reqs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,15 @@ A list of targets can be provided which is ordered by priority, and the first av
     },
   };
 ```
+
+If a default requests configuration object is specified, it will be used for any key which is not set explicitly:
+
+```javascript
+  setDefaultRequestsConfig({
+    retries: 2,
+  });
+```
+
 ## Getting basic statistics and histogram
 
 Getting basic statistics (mean, min, max, standard deviation) and a histogram for a geometry (Polygon or MultiPolygon).

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Services limit the size of the output image per request (2500px in each directio
 IMPORTANT: be careful with the image sizes as a big image could consume a lot of processing units. There is no limit imposed by this method.
 
 ```javascript
-  const imageBlob = await layer.getHugeMap(getMapParams, ApiType.PROCESSING, reqConfig);
+  const imageBlob = await layer.getHugeMap(getMapParams, ApiType.PROCESSING, requestsConfig);
 ```
 
 ## Searching for data
@@ -306,9 +306,9 @@ try {
 }
 ```
 
-To enable caching for the requests, one can add `expiresIn` to the requests configuration object. The values are in seconds.
-```
-// cache is valid for 30 minutes
+To enable caching for the requests, one can add `expiresIn` to the requests configuration object. The values are in seconds. Value `0` disables caching.
+```javascript
+// cache is valid for 30 minutes:
 const requestsConfig = {
   cache: {
     expiresIn: 1800,
@@ -316,17 +316,8 @@ const requestsConfig = {
 };
 ```
 
-To disable caching for the requests that are enabled by default, you can assign 0 to `expiresIn`.
-```
-const requestsConfig = {
-  cache: {
-    expiresIn: 1800,
-  }
-};
-```
-
-Requests can be cached to [CACHE_API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) or to memory, where the target can be specified with.
-```
+Requests can be cached to [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) or to memory:
+```javascript
   const requestsConfig = {
     cache: {
       expiresIn: 5000,
@@ -334,7 +325,8 @@ Requests can be cached to [CACHE_API](https://developer.mozilla.org/en-US/docs/W
     },
   };
 ```
-```
+
+```javascript
   const requestsConfig = {
     cache: {
       expiresIn: 5000,
@@ -342,9 +334,10 @@ Requests can be cached to [CACHE_API](https://developer.mozilla.org/en-US/docs/W
     },
   };
 ```
+
 A list of targets can be provided which is ordered by priority, and the first available target in the list will be used. This example will fallback to caching to memory if [CACHE_API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) is not available:
 
-```
+```javascript
   const requestsConfig = {
     cache: {
       expiresIn: 5000,

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ const requestsConfig = {
 };
 ```
 
-Requests can be cached to [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) or to memory:
+Responses can be cached to [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache):
 ```javascript
   const requestsConfig = {
     cache: {
@@ -326,6 +326,7 @@ Requests can be cached to [Cache API](https://developer.mozilla.org/en-US/docs/W
   };
 ```
 
+They can also be cached to memory:
 ```javascript
   const requestsConfig = {
     cache: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import { LocationIdSHv3, GetMapParams, LinkType, OverrideGetMapParams } from './
 import { registerInitialAxiosInterceptors } from './utils/axiosInterceptors';
 import { registerHostnameReplacing } from './utils/replaceHostnames';
 import { CancelToken, isCancelled, RequestConfiguration } from './utils/cancelRequests';
+import { setDefaultRequestsConfig } from './utils/defaultReqsConfig';
 import { CacheTarget, invalidateCaches } from './utils/Cache';
 import { wmsGetMapUrl as _wmsGetMapUrl } from './layer/wms';
 import { drawBlobOnCanvas, canvasToBlob } from './utils/canvas';
@@ -143,6 +144,7 @@ export {
   invalidateCaches,
   registerHostnameReplacing,
   RequestConfiguration,
+  setDefaultRequestsConfig,
   drawBlobOnCanvas,
   canvasToBlob,
   // legacy:

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -53,7 +53,9 @@ export const getAxiosReqParams = (
   if (reqConfigWithDefault.cancelToken) {
     axiosReqConfig.cancelToken = reqConfigWithDefault.cancelToken.getToken();
   }
-  axiosReqConfig.retries = reqConfigWithDefault.retries;
+  if (reqConfigWithDefault.retries !== null && reqConfigWithDefault.retries !== undefined) {
+    axiosReqConfig.retries = reqConfigWithDefault.retries;
+  }
   if (reqConfigWithDefault.cache) {
     axiosReqConfig.cache = reqConfigWithDefault.cache;
   }

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -46,7 +46,7 @@ export const getAxiosReqParams = (
     ...reqConfig,
   };
 
-  if (!reqConfigWithDefault) {
+  if (Object.keys(reqConfigWithDefault).length === 0) {
     return axiosReqConfig;
   }
 

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -1,5 +1,6 @@
 import axios, { CancelTokenSource, AxiosRequestConfig, CancelToken as CancelTokenAxios } from 'axios';
 import { CacheConfig } from './cacheHandlers';
+import { getDefaultRequestsConfig } from './defaultReqsConfig';
 
 export type RequestConfiguration = {
   authToken?: string | null;
@@ -13,6 +14,7 @@ export type RequestConfiguration = {
 export class CancelToken {
   protected token: CancelTokenAxios | null = null;
   protected source: CancelTokenSource | null = null;
+
   public constructor() {
     this.source = axios.CancelToken.source();
     this.token = this.source.token;
@@ -39,19 +41,24 @@ export const getAxiosReqParams = (
     cache: defaultCache,
   };
 
-  if (!reqConfig) {
+  const reqConfigWithDefault = {
+    ...getDefaultRequestsConfig(),
+    ...reqConfig,
+  };
+
+  if (!reqConfigWithDefault) {
     return axiosReqConfig;
   }
 
-  if (reqConfig.cancelToken) {
-    axiosReqConfig.cancelToken = reqConfig.cancelToken.getToken();
+  if (reqConfigWithDefault.cancelToken) {
+    axiosReqConfig.cancelToken = reqConfigWithDefault.cancelToken.getToken();
   }
-  axiosReqConfig.retries = reqConfig.retries;
-  if (reqConfig.cache) {
-    axiosReqConfig.cache = reqConfig.cache;
+  axiosReqConfig.retries = reqConfigWithDefault.retries;
+  if (reqConfigWithDefault.cache) {
+    axiosReqConfig.cache = reqConfigWithDefault.cache;
   }
-  if (reqConfig.rewriteUrlFunc) {
-    axiosReqConfig.rewriteUrlFunc = reqConfig.rewriteUrlFunc;
+  if (reqConfigWithDefault.rewriteUrlFunc) {
+    axiosReqConfig.rewriteUrlFunc = reqConfigWithDefault.rewriteUrlFunc;
   }
   return axiosReqConfig;
 };

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -46,10 +46,6 @@ export const getAxiosReqParams = (
     ...reqConfig,
   };
 
-  if (Object.keys(reqConfigWithDefault).length === 0) {
-    return axiosReqConfig;
-  }
-
   if (reqConfigWithDefault.cancelToken) {
     axiosReqConfig.cancelToken = reqConfigWithDefault.cancelToken.getToken();
   }

--- a/src/utils/defaultReqsConfig.ts
+++ b/src/utils/defaultReqsConfig.ts
@@ -1,0 +1,11 @@
+import { RequestConfiguration } from './cancelRequests';
+
+let defaultRequestsConfig = {};
+
+export const setDefaultRequestsConfig = (reqConfig: RequestConfiguration): void => {
+  defaultRequestsConfig = reqConfig;
+};
+
+export const getDefaultRequestsConfig = (): RequestConfiguration => {
+  return defaultRequestsConfig;
+};


### PR DESCRIPTION
This MR introduces `setDefaultRequestsConfig()` function. It allows setting the settings app-wide, so that they don't need to be passed through `reqConfig` parameter every time.