### PR TITLE
Fix: parsing GetCapabilities, ignore layers without Name

### DIFF
--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -20,7 +20,7 @@ import {
 import { wmsGetMapUrl } from './wms';
 import { AbstractLayer } from './AbstractLayer';
 import { CRS_EPSG4326, findCrsFromUrn } from '../crs';
-import { fetchGetCapabilitiesXml } from './utils';
+import { fetchLayersFromGetCapabilitiesXml } from './utils';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { ensureTimeout } from '../utils/ensureTimeout';
 import { CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
@@ -297,10 +297,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
       }
 
       const baseUrl = `${this.dataset.shServiceHostname}v1/wms/${this.instanceId}`;
-      const capabilities = await fetchGetCapabilitiesXml(baseUrl, innerReqConfig);
-      const layer = capabilities.WMS_Capabilities.Capability[0].Layer[0].Layer.find(
-        layerInfo => this.layerId === layerInfo.Name[0],
-      );
+      const parsedLayers = await fetchLayersFromGetCapabilitiesXml(baseUrl, innerReqConfig);
+      const layer = parsedLayers.find(layerInfo => this.layerId === layerInfo.Name[0]);
       if (!layer) {
         throw new Error('Layer not found');
       }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -245,20 +245,18 @@ export class LayersFactory {
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const parsedLayers = await fetchLayersFromGetCapabilitiesXml(baseUrl, reqConfig);
-    const layersInfos = parsedLayers
-      .filter(layerInfo => layerInfo.Name)
-      .map(layerInfo => ({
-        layerId: layerInfo.Name[0],
-        title: layerInfo.Title[0],
-        description: layerInfo.Abstract ? layerInfo.Abstract[0] : null,
-        dataset: null,
-        legendUrl:
-          layerInfo.Style && layerInfo.Style[0].LegendURL
-            ? layerInfo.Style[0].LegendURL[0].OnlineResource[0]['$']['xlink:href']
-            : layerInfo.Layer && layerInfo.Layer[0].Style && layerInfo.Layer[0].Style[0].LegendURL
-            ? layerInfo.Layer[0].Style[0].LegendURL[0].OnlineResource[0]['$']['xlink:href']
-            : null,
-      }));
+    const layersInfos = parsedLayers.map(layerInfo => ({
+      layerId: layerInfo.Name[0],
+      title: layerInfo.Title[0],
+      description: layerInfo.Abstract ? layerInfo.Abstract[0] : null,
+      dataset: null,
+      legendUrl:
+        layerInfo.Style && layerInfo.Style[0].LegendURL
+          ? layerInfo.Style[0].LegendURL[0].OnlineResource[0]['$']['xlink:href']
+          : layerInfo.Layer && layerInfo.Layer[0].Style && layerInfo.Layer[0].Style[0].LegendURL
+          ? layerInfo.Layer[0].Style[0].LegendURL[0].OnlineResource[0]['$']['xlink:href']
+          : null,
+    }));
 
     const filteredLayersInfos =
       filterLayers === null ? layersInfos : layersInfos.filter(l => filterLayers(l.layerId, l.dataset));

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -1,5 +1,5 @@
 import {
-  fetchGetCapabilitiesXml,
+  fetchLayersFromGetCapabilitiesXml,
   fetchGetCapabilitiesJsonV1,
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
@@ -237,17 +237,6 @@ export class LayersFactory {
     return result;
   }
 
-  // GetCapabilities might use recursion to group layers, this function allows us to flatten them:
-  private static _flattenLayers(layers: any, result: any[] = []): any[] {
-    layers.forEach((l: any) => {
-      result.push(l);
-      if (l.Layer) {
-        LayersFactory._flattenLayers(l.Layer, result);
-      }
-    });
-    return result;
-  }
-
   private static async makeLayersWms(
     baseUrl: string,
     filterLayers: Function | null,
@@ -255,8 +244,8 @@ export class LayersFactory {
     overrideConstructorParams: Record<string, any> | null,
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
-    const parsedXml = await fetchGetCapabilitiesXml(baseUrl, reqConfig);
-    const layersInfos = LayersFactory._flattenLayers(parsedXml.WMS_Capabilities.Capability[0].Layer)
+    const parsedLayers = await fetchLayersFromGetCapabilitiesXml(baseUrl, reqConfig);
+    const layersInfos = parsedLayers
       .filter(layerInfo => layerInfo.Name)
       .map(layerInfo => ({
         layerId: layerInfo.Name[0],

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -245,7 +245,9 @@ export class LayersFactory {
     reqConfig: RequestConfiguration,
   ): Promise<AbstractLayer[]> {
     const parsedXml = await fetchGetCapabilitiesXml(baseUrl, reqConfig);
-    const layersInfos = parsedXml.WMS_Capabilities.Capability[0].Layer[0].Layer.map(layerInfo => ({
+    const layersInfos = parsedXml.WMS_Capabilities.Capability[0].Layer[0].Layer.filter(
+      layerInfo => layerInfo.Name,
+    ).map(layerInfo => ({
       layerId: layerInfo.Name[0],
       title: layerInfo.Title[0],
       description: layerInfo.Abstract ? layerInfo.Abstract[0] : null,

--- a/src/layer/WmsLayer.ts
+++ b/src/layer/WmsLayer.ts
@@ -4,7 +4,7 @@ import { BBox } from '../bbox';
 import { GetMapParams, ApiType } from './const';
 import { wmsGetMapUrl } from './wms';
 import { AbstractLayer } from './AbstractLayer';
-import { fetchGetCapabilitiesXml } from './utils';
+import { fetchLayersFromGetCapabilitiesXml } from './utils';
 import { RequestConfiguration } from '../utils/cancelRequests';
 import { ensureTimeout } from '../utils/ensureTimeout';
 
@@ -57,10 +57,8 @@ export class WmsLayer extends AbstractLayer {
   ): Promise<Date[]> {
     const dates = await ensureTimeout(async innerReqConfig => {
       // http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#dims
-      const capabilities = await fetchGetCapabilitiesXml(this.baseUrl, innerReqConfig);
-      const layer = capabilities.WMS_Capabilities.Capability[0].Layer[0].Layer.find(
-        layerInfo => this.layerId === layerInfo.Name[0],
-      );
+      const parsedLayers = await fetchLayersFromGetCapabilitiesXml(this.baseUrl, innerReqConfig);
+      const layer = parsedLayers.find(layerInfo => this.layerId === layerInfo.Name[0]);
       if (!layer) {
         throw new Error('Layer not found');
       }
@@ -121,10 +119,8 @@ export class WmsLayer extends AbstractLayer {
           "Additional data can't be fetched from service because baseUrl and layerId are not defined",
         );
       }
-      const capabilities = await fetchGetCapabilitiesXml(this.baseUrl, innerReqConfig);
-      const layer = capabilities.WMS_Capabilities.Capability[0].Layer[0].Layer.find(
-        layer => this.layerId === layer.Name[0],
-      );
+      const parsedLayers = await fetchLayersFromGetCapabilitiesXml(this.baseUrl, innerReqConfig);
+      const layer = parsedLayers.find(layer => this.layerId === layer.Name[0]);
       if (!layer) {
         throw new Error('Layer not found');
       }


### PR DESCRIPTION
What started out as a simple small MR, turned out to be a bigger issue:
- with recent changes to GIBS, `GetCapabilites` response includes layers without `<Name>`; this patch makes `makeLayers` ignore such layers, as we can't get their ID
- we also add support for nested layers (otherwise the list of layers from GIBS is empty)
- we use the same function for getting layers from `GetCapabilities` in all places (code deduplication) to make these changes effective everywhere