### PR TITLE
Support S-1 orthorectify and demInstanceType with data fusion

### DIFF
--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -95,12 +95,22 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
           datasource.dataFilter.mosaickingOrder = layerInfo.layer.mosaickingOrder;
         }
 
+        // note that we should be using updateProcessingGetMapPayload or sth. similar here, this is just a
+        // temporary band-aid which lets us quickly use datafusion:
         if (layerInfo.layer.upsampling) {
           datasource.processing.upsampling = layerInfo.layer.upsampling;
         }
-
         if (layerInfo.layer.downsampling) {
           datasource.processing.downsampling = layerInfo.layer.downsampling;
+        }
+        if (
+          (layerInfo.layer as any).orthorectify !== undefined &&
+          (layerInfo.layer as any).orthorectify !== null
+        ) {
+          datasource.processing.orthorectify = (layerInfo.layer as any).orthorectify;
+          if ((layerInfo.layer as any).orthorectify) {
+            datasource.processing.demInstanceType = (layerInfo.layer as any).demInstanceType;
+          }
         }
 
         payload.input.data.push(datasource);


### PR DESCRIPTION
Only a select few layer parameters are passed to Process API when doing the data fusion. This should be fixed systematically, but for now we need the S-1 orthorectification parameters to be passed, so this is the minimal (and safest) change that achieves that.