### PR TITLE
Fix/datafusion layer params3

### DIFF
--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -80,24 +80,27 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
     return getMapValue;
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload = await super.updateProcessingGetMapPayload(payload);
+  public async _updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    datasetSeqNo: number = 0,
+  ): Promise<ProcessingPayload> {
+    payload = await super._updateProcessingGetMapPayload(payload);
     if (this.demInstance) {
-      payload.input.data[0].dataFilter.demInstance = this.demInstance;
+      payload.input.data[datasetSeqNo].dataFilter.demInstance = this.demInstance;
     }
 
     if (isDefined(this.egm)) {
-      payload.input.data[0].processing.egm = this.egm;
+      payload.input.data[datasetSeqNo].processing.egm = this.egm;
     }
 
     //clampNegative is MAPZEN specific option
     if ((!this.demInstance || this.demInstance === DEMInstanceType.MAPZEN) && isDefined(this.clampNegative)) {
-      payload.input.data[0].processing.clampNegative = this.clampNegative;
+      payload.input.data[datasetSeqNo].processing.clampNegative = this.clampNegative;
     }
 
     //DEM doesn't support dates and mosaickingOrder so they can be removed from payload
-    delete payload.input.data[0].dataFilter.mosaickingOrder;
-    delete payload.input.data[0].dataFilter.timeRange;
+    delete payload.input.data[datasetSeqNo].dataFilter.mosaickingOrder;
+    delete payload.input.data[datasetSeqNo].dataFilter.timeRange;
 
     return payload;
   }

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -133,8 +133,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     return layerParams;
   }
 
-  protected async updateProcessingGetMapPayload(
+  public async _updateProcessingGetMapPayload(
     payload: ProcessingPayload,
+    datasetSeqNo: number = 0, // eslint-disable-line @typescript-eslint/no-unused-vars
     reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<ProcessingPayload> {
     // Subclasses should override this method if they wish to supply additional
@@ -218,7 +219,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
           this.downsampling,
         );
         // allow subclasses to update payload with their own parameters:
-        const updatedPayload = await this.updateProcessingGetMapPayload(payload, innerReqConfig);
+        const updatedPayload = await this._updateProcessingGetMapPayload(payload, 0, innerReqConfig);
         const shServiceHostname = this.getShServiceHostname();
 
         let blob = await processingGetMap(shServiceHostname, updatedPayload, innerReqConfig);

--- a/src/layer/AbstractSentinelHubV3WithCCLayer.ts
+++ b/src/layer/AbstractSentinelHubV3WithCCLayer.ts
@@ -32,9 +32,12 @@ export class AbstractSentinelHubV3WithCCLayer extends AbstractSentinelHubV3Layer
     };
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload = await super.updateProcessingGetMapPayload(payload);
-    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+  public async _updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    datasetSeqNo: number = 0,
+  ): Promise<ProcessingPayload> {
+    payload = await super._updateProcessingGetMapPayload(payload);
+    payload.input.data[datasetSeqNo].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
   }
 

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -103,12 +103,13 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     return getMapValue;
   }
 
-  protected async updateProcessingGetMapPayload(
+  public async _updateProcessingGetMapPayload(
     payload: ProcessingPayload,
-    reqConfig: RequestConfiguration,
+    datasetSeqNo: number = 0,
+    reqConfig?: RequestConfiguration,
   ): Promise<ProcessingPayload> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);
-    payload.input.data[0].dataFilter.collectionId = this.collectionId;
+    payload.input.data[datasetSeqNo].dataFilter.collectionId = this.collectionId;
     return payload;
   }
 

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -95,7 +95,7 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
           datasource.dataFilter.mosaickingOrder = layerInfo.layer.mosaickingOrder;
         }
 
-        // note that we should be using updateProcessingGetMapPayload or sth. similar here, this is just a
+        // note that we should be using _updateProcessingGetMapPayload or sth. similar here, this is just a
         // temporary band-aid which lets us quickly use datafusion:
         if (layerInfo.layer.upsampling) {
           datasource.processing.upsampling = layerInfo.layer.upsampling;

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -94,26 +94,21 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
         if (layerInfo.layer.mosaickingOrder) {
           datasource.dataFilter.mosaickingOrder = layerInfo.layer.mosaickingOrder;
         }
-
-        // note that we should be using _updateProcessingGetMapPayload or sth. similar here, this is just a
-        // temporary band-aid which lets us quickly use datafusion:
         if (layerInfo.layer.upsampling) {
           datasource.processing.upsampling = layerInfo.layer.upsampling;
         }
         if (layerInfo.layer.downsampling) {
           datasource.processing.downsampling = layerInfo.layer.downsampling;
         }
-        if (
-          (layerInfo.layer as any).orthorectify !== undefined &&
-          (layerInfo.layer as any).orthorectify !== null
-        ) {
-          datasource.processing.orthorectify = (layerInfo.layer as any).orthorectify;
-          if ((layerInfo.layer as any).orthorectify) {
-            datasource.processing.demInstanceType = (layerInfo.layer as any).demInstanceType;
-          }
-        }
 
         payload.input.data.push(datasource);
+
+        // the layer should set its parameters for Process API:
+        await layerInfo.layer._updateProcessingGetMapPayload(
+          payload,
+          payload.input.data.length - 1,
+          reqConfig,
+        );
       }
 
       // If all layers share the common endpoint, it is used for the request.

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -20,7 +20,7 @@ import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
 */
 interface ConstructorParameters {
   evalscript: string | null;
-  evalscriptUrl: string | null;
+  evalscriptUrl?: string | null;
   layers: DataFusionLayerInfo[];
   title?: string | null;
   description?: string | null;

--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -131,22 +131,23 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     }, reqConfig);
   }
 
-  protected async updateProcessingGetMapPayload(
+  public async _updateProcessingGetMapPayload(
     payload: ProcessingPayload,
-    reqConfig: RequestConfiguration,
+    datasetSeqNo: number = 0,
+    reqConfig?: RequestConfiguration,
   ): Promise<ProcessingPayload> {
     await this.updateLayerFromServiceIfNeeded(reqConfig);
 
-    payload.input.data[0].dataFilter.acquisitionMode = this.acquisitionMode;
-    payload.input.data[0].dataFilter.polarization = this.polarization;
-    payload.input.data[0].dataFilter.resolution = this.resolution;
+    payload.input.data[datasetSeqNo].dataFilter.acquisitionMode = this.acquisitionMode;
+    payload.input.data[datasetSeqNo].dataFilter.polarization = this.polarization;
+    payload.input.data[datasetSeqNo].dataFilter.resolution = this.resolution;
     if (this.orbitDirection !== null) {
-      payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
+      payload.input.data[datasetSeqNo].dataFilter.orbitDirection = this.orbitDirection;
     }
-    payload.input.data[0].processing.backCoeff = this.backscatterCoeff;
-    payload.input.data[0].processing.orthorectify = this.orthorectify;
+    payload.input.data[datasetSeqNo].processing.backCoeff = this.backscatterCoeff;
+    payload.input.data[datasetSeqNo].processing.orthorectify = this.orthorectify;
     if (this.orthorectify === true) {
-      payload.input.data[0].processing.demInstance = this.demInstanceType;
+      payload.input.data[datasetSeqNo].processing.demInstance = this.demInstanceType;
     }
     return payload;
   }

--- a/src/layer/S2L2ALayer.ts
+++ b/src/layer/S2L2ALayer.ts
@@ -6,8 +6,11 @@ import { Link, LinkType } from './const';
 export class S2L2ALayer extends AbstractSentinelHubV3WithCCLayer {
   public readonly dataset = DATASET_S2L2A;
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+  public async _updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    datasetSeqNo: number = 0,
+  ): Promise<ProcessingPayload> {
+    payload.input.data[datasetSeqNo].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     return payload;
   }
 

--- a/src/layer/S3SLSTRLayer.ts
+++ b/src/layer/S3SLSTRLayer.ts
@@ -49,10 +49,13 @@ export class S3SLSTRLayer extends AbstractSentinelHubV3WithCCLayer {
     this.view = view;
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload = await super.updateProcessingGetMapPayload(payload);
-    payload.input.data[0].dataFilter.orbitDirection = this.orbitDirection;
-    payload.input.data[0].processing.view = this.view;
+  public async _updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    datasetSeqNo: number = 0,
+  ): Promise<ProcessingPayload> {
+    payload = await super._updateProcessingGetMapPayload(payload);
+    payload.input.data[datasetSeqNo].dataFilter.orbitDirection = this.orbitDirection;
+    payload.input.data[datasetSeqNo].processing.view = this.view;
     return payload;
   }
 

--- a/src/layer/S5PL2Layer.ts
+++ b/src/layer/S5PL2Layer.ts
@@ -69,10 +69,13 @@ export class S5PL2Layer extends AbstractSentinelHubV3Layer {
     this.minQa = minQa;
   }
 
-  protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {
-    payload.input.data[0].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
+  public async _updateProcessingGetMapPayload(
+    payload: ProcessingPayload,
+    datasetSeqNo: number = 0,
+  ): Promise<ProcessingPayload> {
+    payload.input.data[datasetSeqNo].dataFilter.maxCloudCoverage = this.maxCloudCoverPercent;
     if (this.minQa !== null) {
-      payload.input.data[0].processing.minQa = this.minQa;
+      payload.input.data[datasetSeqNo].processing.minQa = this.minQa;
     }
     // note that productType is not present among the parameters:
     // https://docs.sentinel-hub.com/api/latest/reference/#operation/process

--- a/src/layer/__tests__/ProcessingDataFusionLayer.ts
+++ b/src/layer/__tests__/ProcessingDataFusionLayer.ts
@@ -10,9 +10,14 @@ import {
   MimeTypes,
   BBox,
   CRS_EPSG4326,
+  S1GRDAWSEULayer,
+  Polarization,
 } from '../../index';
 import { DataFusionLayerInfo, DEFAULT_SH_SERVICE_HOSTNAME } from '../ProcessingDataFusionLayer';
 import '../../../jest-setup';
+import { DEMInstanceTypeOrthorectification } from '../const';
+import { constructFixtureGetMapRequest } from './fixtures.ProcessingDataFusionLayer';
+import { AcquisitionMode, Resolution } from '../S1GRDAWSEULayer';
 
 const mockNetwork = new MockAdapter(axios);
 
@@ -23,6 +28,10 @@ describe("Test data fusion uses correct URL depending on layers' combination", (
   const creodiasLayer = new S3OLCILayer({ evalscript: mockEvalscript });
   const usWestLayer = new Landsat8AWSLayer({ evalscript: mockEvalscript });
 
+  const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
+  const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
+
   test.each([
     [[shServicesLayer, shServicesLayer], shServicesLayer.dataset.shServiceHostname],
     [[creodiasLayer, shServicesLayer, usWestLayer], DEFAULT_SH_SERVICE_HOSTNAME],
@@ -30,14 +39,9 @@ describe("Test data fusion uses correct URL depending on layers' combination", (
   ])(
     'ProcessingDataFusionLayer chooses the correct shServiceHostname',
     async (layers, expectedShServiceHostname) => {
-      const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
-      const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
-      const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
-
       const layerInfo: DataFusionLayerInfo[] = layers.map(layer => ({ layer: layer }));
       const dataFusionLayer = new ProcessingDataFusionLayer({
         evalscript: mockEvalscript,
-        evalscriptUrl: null,
         layers: layerInfo,
       });
 
@@ -50,9 +54,93 @@ describe("Test data fusion uses correct URL depending on layers' combination", (
             authToken: 'some-token',
           },
         )
-        .catch(() => null);
+        .catch(() => {});
 
       expect(mockNetwork.history.post[0].url).toBe(`${expectedShServiceHostname}api/v1/process`);
     },
   );
+});
+
+describe('Test data fusion passes layer parameters correctly', () => {
+  const s2Layer = new S2L1CLayer({ evalscript: mockEvalscript });
+  const s1Layer = new S1GRDAWSEULayer({
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+    acquisitionMode: AcquisitionMode.IW,
+    evalscript: mockEvalscript,
+    orthorectify: true,
+    demInstanceType: DEMInstanceTypeOrthorectification.COPERNICUS_90,
+  });
+
+  const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
+  const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
+  const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
+
+  test.each([
+    [
+      [s2Layer, s1Layer],
+      [
+        {
+          dataFilter: {
+            maxCloudCoverage: 100,
+            mosaickingOrder: 'mostRecent',
+            timeRange: {
+              from: fromTime.toISOString(),
+              to: toTime.toISOString(),
+            },
+          },
+          processing: {},
+          type: 'S2L1C',
+        },
+        {
+          dataFilter: {
+            acquisitionMode: 'IW',
+            mosaickingOrder: 'mostRecent',
+            polarization: 'DV',
+            resolution: 'HIGH',
+            timeRange: {
+              from: fromTime.toISOString(),
+              to: toTime.toISOString(),
+            },
+          },
+          processing: {
+            backCoeff: 'GAMMA0_ELLIPSOID',
+            orthorectify: true,
+            demInstance: 'COPERNICUS_90',
+          },
+          type: 'S1GRD',
+        },
+      ],
+    ],
+  ])('ProcessingDataFusionLayer passes the correct parameters', async (layers, expectedData) => {
+    const layerInfo: DataFusionLayerInfo[] = layers.map(layer => ({ layer: layer }));
+    const dataFusionLayer = new ProcessingDataFusionLayer({
+      evalscript: mockEvalscript,
+      layers: layerInfo,
+    });
+
+    mockNetwork.resetHistory();
+    await dataFusionLayer
+      .getMap(
+        { bbox: bbox, fromTime: fromTime, toTime: toTime, format: MimeTypes.PNG, width: 300, height: 400 },
+        ApiType.PROCESSING,
+        {
+          authToken: 'some-token',
+        },
+      )
+      .catch(() => {});
+
+    const request = mockNetwork.history.post[0];
+
+    const { expectedRequest } = constructFixtureGetMapRequest({
+      bbox,
+      evalscript: mockEvalscript,
+      width: 300,
+      height: 400,
+      data: expectedData,
+      format: MimeTypes.PNG,
+    });
+    expect(request.data).not.toBeNull();
+    expect(JSON.parse(request.data)).toStrictEqual(expectedRequest);
+  });
 });

--- a/src/layer/__tests__/ProcessingDataFusionLayer.ts
+++ b/src/layer/__tests__/ProcessingDataFusionLayer.ts
@@ -18,35 +18,41 @@ const mockNetwork = new MockAdapter(axios);
 
 const mockEvalscript = '\\VERSION=3\n';
 
-const shServicesLayer = new S2L1CLayer({ evalscript: mockEvalscript });
-const creodiasLayer = new S3OLCILayer({ evalscript: mockEvalscript });
-const usWestLayer = new Landsat8AWSLayer({ evalscript: mockEvalscript });
+describe("Test data fusion uses correct URL depending on layers' combination", () => {
+  const shServicesLayer = new S2L1CLayer({ evalscript: mockEvalscript });
+  const creodiasLayer = new S3OLCILayer({ evalscript: mockEvalscript });
+  const usWestLayer = new Landsat8AWSLayer({ evalscript: mockEvalscript });
 
-test.each([
-  [[shServicesLayer, shServicesLayer], shServicesLayer.dataset.shServiceHostname],
-  [[creodiasLayer, shServicesLayer, usWestLayer], DEFAULT_SH_SERVICE_HOSTNAME],
-  [[creodiasLayer, creodiasLayer], creodiasLayer.dataset.shServiceHostname],
-])(
-  'ProcessingDataFusionLayer chooses the correct shServiceHostname',
-  async (layers, expectedShServiceHostname) => {
-    const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
-    const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
-    const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
+  test.each([
+    [[shServicesLayer, shServicesLayer], shServicesLayer.dataset.shServiceHostname],
+    [[creodiasLayer, shServicesLayer, usWestLayer], DEFAULT_SH_SERVICE_HOSTNAME],
+    [[creodiasLayer, creodiasLayer], creodiasLayer.dataset.shServiceHostname],
+  ])(
+    'ProcessingDataFusionLayer chooses the correct shServiceHostname',
+    async (layers, expectedShServiceHostname) => {
+      const fromTime = new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0));
+      const toTime = new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59));
+      const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
 
-    const layerInfo: DataFusionLayerInfo[] = layers.map(layer => ({ layer: layer }));
-    const dataFusionLayer = new ProcessingDataFusionLayer({
-      evalscript: mockEvalscript,
-      evalscriptUrl: null,
-      layers: layerInfo,
-    });
+      const layerInfo: DataFusionLayerInfo[] = layers.map(layer => ({ layer: layer }));
+      const dataFusionLayer = new ProcessingDataFusionLayer({
+        evalscript: mockEvalscript,
+        evalscriptUrl: null,
+        layers: layerInfo,
+      });
 
-    mockNetwork.resetHistory();
-    await dataFusionLayer
-      .getMap({ bbox: bbox, fromTime: fromTime, toTime: toTime, format: MimeTypes.PNG }, ApiType.PROCESSING, {
-        authToken: 'some-token',
-      })
-      .catch(() => null);
+      mockNetwork.resetHistory();
+      await dataFusionLayer
+        .getMap(
+          { bbox: bbox, fromTime: fromTime, toTime: toTime, format: MimeTypes.PNG },
+          ApiType.PROCESSING,
+          {
+            authToken: 'some-token',
+          },
+        )
+        .catch(() => null);
 
-    expect(mockNetwork.history.post[0].url).toBe(`${expectedShServiceHostname}api/v1/process`);
-  },
-);
+      expect(mockNetwork.history.post[0].url).toBe(`${expectedShServiceHostname}api/v1/process`);
+    },
+  );
+});

--- a/src/layer/__tests__/fixtures.ProcessingDataFusionLayer.ts
+++ b/src/layer/__tests__/fixtures.ProcessingDataFusionLayer.ts
@@ -1,0 +1,37 @@
+import { BBox, CRS_EPSG4326, MimeTypes } from '../../index';
+
+export function constructFixtureGetMapRequest({
+  bbox = new BBox(CRS_EPSG4326, 18, 20, 20, 22),
+  width = 512,
+  height = 512,
+  format = MimeTypes.JPEG,
+  evalscript = '',
+  data = [],
+}): Record<any, any> {
+  const expectedRequest = {
+    evalscript: evalscript,
+    input: {
+      bounds: {
+        bbox: [bbox.minX, bbox.minY, bbox.maxX, bbox.maxY],
+        properties: { crs: bbox.crs.opengisUrl },
+      },
+      data: data,
+    },
+    output: {
+      width: width,
+      height: height,
+      responses: [
+        {
+          format: {
+            type: format,
+          },
+          identifier: 'default',
+        },
+      ],
+    },
+  };
+
+  return {
+    expectedRequest: expectedRequest,
+  };
+}


### PR DESCRIPTION
This PR is similar to #160, but tries to solve setting data fusion Process API parameters more properly (that is, layers themselves are now responsible for setting the params).

- to do that, I needed to make `updateProcessingGetMapPayload` public - however, I have prepended it with `_` to discourage its use outside of the library
- `evalscriptUrl` parameter in `ProcessingDataFusionLayer` constructor was mandatory; I have added `?` to avoid having to declare it in tests
- I didn't dare remove `upsampling` and `downsampling` from `ProcessingDataFusionLayer.getMap()` - they are not covered with tests and I am not certain that I can remove them
- I have rearranged the existing test for `ProcessingDataFusionLayer` a bit to allow adding a new one in a clearer manner