### PR TITLE
Image fetching optimization: automatically decide between JPEG and PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ If your evalscript contains multiple [output response objects](https://docs.sent
   const imageBlob = await layer.getMap(getMapParams, ApiType.PROCESSING);
 ```
 
+### Optimizing the data retrieval
+
+This library is often used to display satellite imagery on the map. Data in this case is requested in "tiles" (typically of 256x256 or 512x512 pixels) and is often overlaid over some background map, which shows land cover, borders, roads, places,... Thus, when making `getMap` requests, it is usually desirable to get images which are transparent in places where the satellite data is not available. The easiest solution is to use `PNG` format instead of `JPEG` (because `JPEG` does not support transparency), however this makes the size of the images much bigger, leading to longer load times on slow connections.
+
+To solve this issue, there is a special format available (`MimeTypes.JPEG_or_PNG`). If specified, `getMap` call will try to determine if it should use `JPEG` or `PNG` based on the data available. If requested bounding box is fully covered with data, it will use JPEG (for performance reasons), otherwise it will use PNG and will return an image with transparent channel.
+
+CAREFUL: this setting should only be used if the retrieved data is not transparent (within the tiles). In other words: if `evalscript` returns a transparent image channel, using `PNG` is probably the only viable option.
+
+```javascript
+  const getMapParams = {
+    bbox: new BBox(CRS_EPSG4326, 18.3, 20.1, 18.7, 20.4),
+    fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+    toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+    width: 512,
+    height: 512,
+    format: MimeTypes.JPEG_or_PNG,
+  };
+  const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
+  const imageBlob2 = await layer.getMap(getMapParams, ApiType.PROCESSING);
+```
+
 ### Effects
 
 When requesting an image, effects can be applied to visually improve the image.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If your evalscript contains multiple [output response objects](https://docs.sent
 
 This library is often used to display satellite imagery on the map. Data in this case is requested in "tiles" (typically of 256x256 or 512x512 pixels) and is often overlaid over some background map, which shows land cover, borders, roads, places,... Thus, when making `getMap` requests, it is usually desirable to get images which are transparent in places where the satellite data is not available. The easiest solution is to use `PNG` format instead of `JPEG` (because `JPEG` does not support transparency), however this makes the size of the images much bigger, leading to longer load times on slow connections.
 
-To solve this issue, there is a special format available (`MimeTypes.JPEG_or_PNG`). If specified, `getMap` call will try to determine if it should use `JPEG` or `PNG` based on the data available. If requested bounding box is fully covered with data, it will use JPEG (for performance reasons), otherwise it will use PNG and will return an image with transparent channel.
+To solve this issue, there is a special format available (`MimeTypes.JPEG_OR_PNG`). If specified, `getMap` call will try to determine if it should use `JPEG` or `PNG` based on the data available. If requested bounding box is fully covered with data, it will use JPEG (for performance reasons), otherwise it will use PNG and will return an image with transparent channel.
 
 CAREFUL: this setting should only be used if the retrieved data is not transparent (within the tiles). In other words: if `evalscript` returns a transparent image channel, using `PNG` is probably the only viable option.
 
@@ -193,7 +193,7 @@ CAREFUL: this setting should only be used if the retrieved data is not transpare
     toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
     width: 512,
     height: 512,
-    format: MimeTypes.JPEG_or_PNG,
+    format: MimeTypes.JPEG_OR_PNG,
   };
   const imageBlob = await layer.getMap(getMapParams, ApiType.WMS);
   const imageBlob2 = await layer.getMap(getMapParams, ApiType.PROCESSING);

--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -71,13 +71,13 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    const getMapValue = await ensureTimeout(async innerReqConfig => {
+    params = await this.decideJpegOrPng(params);
+    return await ensureTimeout(async innerReqConfig => {
       if (api === ApiType.PROCESSING) {
         await this.updateLayerFromServiceIfNeeded(innerReqConfig);
       }
       return await super.getMap(params, api, innerReqConfig);
     }, reqConfig);
-    return getMapValue;
   }
 
   protected async updateProcessingGetMapPayload(payload: ProcessingPayload): Promise<ProcessingPayload> {

--- a/src/layer/AbstractDEMLayer.ts
+++ b/src/layer/AbstractDEMLayer.ts
@@ -71,8 +71,8 @@ export class AbstractDEMLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    params = await this.decideJpegOrPng(params);
     return await ensureTimeout(async innerReqConfig => {
+      params = await this.decideJpegOrPng(params, innerReqConfig);
       if (api === ApiType.PROCESSING) {
         await this.updateLayerFromServiceIfNeeded(innerReqConfig);
       }

--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -89,7 +89,10 @@ export class AbstractLayer {
     return blob;
   }
 
-  protected async decideJpegOrPng(params: GetMapParams): Promise<GetMapParams> {
+  protected async decideJpegOrPng(
+    params: GetMapParams,
+    reqConfig: RequestConfiguration,
+  ): Promise<GetMapParams> {
     // If using JPEG_OR_PNG format, this function changes params so that format is set to either JPEG or PNG.
 
     if (params.format !== MimeTypes.JPEG_OR_PNG) {
@@ -102,7 +105,7 @@ export class AbstractLayer {
       params.toTime,
       null,
       null,
-      null,
+      reqConfig,
       Number.POSITIVE_INFINITY,
     );
     if (res.length === 0) {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -167,7 +167,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    const getMapValue = await ensureTimeout(async innerReqConfig => {
+    params = await this.decideJpegOrPng(params);
+    return await ensureTimeout(async innerReqConfig => {
       // SHv3 services support Processing API:
       if (api === ApiType.PROCESSING) {
         if (!this.dataset) {
@@ -234,7 +235,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
       return super.getMap(params, api, innerReqConfig);
     }, reqConfig);
-    return getMapValue;
   }
 
   public supportsApiType(api: ApiType): boolean {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -167,8 +167,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    params = await this.decideJpegOrPng(params);
     return await ensureTimeout(async innerReqConfig => {
+      params = await this.decideJpegOrPng(params, innerReqConfig);
       // SHv3 services support Processing API:
       if (api === ApiType.PROCESSING) {
         if (!this.dataset) {

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -96,8 +96,8 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    params = await this.decideJpegOrPng(params);
     return await ensureTimeout(async innerReqConfig => {
+      params = await this.decideJpegOrPng(params, innerReqConfig);
       await this.updateLayerFromServiceIfNeeded(innerReqConfig);
       return await super.getMap(params, api, innerReqConfig);
     }, reqConfig);

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -96,11 +96,11 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    const getMapValue = await ensureTimeout(async innerReqConfig => {
+    params = await this.decideJpegOrPng(params);
+    return await ensureTimeout(async innerReqConfig => {
       await this.updateLayerFromServiceIfNeeded(innerReqConfig);
       return await super.getMap(params, api, innerReqConfig);
     }, reqConfig);
-    return getMapValue;
   }
 
   protected async updateProcessingGetMapPayload(

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -54,7 +54,8 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    const getMapValue = await ensureTimeout(async innerReqConfig => {
+    params = await this.decideJpegOrPng(params);
+    return await ensureTimeout(async innerReqConfig => {
       if (api !== ApiType.PROCESSING) {
         throw new Error(`Only API type "PROCESSING" is supported`);
       }
@@ -139,7 +140,6 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
 
       return blob;
     }, reqConfig);
-    return getMapValue;
   }
 
   public supportsApiType(api: ApiType): boolean {

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -54,8 +54,8 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
   }
 
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
-    params = await this.decideJpegOrPng(params);
     return await ensureTimeout(async innerReqConfig => {
+      params = await this.decideJpegOrPng(params, innerReqConfig);
       if (api !== ApiType.PROCESSING) {
         throw new Error(`Only API type "PROCESSING" is supported`);
       }

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -13,7 +13,7 @@ export type GetMapParams = {
   fromTime: Date | null;
   /** End of the time interval for which the images are fetched. If `fromTime` is null, only this parameter will be used to set time. */
   toTime: Date;
-  format: MimeType;
+  format: MimeType | FormatJpegOrPng;
   resx?: string; // either resx + resy or width + height must be specified
   resy?: string;
   width?: number;
@@ -123,9 +123,12 @@ export type MimeType =
   | 'image/tiff;depth=16'
   | 'image/tiff;depth=32f';
 
-export const MimeTypes: Record<string, MimeType> = {
+export type FormatJpegOrPng = 'JPEG_OR_PNG';
+
+export const MimeTypes: Record<string, MimeType | FormatJpegOrPng> = {
   JPEG: 'image/jpeg',
   PNG: 'image/png',
+  JPEG_OR_PNG: 'JPEG_OR_PNG',
 };
 
 export type ImageProperties = {

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -126,7 +126,9 @@ export function createProcessingPayload(
       responses: [
         {
           identifier: params.outputResponseId ? params.outputResponseId : 'default',
-          format: { type: params.format },
+          format: {
+            type: params.format as MimeType,
+          },
         },
       ],
     },

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -61,7 +61,7 @@ export function wmsGetMapUrl(
     version: OGC_SERVICES_IMPLEMENTED_VERSIONS[ServiceType.WMS],
     service: ServiceType.WMS,
     request: 'GetMap',
-    format: MimeTypes.JPEG,
+    format: MimeTypes.JPEG as MimeType,
     srs: CRS_EPSG4326.authId,
     layers: undefined,
     bbox: undefined,
@@ -85,7 +85,7 @@ export function wmsGetMapUrl(
   queryParams.srs = params.bbox.crs.authId;
 
   if (params.format) {
-    queryParams.format = params.format;
+    queryParams.format = params.format as MimeType;
   }
 
   if (!params.fromTime) {


### PR DESCRIPTION
As an optimization, we can decide for some layers (which don't output transparent values where the data is available) to use JPEG instead of PNG depending on availability of data. This PR adds `MimeTypes.JPEG_OR_PNG` "format", which causes this library to search for tiles and change format to JPEG (if the whole area is covered) or PNG (if not).

Further optimization is possible: we could search for the data availability for the whole screen to avoid excessive number of requests; however, this is something that can be improved in the next PR.