### PR TITLE
Retry failed requests if rate limited

### DIFF
--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -129,5 +129,5 @@ const shouldRetry = (error: AxiosError): boolean => {
   if (!error.response || !error.response.status) {
     return false;
   }
-  return error.response.status >= 500 && error.response.status <= 599;
+  return error.response.status == 429 || (error.response.status >= 500 && error.response.status <= 599);
 };


### PR DESCRIPTION
This MR makes sh-js treat `429` responses the same as `5xx`. The reasoning behind it is that user doesn't really care about the reason for failure - if repeating the request might make it succeed, then it should be repeated.

Rate limiting responses can of course be treated a bit more subtly:
- failed requests (on the same page) could coordinate to avoid hitting the endpoint at the same time
- one 429 response could signal all other requests (to the same service) to delay a bit, thus avoiding multiple 429 responses

But this is left for the future MRs.