### PR TITLE
add previews for LOTL1

### DIFF
--- a/src/layer/Landsat8AWSLOTL1Layer.ts
+++ b/src/layer/Landsat8AWSLOTL1Layer.ts
@@ -5,11 +5,19 @@ import { Link, LinkType } from './const';
 export class Landsat8AWSLOTL1Layer extends AbstractLandsat8Layer {
   public readonly dataset = DATASET_AWS_LOTL1;
 
+  private getPreviewUrl(productId: string): string {
+    return `https://landsatlook.usgs.gov/gen-browse?size=thumb&type=refl&product_id=${productId}`;
+  }
+
   protected getTileLinks(tile: Record<string, any>): Link[] {
     return [
       {
         target: tile.dataUri,
         type: LinkType.AWS,
+      },
+      {
+        target: this.getPreviewUrl(tile.originalId),
+        type: LinkType.PREVIEW,
       },
     ];
   }
@@ -21,6 +29,11 @@ export class Landsat8AWSLOTL1Layer extends AbstractLandsat8Layer {
     if (assets && assets.data) {
       result.push({ target: assets.data.href, type: LinkType.AWS });
     }
+
+    result.push({
+      target: this.getPreviewUrl(feature.id),
+      type: LinkType.PREVIEW,
+    });
 
     return result;
   }


### PR DESCRIPTION
Adds previews for LOTL1 ( as described in core issue 1617)

```
Landsat Collection 2 is fully under Requester pays, so no data is available via http.

The best option I was able to find is this one from Earth Explorer:
https://landsatlook.usgs.gov/gen-browse?size=thumb&type=refl&product_id=LC08_L1TP_031028_20210411_20210416_02_T1
```