### PR TITLE
Fix/caching and retrying

### DIFF
--- a/src/layer/__tests__/retries.ts
+++ b/src/layer/__tests__/retries.ts
@@ -110,7 +110,7 @@ test('Uses default number of retries (2) if null is set', async () => {
   expect(mockNetwork.history.post.length).toBe(3);
 });
 
-test.only('Retries correctly when caching is enabled', async () => {
+test('Retries correctly when caching is enabled', async () => {
   jest.setTimeout(10 * 3000 + 1000);
   const {
     fromTime,

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -6,6 +6,7 @@ import {
   saveCacheResponse,
   findAndDeleteExpiredCachedItems,
   CacheConfig,
+  removeCacheableRequestsInProgress,
 } from './cacheHandlers';
 
 const DEFAULT_RETRY_DELAY = 3000;
@@ -116,6 +117,9 @@ const retryRequests = (err: any): any => {
     const shouldRetry = err.config.retriesCount < maxRetries;
     if (shouldRetry) {
       err.config.retriesCount += 1;
+      if (err.config.cacheKey) {
+        removeCacheableRequestsInProgress(err.config.cacheKey);
+      }
       return new Promise(resolve => setTimeout(() => resolve(axios(err.config)), DEFAULT_RETRY_DELAY));
     }
   }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -120,7 +120,8 @@ const generateCacheKey = (request: AxiosRequestConfig): string | null => {
     // post requests are not supported, so we mimic a get request, by formatting the body/params to sha256, and constructing a key/url
     // idea taken from https://blog.cloudflare.com/introducing-the-workers-cache-api-giving-you-control-over-how-your-content-is-cached/
     case 'post':
-      const body = JSON.stringify(request.data);
+      // don't serialize strings or already serialized objects as this will result in escaping some chars and different hash
+      const body = typeof request.data === 'string' ? request.data : JSON.stringify(request.data);
       const hash = stringToHash(body);
       return `${request.url}?${hash}`;
     case 'get':

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -17,11 +17,14 @@ export type CacheConfig = {
 // simply delay new requests with the same cacheKey.
 const cacheableRequestsInProgress = new Set();
 
+export const removeCacheableRequestsInProgress = (cacheKey: string): void => {
+  cacheableRequestsInProgress.delete(cacheKey);
+};
+
 export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (!isRequestCachable(request)) {
     return request;
   }
-
   const cacheKey = generateCacheKey(request);
   // resource not cacheable? It couldn't have been saved to cache:
   if (cacheKey === null) {
@@ -63,7 +66,7 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
     // if we have blocked other requests by mistake (we will not be creating a new cache
     // entry from this request), we should fix this now:
     if (!request.cacheKey) {
-      cacheableRequestsInProgress.delete(cacheKey);
+      removeCacheableRequestsInProgress(cacheKey);
     }
   }
 };
@@ -102,7 +105,7 @@ export const saveCacheResponse = async (response: AxiosResponse): Promise<any> =
     // if response.config.cacheKey was there, we *must* remove it from the list
     // of requests in progress, otherwise all other requests with the same cacheKey
     // will wait indefinitely:
-    cacheableRequestsInProgress.delete(response.config.cacheKey);
+    removeCacheableRequestsInProgress(response.config.cacheKey);
   }
 };
 


### PR DESCRIPTION
closes #167 

There were 2 bugs related with this issue (there are probably some more, but I was able to find only those two) 
- creating cache key for same request didn't always produce  same hash
- if caching is enabled request locked itself on retry as it was waiting infinitely for "cache lock".

1. problem with caching keys

Cache key for post requests was created by serializing request data and calculating the hash. However, request data is not always JSON object but it can be already serialized JSON object (probably axios is doing some behind the scenes serialization). In such cases, the already serialized response was serialized once again resulting in escaping some characters like double quotes. When request is retried, request data is provided as string not as object. 

```javascript

const requestData={
"width":10
};
console.log(requestData,typeof requestData);
const requestDataAsString1=JSON.stringify(requestData);
console.log(requestDataAsString1,typeof requestDataAsString1);
const requestDataAsString2=JSON.stringify(requestDataAsString1);
console.log(requestDataAsString2,typeof requestDataAsString2);
```
Sequence above will produce this output, hashes calculated from requestDataAsString1 and requestDataAsString2 will obviously be different.

```console
{width: 10} "object"
{"width":10} string
"{\"width\":10}" string
```


