### PR TITLE
Fix identical request with a different authToken not being made after a failed one

### DIFF
--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -75,3 +75,19 @@ test('requestAuthToken correctly encodes URI parameters', async () => {
   const req = mockNetwork.history.post[0];
   expect(req.data).toBe('grant_type=client_credentials&client_id=asd%2C321&client_secret=.%2F*%26');
 });
+
+test('getMap with different authToken following an identical failed getMap makes a request', async () => {
+  const { layer, getMapParams } = constructFixtureGetMap();
+
+  mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(429, '');
+  mockNetwork.onPost().replyOnce(200, '');
+
+  const reqConfig = { authToken: EXAMPLE_TOKEN1 };
+  await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
+
+  reqConfig.authToken = EXAMPLE_TOKEN2;
+  await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
+
+  expect(mockNetwork.history.post.length).toBe(2);
+});

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -79,15 +79,23 @@ test('requestAuthToken correctly encodes URI parameters', async () => {
 test('getMap with different authToken following an identical failed getMap makes a request', async () => {
   const { layer, getMapParams } = constructFixtureGetMap();
 
+  jest.setTimeout(30000);
+
   mockNetwork.reset();
+  mockNetwork.onPost().replyOnce(429, '');
+  mockNetwork.onPost().replyOnce(429, '');
   mockNetwork.onPost().replyOnce(429, '');
   mockNetwork.onPost().replyOnce(200, '');
 
-  const reqConfig = { authToken: EXAMPLE_TOKEN1 };
-  await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
+  const reqConfig = { authToken: EXAMPLE_TOKEN1, retries: 2 };
+  try {
+    await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
+  } catch (err) {
+    expect(err.response.status).toBe(429);
+  }
 
   reqConfig.authToken = EXAMPLE_TOKEN2;
   await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
 
-  expect(mockNetwork.history.post.length).toBe(2);
+  expect(mockNetwork.history.post.length).toBe(4);
 });

--- a/src/layer/__tests__/auth.ts
+++ b/src/layer/__tests__/auth.ts
@@ -98,4 +98,6 @@ test('getMap with different authToken following an identical failed getMap makes
   await layer.getMap(getMapParams, ApiType.PROCESSING, reqConfig);
 
   expect(mockNetwork.history.post.length).toBe(4);
+  expect(mockNetwork.history.post[2].headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN1}`);
+  expect(mockNetwork.history.post[3].headers.Authorization).toBe(`Bearer ${EXAMPLE_TOKEN2}`);
 });

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -108,6 +108,11 @@ const retryRequests = (err: any): any => {
   if (!err.config) {
     return Promise.reject(err);
   }
+
+  if (err.config.cacheKey) {
+    removeCacheableRequestsInProgress(err.config.cacheKey);
+  }
+
   if (shouldRetry(err)) {
     err.config.retriesCount = err.config.retriesCount | 0;
     const maxRetries =
@@ -117,9 +122,6 @@ const retryRequests = (err: any): any => {
     const shouldRetry = err.config.retriesCount < maxRetries;
     if (shouldRetry) {
       err.config.retriesCount += 1;
-      if (err.config.cacheKey) {
-        removeCacheableRequestsInProgress(err.config.cacheKey);
-      }
       return new Promise(resolve => setTimeout(() => resolve(axios(err.config)), DEFAULT_RETRY_DELAY));
     }
   }


### PR DESCRIPTION
After a request failed and finally rejected the promise, `cacheKey` wasn't removed from `cacheableRequestsInProgress`.

So making a request with identical parameters, but a different `authToken` (which isn't a part of the hash), didn't work.