### PR TITLE
Add CRS:84 as a separate CRS from EPSG:4326

### DIFF
--- a/src/crs.ts
+++ b/src/crs.ts
@@ -35,7 +35,13 @@ export const CRS_EPSG4326: CRS = {
   opengisUrl: 'http://www.opengis.net/def/crs/EPSG/0/4326',
 };
 
-export const CRS_WGS84: CRS = CRS_EPSG4326;
+export const CRS_WGS84: CRS = {
+  authId: 'CRS:84',
+  auth: 'CRS',
+  srid: 84,
+  urn: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+  opengisUrl: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+};
 
 export const SUPPORTED_CRS_OBJ = {
   [CRS_EPSG3857.authId]: CRS_EPSG3857,

--- a/src/crs.ts
+++ b/src/crs.ts
@@ -35,6 +35,9 @@ export const CRS_EPSG4326: CRS = {
   opengisUrl: 'http://www.opengis.net/def/crs/EPSG/0/4326',
 };
 
+/**
+ * Same as EPSG:4326, but with a switched coordinate order.
+ */
 export const CRS_WGS84: CRS = {
   authId: 'CRS:84',
   auth: 'CRS',

--- a/src/layer/AbstractSentinelHubV1OrV2Layer.ts
+++ b/src/layer/AbstractSentinelHubV1OrV2Layer.ts
@@ -19,7 +19,7 @@ import {
 } from './const';
 import { wmsGetMapUrl } from './wms';
 import { AbstractLayer } from './AbstractLayer';
-import { CRS_EPSG4326, findCrsFromUrn } from '../crs';
+import { CRS_EPSG4326, CRS_WGS84, findCrsFromUrn } from '../crs';
 import { fetchLayersFromGetCapabilitiesXml } from './utils';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { ensureTimeout } from '../utils/ensureTimeout';
@@ -242,7 +242,7 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
 
       const payload: FisPayload = {
         layer: this.layerId,
-        crs: CRS_EPSG4326.authId,
+        crs: params.crs ? params.crs.authId : CRS_EPSG4326.authId,
         geometry: WKT.convert(params.geometry),
         time: `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
           .utc(params.toTime)
@@ -257,8 +257,8 @@ export class AbstractSentinelHubV1OrV2Layer extends AbstractLayer {
         const selectedCrs = findCrsFromUrn(params.geometry.crs.properties.name);
         payload.crs = selectedCrs.authId;
       }
-      // When using CRS=EPSG:4326 one has to add the "m" suffix to enforce resolution in meters per pixel
-      if (payload.crs === CRS_EPSG4326.authId) {
+      // When using CRS=EPSG:4326 or CRS_WGS84 one has to add the "m" suffix to enforce resolution in meters per pixel
+      if (payload.crs === CRS_EPSG4326.authId || payload.crs === CRS_WGS84.authId) {
         payload.resolution = params.resolution + 'm';
       } else {
         payload.resolution = params.resolution;

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -668,7 +668,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         const selectedCrs = findCrsFromUrn(params.geometry.crs.properties.name);
         payload.crs = selectedCrs.authId;
       }
-      // When using CRS=EPSG:4326 one has to add the "m" suffix to enforce resolution in meters per pixel
+      // When using CRS=EPSG:4326 or CRS_WGS84 one has to add the "m" suffix to enforce resolution in meters per pixel
       if (payload.crs === CRS_EPSG4326.authId || payload.crs === CRS_WGS84.authId) {
         payload.resolution = params.resolution + 'm';
       } else {

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -25,7 +25,7 @@ import {
 import { wmsGetMapUrl } from './wms';
 import { processingGetMap, createProcessingPayload, ProcessingPayload } from './processing';
 import { AbstractLayer } from './AbstractLayer';
-import { CRS_EPSG4326, findCrsFromUrn } from '../crs';
+import { CRS_EPSG4326, CRS_WGS84, findCrsFromUrn } from '../crs';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { ensureTimeout } from '../utils/ensureTimeout';
 
@@ -653,7 +653,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
 
       const payload: FisPayload = {
         layer: this.layerId,
-        crs: CRS_EPSG4326.authId,
+        crs: params.crs ? params.crs.authId : CRS_EPSG4326.authId,
         geometry: WKT.convert(params.geometry),
         time: `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
           .utc(params.toTime)
@@ -669,7 +669,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         payload.crs = selectedCrs.authId;
       }
       // When using CRS=EPSG:4326 one has to add the "m" suffix to enforce resolution in meters per pixel
-      if (payload.crs === CRS_EPSG4326.authId) {
+      if (payload.crs === CRS_EPSG4326.authId || payload.crs === CRS_WGS84.authId) {
         payload.resolution = params.resolution + 'm';
       } else {
         payload.resolution = params.resolution;

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -1,7 +1,7 @@
 import { Polygon, MultiPolygon } from '@turf/helpers';
 
 import { BBox } from '../bbox';
-import { CRS_IDS } from '../crs';
+import { CRS_IDS, CRS } from '../crs';
 import { Effects } from '../mapDataManipulation/const';
 
 /**
@@ -167,6 +167,7 @@ export type GetStatsParams = {
   resolution: number;
   geometry: Polygon;
   bins?: number;
+  crs?: CRS;
 };
 
 export type FisPayload = {

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -359,7 +359,7 @@ export const stats = () => {
 
 
 export const getStatsGeoJSONDifferentCRS = () => {
-  // GeoJSON is in CRS:84. Use geometry with longitude > 90, so switched coordinates aren't valid
+  // GeoJSON is in CRS:84. Use geometry with longitude near 0, so switched coordinates outside of data availability
 const geometry = {
         "type": "Polygon",
         "coordinates": [

--- a/stories/landsat5.eocloud.stories.js
+++ b/stories/landsat5.eocloud.stories.js
@@ -9,6 +9,7 @@ import {
   DATASET_EOCLOUD_LANDSAT5,
   LayersFactory,
   CRS_EPSG4326,
+  CRS_WGS84
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.EOC_INSTANCE_ID) {
@@ -355,3 +356,80 @@ export const stats = () => {
 
   return wrapperEl;
 };
+
+
+export const getStatsGeoJSONDifferentCRS = () => {
+  // GeoJSON is in CRS:84. Use geometry with longitude > 90, so switched coordinates aren't valid
+const geometry = {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0.9860229492187499,
+              48.86471476180277
+            ],
+            [
+              1.0876464843749998,
+              48.86471476180277
+            ],
+            [
+              1.0876464843749998,
+              48.922499263758255
+            ],
+            [
+              0.9860229492187499,
+              48.922499263758255
+            ],
+            [
+              0.9860229492187499,
+              48.86471476180277
+            ]
+          ]
+        ]
+      }
+     const layer = new Landsat5EOCloudLayer({
+    instanceId,
+    layerId,
+  });
+
+     const wrapperElCRS84 = document.createElement('div');
+     const wrapperElEPSG426 = document.createElement('div');
+     wrapperElEPSG426.innerHTML = `<h4>Request with EPSG:4326. Should return an empty object.</h4>`;
+     wrapperElCRS84.innerHTML = `<h4>Request with CRS:84. Should return results.</h4>`;
+
+      const containerElCRS84 = document.createElement('pre');
+     const containerElEPSG426 = document.createElement('pre');
+     wrapperElCRS84.insertAdjacentElement('beforeend', containerElCRS84);
+     wrapperElEPSG426.insertAdjacentElement('beforeend', containerElEPSG426)
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>getStats using GeoJSON with correct (CRS:84) and incorrect (EPSG:4326) crs</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', wrapperElEPSG426);
+  wrapperEl.insertAdjacentElement('beforeend', wrapperElCRS84);
+  
+
+
+     const fromTime = new Date(Date.UTC(2011, 1 - 1, 1, 0, 0, 0, 0));
+const toTime= new Date(Date.UTC(2011, 5 - 1, 1, 23, 59, 59, 999));
+
+const getStatsParams = {
+       fromTime: fromTime,
+       toTime: toTime,
+       geometry: geometry,
+       resolution: 200,
+          bins: 1,
+     }
+     const perform = async () => {
+  
+     getStatsParams['crs'] = CRS_EPSG4326
+     const statsESPG4326 = await layer.getStats(getStatsParams).catch(err => err)
+     containerElEPSG426.innerHTML = JSON.stringify(statsESPG4326,null, 4);
+
+     getStatsParams['crs'] = CRS_WGS84
+     const statsCRS84 = await layer.getStats(getStatsParams).catch(err => err)
+     containerElCRS84.innerHTML = JSON.stringify(statsCRS84,null, 4);
+   }
+
+     perform().then(() => {});
+
+     return wrapperEl;
+}

--- a/stories/s2l1c.stories.js
+++ b/stories/s2l1c.stories.js
@@ -5,6 +5,7 @@ import {
   S2L1CLayer,
   CRS_EPSG4326,
   CRS_EPSG3857,
+  CRS_WGS84,
   BBox,
   MimeTypes,
   ApiType,
@@ -487,3 +488,80 @@ export const cancelRequests = () => {
   setToken();
   return wrapperEl;
 };
+
+
+export const getStatsGeoJSONDifferentCRS = () => {
+  // GeoJSON is in CRS:84. Use geometry with longitude > 90, so switched coordinates aren't valid
+const geometry = {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              131.8359375,
+              50.958426723359935
+            ],
+            [
+              144.755859375,
+              50.958426723359935
+            ],
+            [
+              144.755859375,
+              57.468589192089354
+            ],
+            [
+              131.8359375,
+              57.468589192089354
+            ],
+            [
+              131.8359375,
+              50.958426723359935
+            ]
+          ]
+        ]
+      }
+     const layerS2L1C = new S2L1CLayer({
+    instanceId,
+    layerId,
+  });
+
+     const wrapperElCRS84 = document.createElement('div');
+     const wrapperElEPSG426 = document.createElement('div');
+     wrapperElEPSG426.innerHTML = `<h4>Request with EPSG:4326. Should return an empty object.</h4>`;
+     wrapperElCRS84.innerHTML = `<h4>Request with CRS:84. Should return results.</h4>`;
+
+      const containerElCRS84 = document.createElement('pre');
+     const containerElEPSG426 = document.createElement('pre');
+     wrapperElCRS84.insertAdjacentElement('beforeend', containerElCRS84);
+     wrapperElEPSG426.insertAdjacentElement('beforeend', containerElEPSG426)
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = `<h2>getStats using GeoJSON with correct (CRS:84) and incorrect (EPSG:4326) crs</h2>`;
+  wrapperEl.insertAdjacentElement('beforeend', wrapperElEPSG426);
+  wrapperEl.insertAdjacentElement('beforeend', wrapperElCRS84);
+  
+
+
+     const fromTime = new Date(Date.UTC(2020, 4 - 1, 1, 0, 0, 0, 0));
+const toTime= new Date(Date.UTC(2020, 5 - 1, 1, 23, 59, 59, 999));
+
+const getStatsParams = {
+       fromTime: fromTime,
+       toTime: toTime,
+       geometry: geometry,
+       resolution: 20000,
+          bins: 1,
+     }
+     const perform = async () => {
+  
+     getStatsParams['crs'] = CRS_EPSG4326
+     const statsESPG4326 = await layerS2L1C.getStats(getStatsParams)
+     containerElEPSG426.innerHTML = JSON.stringify(statsESPG4326,null, 4);
+
+     getStatsParams['crs'] = CRS_WGS84
+     const statsCRS84 = await layerS2L1C.getStats(getStatsParams)
+     containerElCRS84.innerHTML = JSON.stringify(statsCRS84,null, 4);
+   }
+
+     perform().then(() => {});
+
+     return wrapperEl;
+}


### PR DESCRIPTION
`CRS:84` is not identical to `EPSG:4326`, they have switched coordinates (in some cases).

So when requesting FIS with  `EPSG:4326`, but using GeoJSON (which has `CRS:84`), the service switched the coordinates around.

