### PR TITLE
remove cancelled requests from list of requests in progress

### DIFF
--- a/src/layer/__tests__/cancelToken.ts
+++ b/src/layer/__tests__/cancelToken.ts
@@ -11,7 +11,7 @@ import { constructFixtureFindTiles } from './fixtures.findTiles';
 import { RequestConfiguration } from '../../utils/cancelRequests';
 import { constructFixtureGetMap } from './fixtures.getMap';
 
-const createRequestPromise = (useCache = true, setRequestError: (err: any) => {}): any => {
+const createRequestPromise = (useCache = true, setRequestError: (err: any) => void): any => {
   const { fromTime, toTime, bbox, layer, mockedResponse } = constructFixtureFindTiles({});
   let cancelToken = new CancelToken();
   const requestsConfig: RequestConfiguration = {
@@ -122,11 +122,7 @@ describe('Handling cancelled requests', () => {
   });
 
   it('handles multiple requests with the same cancel token', async () => {
-    let requestError = null;
-    const { requestPromise, cancelToken, mockedResponse } = createRequestPromise(
-      true,
-      err => (requestError = err),
-    );
+    const { requestPromise, cancelToken, mockedResponse } = createRequestPromise(true, () => {});
 
     const { layer, getMapParams, mockedResponse: mockedResponse2 } = constructFixtureGetMap();
 

--- a/src/layer/__tests__/cancelToken.ts
+++ b/src/layer/__tests__/cancelToken.ts
@@ -1,0 +1,122 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import makeServiceWorkerEnv from 'service-worker-mock';
+import fetch from 'node-fetch';
+
+import { setAuthToken, invalidateCaches, CacheTarget, CancelToken, isCancelled } from '../../index';
+import { cacheableRequestsInProgress } from '../../utils/cacheHandlers';
+
+import '../../../jest-setup';
+import { constructFixtureFindTiles } from './fixtures.findTiles';
+import { RequestConfiguration } from '../../utils/cancelRequests';
+
+const createRequestPromise = (useCache = true, setRequestError: (err: any) => {}): any => {
+  const { fromTime, toTime, bbox, layer, mockedResponse } = constructFixtureFindTiles({});
+  let cancelToken = new CancelToken();
+  const requestsConfig: RequestConfiguration = {
+    cancelToken: cancelToken,
+  };
+
+  if (useCache) {
+    requestsConfig.cache = {
+      expiresIn: 60,
+      targets: [CacheTarget.MEMORY],
+    };
+  }
+
+  const thenFn = jest.fn();
+  const catchFn = jest.fn(err => {
+    setRequestError(err);
+  });
+
+  const requestPromise = layer
+    .findTiles(bbox, fromTime, toTime, null, null, requestsConfig)
+    .then(thenFn)
+    .catch(catchFn);
+
+  return {
+    requestPromise: requestPromise,
+    thenFn: thenFn,
+    catchFn: catchFn,
+    cancelToken: cancelToken,
+    mockedResponse: mockedResponse,
+  };
+};
+const mockNetwork = new MockAdapter(axios, { delayResponse: 10 });
+
+describe('Handling cancelled requests', () => {
+  beforeEach(async () => {
+    Object.assign(global, makeServiceWorkerEnv(), fetch); // adds these functions to the global object
+    await invalidateCaches();
+    setAuthToken(undefined);
+    mockNetwork.reset();
+    cacheableRequestsInProgress.clear();
+  });
+
+  it('doesnt cancel a request if cancel() is not called', async () => {
+    let requestError = null;
+    const { requestPromise, thenFn, catchFn, mockedResponse } = createRequestPromise(
+      true,
+      err => (requestError = err),
+    );
+
+    mockNetwork.onPost().replyOnce(200, mockedResponse);
+
+    await Promise.all([requestPromise]);
+    expect(thenFn).toHaveBeenCalled();
+    expect(catchFn).not.toHaveBeenCalled();
+    expect(requestError).toBeNull();
+    expect(isCancelled(requestError)).toBeFalsy();
+    expect(cacheableRequestsInProgress.size).toBe(0);
+  });
+
+  it.each([[true], [false]])('cancels a request', async useCache => {
+    let requestError = null;
+    const { requestPromise, thenFn, catchFn, cancelToken } = createRequestPromise(
+      useCache,
+      err => (requestError = err),
+    );
+
+    mockNetwork.onPost().replyOnce(200);
+
+    await Promise.all([requestPromise, setTimeout(() => cancelToken.cancel(), 1)]);
+    expect(thenFn).not.toHaveBeenCalled();
+    expect(catchFn).toHaveBeenCalled();
+    expect(isCancelled(requestError)).toBeTruthy();
+    //check if request was removed from requestsInProgress
+    expect(cacheableRequestsInProgress.size).toBe(0);
+  });
+
+  it('makes a second request after first is cancelled', async () => {
+    let requestError = null;
+    const { requestPromise, thenFn, catchFn, cancelToken, mockedResponse } = createRequestPromise(
+      true,
+      err => (requestError = err),
+    );
+
+    mockNetwork.onPost().replyOnce(200, mockedResponse);
+    mockNetwork.onPost().replyOnce(200, mockedResponse);
+
+    //first request is cancelled
+    await Promise.all([requestPromise, setTimeout(() => cancelToken.cancel(), 1)]);
+    expect(thenFn).not.toHaveBeenCalled();
+    expect(catchFn).toHaveBeenCalled();
+    expect(isCancelled(requestError)).toBeTruthy();
+    expect(cacheableRequestsInProgress.size).toBe(0);
+
+    //repeat request without cancelling
+    requestError = null;
+
+    const { requestPromise: requestPromise2, thenFn: thenFn2, catchFn: catchFn2 } = createRequestPromise(
+      true,
+      err => (requestError = err),
+    );
+
+    await Promise.all([requestPromise2]);
+    expect(thenFn2).toHaveBeenCalled();
+    expect(catchFn2).not.toHaveBeenCalled();
+    expect(requestError).toBeNull();
+    expect(isCancelled(requestError)).toBeFalsy();
+    expect(cacheableRequestsInProgress.size).toBe(0);
+  });
+});

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -21,6 +21,7 @@ declare module 'axios' {
     cacheKey?: string;
     cache?: CacheConfig;
     rewriteUrlFunc?: (url: string) => string;
+    setCancelTokenCacheKey?: (cacheKey: string) => void;
   }
 }
 

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -15,7 +15,7 @@ export type CacheConfig = {
 // still all be executed - because by the time first response is saved in cache, the other 9
 // requests are already made too. To combat this, we save cacheKeys of ongoing requests and
 // simply delay new requests with the same cacheKey.
-const cacheableRequestsInProgress = new Set();
+export const cacheableRequestsInProgress = new Set();
 
 export const removeCacheableRequestsInProgress = (cacheKey: string): void => {
   cacheableRequestsInProgress.delete(cacheKey);
@@ -30,7 +30,6 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (cacheKey === null) {
     return request;
   }
-
   if (request.cancelToken && request.setCancelTokenCacheKey) {
     request.setCancelTokenCacheKey(cacheKey);
   }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -30,6 +30,9 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
   if (cacheKey === null) {
     return request;
   }
+
+  // When request is cancelled, it must also be removed from list of cacheableRequestsInProgress.
+  // In order to remove requests from cacheableRequestsInProgress, cancelToken must be aware of requests(cacheKeys) it is responsible for.
   if (request.cancelToken && request.setCancelTokenCacheKey) {
     request.setCancelTokenCacheKey(cacheKey);
   }

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -31,6 +31,10 @@ export const fetchCachedResponse = async (request: any): Promise<any> => {
     return request;
   }
 
+  if (request.cancelToken && request.setCancelTokenCacheKey) {
+    request.setCancelTokenCacheKey(cacheKey);
+  }
+
   // there is a request with the same cacheKey in progress - wait until it
   // finishes (we might be able to use its response from cache)
   while (cacheableRequestsInProgress.has(cacheKey)) {

--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -14,21 +14,24 @@ export type RequestConfiguration = {
 export class CancelToken {
   protected token: CancelTokenAxios | null = null;
   protected source: CancelTokenSource | null = null;
-  protected cacheKey: string | null = null;
+  //list of all request that can be cancelled by token instance
+  protected cacheKeys: Set<string> = new Set();
 
   public constructor() {
     this.source = axios.CancelToken.source();
     this.token = this.source.token;
   }
 
-  public setCancelTokenCacheKey(cacheKey: string | null): void {
-    this.cacheKey = cacheKey;
+  public setCancelTokenCacheKey(cacheKey: string): void {
+    this.cacheKeys.add(cacheKey);
   }
 
   public cancel(): void {
-    if (!!this.cacheKey) {
-      removeCacheableRequestsInProgress(this.cacheKey);
-      this.cacheKey = null;
+    if (this.cacheKeys.size > 0) {
+      for (let cacheKey of this.cacheKeys) {
+        removeCacheableRequestsInProgress(cacheKey);
+      }
+      this.cacheKeys.clear();
     }
     this.source.cancel();
   }


### PR DESCRIPTION
As described in #174, after canceling request was not removed from the list of requestsInProgress which result in infinite wait for cache lock when the same request was made next time.

What was done
- cacheKey was added to our CancelToken and it is set by axios interceptor when trying to get cache lock (fetchCachedResponse)
- cackeKey is removed from cacheableRequestsInProgress when cancel is invoked

The problem can be observed in Sentinel 2 L1C˙ stories Cancel Requests example` where repeating request after cancellation resulted in the broken image and missing requests.

Previous behavior can be replicated by commenting out code code added to the interceptor or cancel() method and running `cancelToken` tests (2 should fail) or story mentioned above.