### PR TITLE
Fix/aux request cache

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -114,7 +114,8 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     // we do not want this as layer updates will not invalidate this cache, so we rathger cache to memory
     const reqConfigWithMemoryCache = {
       ...reqConfig,
-      cache: CACHE_CONFIG_30MIN_MEMORY,
+      // Do not override cache if cache is disabled with `expiresIn: 0`
+      cache: reqConfig.cache.expiresIn === 0 ? reqConfig.cache : CACHE_CONFIG_30MIN_MEMORY,
     };
     const requestConfig: AxiosRequestConfig = {
       responseType: 'json',

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -31,8 +31,7 @@ import { ensureTimeout } from '../utils/ensureTimeout';
 
 import { Effects } from '../mapDataManipulation/const';
 import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
-import { CACHE_CONFIG_30MIN, CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
-
+import { CACHE_CONFIG_30MIN, CACHE_CONFIG_30MIN_MEMORY, CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
 interface ConstructorParameters {
   instanceId?: string | null;
   layerId?: string | null;
@@ -110,10 +109,17 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const headers = {
       Authorization: `Bearer ${authToken}`,
     };
+
+    // reqConfig might include the cache config from getMap, which could cache instances/${this.instanceId}/layers
+    // we do not want this as layer updates will not invalidate this cache, so we rathger cache to memory
+    const reqConfigWithMemoryCache = {
+      ...reqConfig,
+      cache: CACHE_CONFIG_30MIN_MEMORY,
+    };
     const requestConfig: AxiosRequestConfig = {
       responseType: 'json',
       headers: headers,
-      ...getAxiosReqParams(reqConfig, CACHE_CONFIG_30MIN),
+      ...getAxiosReqParams(reqConfigWithMemoryCache, null),
     };
     const res = await axios.get(url, requestConfig);
     const layersParams = res.data.map((l: any) => ({
@@ -222,7 +228,6 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         // allow subclasses to update payload with their own parameters:
         const updatedPayload = await this._updateProcessingGetMapPayload(payload, 0, innerReqConfig);
         const shServiceHostname = this.getShServiceHostname();
-
         let blob = await processingGetMap(shServiceHostname, updatedPayload, innerReqConfig);
 
         // apply effects:

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -111,7 +111,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     };
 
     // reqConfig might include the cache config from getMap, which could cache instances/${this.instanceId}/layers
-    // we do not want this as layer updates will not invalidate this cache, so we rathger cache to memory
+    // we do not want this as layer updates will not invalidate this cache, so we rather cache to memory
     const reqConfigWithMemoryCache = {
       ...reqConfig,
       // Do not override cache if cache is disabled with `expiresIn: 0`

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -115,7 +115,10 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     const reqConfigWithMemoryCache = {
       ...reqConfig,
       // Do not override cache if cache is disabled with `expiresIn: 0`
-      cache: reqConfig.cache.expiresIn === 0 ? reqConfig.cache : CACHE_CONFIG_30MIN_MEMORY,
+      cache:
+        reqConfig && reqConfig.cache && reqConfig.cache.expiresIn === 0
+          ? reqConfig.cache
+          : CACHE_CONFIG_30MIN_MEMORY,
     };
     const requestConfig: AxiosRequestConfig = {
       responseType: 'json',

--- a/src/layer/__tests__/fixtures.BYOCLayer.ts
+++ b/src/layer/__tests__/fixtures.BYOCLayer.ts
@@ -284,3 +284,121 @@ export function constructFixtureFindTilesCatalog({
     expectedResultHasMore: hasMore,
   };
 }
+
+export function constructFixtureUpdateLayerFromServiceIfNeeded({
+  collectionId = '0ed669e7-0f09-4909-9b9b-ffff1c9eaca5',
+  locationId = LocationIdSHv3.awsEuCentral1,
+}): Record<any, any> {
+  const layer = new BYOCLayer({
+    instanceId: 'cc6082af-2788-4b20-b0fe-54e13454bc66',
+    layerId: 'BYOC3',
+    collectionId: collectionId,
+    locationId: locationId,
+  });
+
+  const mockedResponse = [
+    {
+      '@id':
+        'https://services.sentinel-hub.com/configuration/v1/wms/instances/cc6082af-2788-4b20-b0fe-54e13454bc66/layers/BYOC3',
+      id: 'BYOC3',
+      title: 'byoc3',
+      description: '',
+      styles: [
+        {
+          name: 'default',
+          description: 'Default layer style',
+          evalScript:
+            '//VERSION=3\nfunction setup() {\nreturn {\n         input: ["IR", "G", "B"],\n          output: { bands: 3 }\n        };\n}\n\nfunction evaluatePixel(sample) {\n    return [sample.IR/255, sample.G/255, sample.B/255];\n}',
+        },
+      ],
+      orderHint: 0,
+      instance: {
+        '@id':
+          'https://services.sentinel-hub.com/configuration/v1/wms/instances/cc6082af-2788-4b20-b0fe-54e13454bc66',
+      },
+      dataset: {
+        '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/CUSTOM',
+      },
+      datasetSource: {
+        '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/CUSTOM/sources/10',
+      },
+      defaultStyleName: 'default',
+      datasourceDefaults: {
+        timeRange: {
+          startTime: {
+            type: 'ABSOLUTE',
+          },
+          endTime: {
+            type: 'ABSOLUTE',
+          },
+        },
+        mosaickingOrder: 'mostRecent',
+        temporal: false,
+        collectionId: '0ed669e7-0f09-4909-9b9b-ffff1c9eaca5',
+        type: 'CUSTOM',
+      },
+    },
+    {
+      '@id':
+        'https://services.sentinel-hub.com/configuration/v1/wms/instances/cc6082af-2788-4b20-b0fe-54e13454bc66/layers/BYOC_AZER_SKY_TRUE_COLOR',
+      id: 'BYOC_AZER_SKY_TRUE_COLOR',
+      title: 'BYOC_AZER_SKY_TRUE_COLOR',
+      description: '',
+      styles: [
+        {
+          name: 'default',
+          description: 'Default layer style',
+          evalScript:
+            '//VERSION=3\n//This script was converted from v1 to v3 using the converter API\n\nfunction evaluatePixel(samples) {\n  let r = Math.cbrt(samples.R * 0.000375);\n  let g = Math.cbrt(samples.G * 0.000375);\n  let b = Math.cbrt(samples.B * 0.000375);\n  return [r*r,g*g,b*b];\n}\n\nfunction setup() {\n  return {\n    input: [{\n      bands: [\n        "R",\n        "G",\n        "B"\n      ]\n    }],\n    output: {\n      bands: 3\n    }\n  }\n}\n',
+        },
+      ],
+      orderHint: 0,
+      instance: {
+        '@id':
+          'https://services.sentinel-hub.com/configuration/v1/wms/instances/cc6082af-2788-4b20-b0fe-54e13454bc66',
+      },
+      dataset: {
+        '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/CUSTOM',
+      },
+      datasetSource: {
+        '@id': 'https://services.sentinel-hub.com/configuration/v1/datasets/CUSTOM/sources/10',
+      },
+      defaultStyleName: 'default',
+      datasourceDefaults: {
+        mosaickingOrder: 'mostRecent',
+        temporal: false,
+        collectionId: '70874d64-7ef0-4ec4-a302-b1f00649c78d',
+        type: 'CUSTOM',
+      },
+    },
+  ];
+
+  const expectedLayerParams = {
+    layerId: 'BYOC3',
+    timeRange: { startTime: { type: 'ABSOLUTE' }, endTime: { type: 'ABSOLUTE' } },
+    mosaickingOrder: 'mostRecent',
+    temporal: false,
+    collectionId: '0ed669e7-0f09-4909-9b9b-ffff1c9eaca5',
+    type: 'CUSTOM',
+    evalscript:
+      '//VERSION=3\n' +
+      'function setup() {\n' +
+      'return {\n' +
+      '         input: ["IR", "G", "B"],\n' +
+      '          output: { bands: 3 }\n' +
+      '        };\n' +
+      '}\n' +
+      '\n' +
+      'function evaluatePixel(sample) {\n' +
+      '    return [sample.IR/255, sample.G/255, sample.B/255];\n' +
+      '}',
+    dataProduct: undefined as any,
+    legend: undefined as any,
+  };
+
+  return {
+    layer: layer,
+    mockedResponse: mockedResponse,
+    expectedLayerParams: expectedLayerParams,
+  };
+}

--- a/src/utils/cacheHandlers.ts
+++ b/src/utils/cacheHandlers.ts
@@ -1,9 +1,13 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { stringify } from 'query-string';
-import { CacheTargets, cacheFactory, SUPPORTED_TARGETS } from './Cache';
+import { CacheTarget, CacheTargets, cacheFactory, SUPPORTED_TARGETS } from './Cache';
 
 export const CACHE_CONFIG_30MIN = { expiresIn: 1800 };
 export const CACHE_CONFIG_NOCACHE = { expiresIn: 0 };
+export const CACHE_CONFIG_30MIN_MEMORY = {
+  targets: [CacheTarget.MEMORY],
+  expiresIn: CACHE_CONFIG_30MIN.expiresIn,
+};
 export const EXPIRY_HEADER_KEY = 'cache_expires';
 
 export type CacheConfig = {


### PR DESCRIPTION
resolve #180 

- Introduces `CACHE_CONFIG_30MIN_MEMORY`
- Removes cache config received from `getMap` in `fetchLayerParamsFromSHServiceV3` and assign  `CACHE_CONFIG_30MIN_MEMORY` to the cache property of `reqConfig`