### PR TITLE
Fix/planet nicfi force rgb image

### DIFF
--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -374,7 +374,10 @@ export class LayersFactory {
           description: template.description,
           legendUrl: layer.legendUrl,
           dataset: layer.dataset,
-          resourceUrl: stringifyUrl({ url: parsedResourceUrl.url, query: template.resourceUrlParams }),
+          resourceUrl: stringifyUrl({
+            url: parsedResourceUrl.url,
+            query: { ...parsedResourceUrl.query, ...template.resourceUrlParams },
+          }),
         }));
         newLayers.push(...falseColorLayers);
       }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -1,4 +1,4 @@
-import { stringify } from 'query-string';
+import { parseUrl, stringifyUrl } from 'query-string';
 
 import {
   fetchLayersFromGetCapabilitiesXml,
@@ -361,17 +361,20 @@ export class LayersFactory {
         description: layerInfo.Abstract ? layerInfo.Abstract[0] : null,
         dataset: DATASET_PLANET_NICFI,
         legendUrl: layerInfo.Style[0].LegendURL,
-        resourceUrl: layerInfo.ResourceUrl,
+        resourceUrl: layerInfo.Name[0].includes('analytic')
+          ? `${layerInfo.ResourceUrl}&proc=rgb`
+          : layerInfo.ResourceUrl,
       };
       newLayers.push(layer);
       if (layer.layerId.includes('analytic')) {
+        const parsedResourceUrl = parseUrl(layer.resourceUrl);
         const falseColorLayers = PLANET_FALSE_COLOR_TEMPLATES.map(template => ({
           layerId: `${layer.layerId}_${template.titleSuffix}`,
           title: `${layer.title} ${template.titleSuffix}`,
           description: template.description,
           legendUrl: layer.legendUrl,
           dataset: layer.dataset,
-          resourceUrl: `${layer.resourceUrl}&${stringify(template.resourceUrlParams)}`,
+          resourceUrl: stringifyUrl({ url: parsedResourceUrl.url, query: template.resourceUrlParams }),
         }));
         newLayers.push(...falseColorLayers);
       }

--- a/src/layer/PlanetNicfi.ts
+++ b/src/layer/PlanetNicfi.ts
@@ -48,17 +48,10 @@ export class PlanetNicfiLayer extends WmtsLayer {
     reqConfig?: RequestConfiguration, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<Date[]> {
     return await ensureTimeout(async innerReqConfig => {
-      const currentLayerDate = this.layerId.match(YYYY_MM_REGEX);
       const parsedLayers = await fetchLayersFromWmtsGetCapabilitiesXml(this.baseUrl, innerReqConfig);
       const applicableLayers = parsedLayers.filter(l => {
-        const lDateRange = l.Name[0].match(YYYY_MM_REGEX);
-        return (
-          lDateRange &&
-          lDateRange.length === currentLayerDate.length &&
-          this.getLayerType(this.layerId) === this.getLayerType(l.Name[0])
-        );
+        return this.getLayerType(this.layerId) === this.getLayerType(l.Name[0]);
       });
-
       const datesFromApplicableLayers = applicableLayers.map(l => {
         const dateArray = l.Name[0].match(YYYY_MM_REGEX);
         return moment.utc(dateArray[dateArray.length - 1]).endOf('month');


### PR DESCRIPTION
planet_medres_normalized_analytic_2017-06_2017-11_mosaic should return an RGB image, but it returns a false colour color image.

This MR adds a `proc=rgb` to `planet_medres_normalized_analytic` layers in order to force an RGB image.
