### PR TITLE
Feature/additional tpdi order params

### DIFF
--- a/src/dataimport/AirbusDataProvider.ts
+++ b/src/dataimport/AirbusDataProvider.ts
@@ -60,8 +60,8 @@ export class AirbusDataProvider extends AbstractTPDProvider {
     return { data: [data] };
   }
 
-  protected getAdditionalOrderParams(items: string[], params: TPDISearchParams): any {
-    const input = this.getSearchPayload(params);
+  protected getAdditionalOrderParams(items: string[], searchParams: TPDISearchParams): any {
+    const input = this.getSearchPayload(searchParams);
     if (!!items && items.length) {
       const dataObject = input.data[0];
       dataObject.products = items.map(item => ({ id: item }));

--- a/src/dataimport/MaxarDataProvider.ts
+++ b/src/dataimport/MaxarDataProvider.ts
@@ -1,4 +1,4 @@
-import { TPDProvider, TPDISearchParams, MaxarProductBands } from './const';
+import { TPDProvider, TPDISearchParams, MaxarProductBands, TPDIOrderParams } from './const';
 import { AbstractTPDProvider } from './TPDProvider';
 
 export class MaxarDataProvider extends AbstractTPDProvider {
@@ -60,8 +60,12 @@ export class MaxarDataProvider extends AbstractTPDProvider {
     return { data: [data] };
   }
 
-  protected getAdditionalOrderParams(items: string[], params: TPDISearchParams): any {
-    const input = this.getSearchPayload(params);
+  protected getAdditionalOrderParams(
+    items: string[],
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams,
+  ): any {
+    const input = this.getSearchPayload(searchParams);
     if (!!items && items.length) {
       const dataObject = input.data[0];
       dataObject.selectedImages = items;

--- a/src/dataimport/MaxarDataProvider.ts
+++ b/src/dataimport/MaxarDataProvider.ts
@@ -71,6 +71,11 @@ export class MaxarDataProvider extends AbstractTPDProvider {
       dataObject.selectedImages = items;
       delete dataObject.dataFilter;
     }
+
+    if (orderParams?.productKernel) {
+      input.productKernel = orderParams.productKernel;
+    }
+
     return input;
   }
 }

--- a/src/dataimport/MaxarDataProvider.ts
+++ b/src/dataimport/MaxarDataProvider.ts
@@ -66,14 +66,15 @@ export class MaxarDataProvider extends AbstractTPDProvider {
     orderParams: TPDIOrderParams,
   ): any {
     const input = this.getSearchPayload(searchParams);
-    if (!!items && items.length) {
-      const dataObject = input.data[0];
-      dataObject.selectedImages = items;
-      delete dataObject.dataFilter;
-    }
+    const dataObject = input.data[0];
 
     if (orderParams?.productKernel) {
-      input.productKernel = orderParams.productKernel;
+      dataObject.productKernel = orderParams.productKernel;
+    }
+
+    if (!!items && items.length) {
+      dataObject.selectedImages = items;
+      delete dataObject.dataFilter;
     }
 
     return input;

--- a/src/dataimport/PlanetDataProvider.ts
+++ b/src/dataimport/PlanetDataProvider.ts
@@ -1,4 +1,4 @@
-import { TPDProvider, TPDISearchParams, PlanetItemType } from './const';
+import { TPDProvider, TPDISearchParams, PlanetItemType, TPDIOrderParams } from './const';
 import { AbstractTPDProvider } from './TPDProvider';
 
 export class PlanetDataProvider extends AbstractTPDProvider {
@@ -47,13 +47,16 @@ export class PlanetDataProvider extends AbstractTPDProvider {
     data.dataFilter = dataFilter;
 
     return {
-      planetApiKey: params.planetApiKey,
       data: [data],
     };
   }
 
-  protected getAdditionalOrderParams(items: string[], params: TPDISearchParams): any {
-    const input = this.getSearchPayload(params);
+  protected getAdditionalOrderParams(
+    items: string[],
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams,
+  ): any {
+    const input = this.getSearchPayload(searchParams);
     const dataObject = input.data[0];
 
     if (!!params.harmonizeTo) {

--- a/src/dataimport/PlanetDataProvider.ts
+++ b/src/dataimport/PlanetDataProvider.ts
@@ -59,8 +59,12 @@ export class PlanetDataProvider extends AbstractTPDProvider {
     const input = this.getSearchPayload(searchParams);
     const dataObject = input.data[0];
 
-    if (!!params.harmonizeTo) {
-      dataObject.harmonizeTo = params.harmonizeTo;
+    if (orderParams?.harmonizeTo) {
+      dataObject.harmonizeTo = orderParams.harmonizeTo;
+    }
+
+    if (orderParams?.planetApiKey) {
+      input.planetApiKey = orderParams.planetApiKey;
     }
 
     if (!!items && items.length) {

--- a/src/dataimport/TPDI.ts
+++ b/src/dataimport/TPDI.ts
@@ -130,7 +130,7 @@ export class TPDI {
     collectionId: string,
     items: string[],
     searchParams: TPDISearchParams,
-    orderParams: TPDIOrderParams,
+    orderParams?: TPDIOrderParams,
     reqConfig?: RequestConfiguration,
   ): Promise<Order> {
     return await ensureTimeout(async innerReqConfig => {

--- a/src/dataimport/TPDI.ts
+++ b/src/dataimport/TPDI.ts
@@ -9,6 +9,7 @@ import {
   TPDSearchResult,
   OrderSearchParams,
   OrderSearchResult,
+  TPDIOrderParams,
 } from './const';
 import { AirbusDataProvider } from './AirbusDataProvider';
 import { PlanetDataProvider } from './PlanetDataProvider';
@@ -128,13 +129,14 @@ export class TPDI {
     name: string,
     collectionId: string,
     items: string[],
-    params: TPDISearchParams,
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams,
     reqConfig?: RequestConfiguration,
   ): Promise<Order> {
     return await ensureTimeout(async innerReqConfig => {
       const requestConfig: AxiosRequestConfig = createRequestConfig(innerReqConfig);
       const tpdp = getThirdPartyDataProvider(provider);
-      const payload = tpdp.getOrderPayload(name, collectionId, items, params);
+      const payload = tpdp.getOrderPayload(name, collectionId, items, searchParams, orderParams);
       const response = await axios.post<Order>(`${TPDI_SERVICE_URL}/orders`, payload, requestConfig);
       const order: Order = response.data;
       return order;

--- a/src/dataimport/TPDProvider.ts
+++ b/src/dataimport/TPDProvider.ts
@@ -82,11 +82,10 @@ export abstract class AbstractTPDProvider implements TPDProviderInterface {
     return payload;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getAdditionalOrderParams(
-    items: string[],
-    searchParams: TPDISearchParams,
-    orderParams: TPDIOrderParams,
+    items: string[], // eslint-disable-line @typescript-eslint/no-unused-vars
+    searchParams: TPDISearchParams, // eslint-disable-line @typescript-eslint/no-unused-vars
+    orderParams: TPDIOrderParams, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): any {
     return {};
   }

--- a/src/dataimport/TPDProvider.ts
+++ b/src/dataimport/TPDProvider.ts
@@ -1,9 +1,15 @@
 import { AxiosRequestConfig } from 'axios';
-import { TPDProvider, TPDISearchParams } from './const';
+import { TPDProvider, TPDISearchParams, TPDIOrderParams } from './const';
 
 export interface TPDProviderInterface {
   getSearchPayload(params: TPDISearchParams): any;
-  getOrderPayload(name: string, collectionId: string, items: string[], params: TPDISearchParams): any;
+  getOrderPayload(
+    name: string,
+    collectionId: string,
+    items: string[],
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams,
+  ): any;
   addSearchPagination(requestConfig: AxiosRequestConfig, count: number, viewtoken: string): void;
 }
 
@@ -77,11 +83,21 @@ export abstract class AbstractTPDProvider implements TPDProviderInterface {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getAdditionalOrderParams(items: string[], params: TPDISearchParams): any {
+  protected getAdditionalOrderParams(
+    items: string[],
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams,
+  ): any {
     return {};
   }
 
-  public getOrderPayload(name: string, collectionId: string, items: string[], params: TPDISearchParams): any {
+  public getOrderPayload(
+    name: string,
+    collectionId: string,
+    items: string[],
+    searchParams: TPDISearchParams,
+    orderParams: TPDIOrderParams | null = null,
+  ): any {
     const payload: any = {};
 
     if (!!name) {
@@ -91,7 +107,7 @@ export abstract class AbstractTPDProvider implements TPDProviderInterface {
     if (!!collectionId) {
       payload.collectionId = collectionId;
     }
-    payload.input = this.getAdditionalOrderParams(items, params);
+    payload.input = this.getAdditionalOrderParams(items, searchParams, orderParams);
 
     return payload;
   }

--- a/src/dataimport/TPDProvider.ts
+++ b/src/dataimport/TPDProvider.ts
@@ -8,7 +8,7 @@ export interface TPDProviderInterface {
     collectionId: string,
     items: string[],
     searchParams: TPDISearchParams,
-    orderParams: TPDIOrderParams,
+    orderParams?: TPDIOrderParams,
   ): any;
   addSearchPagination(requestConfig: AxiosRequestConfig, count: number, viewtoken: string): void;
 }

--- a/src/dataimport/__tests__/AirbusDataProvider.ts
+++ b/src/dataimport/__tests__/AirbusDataProvider.ts
@@ -179,4 +179,42 @@ describe('Test create order payload', () => {
       }
     },
   );
+
+  test('creating an order without any dataprovider specific order params', async () => {
+    const name = 'name';
+    const collectionId = 'collectionId';
+    const items = ['id'];
+    const searchParams = { ...defaultSearchParams };
+
+    const tpdp = new AirbusDataProvider();
+    const payload = tpdp.getOrderPayload(name, collectionId, items, searchParams);
+
+    if (!!name) {
+      expect(payload.name).toBeDefined();
+      expect(payload.name).toStrictEqual(name);
+    } else {
+      expect(payload.name).toBeUndefined();
+    }
+
+    if (!!collectionId) {
+      expect(payload.collectionId).toBeDefined();
+      expect(payload.collectionId).toStrictEqual(collectionId);
+    } else {
+      expect(payload.collectionId).toBeUndefined();
+    }
+
+    const { input } = payload;
+
+    const dataObject = input.data[0];
+    const { products } = dataObject;
+
+    if (!!items && items.length) {
+      expect(products).toBeDefined();
+      expect(dataObject.products.length).toStrictEqual(items.length);
+      expect(dataObject.dataFilter).toBeUndefined();
+    } else {
+      expect(products).toBeUndefined();
+      checkSearchPayload(input, searchParams);
+    }
+  });
 });

--- a/src/dataimport/__tests__/AirbusDataProvider.ts
+++ b/src/dataimport/__tests__/AirbusDataProvider.ts
@@ -125,7 +125,7 @@ describe('Test search', () => {
 
 describe('Test create order payload', () => {
   it.each([
-    ['name', 'collectionId', ['id'], { ...defaultSearchParams }],
+    ['name', 'collectionId', ['id'], { ...defaultSearchParams }, null],
     [
       'name',
       'collectionId',
@@ -137,42 +137,46 @@ describe('Test create order payload', () => {
         maxSnowCoverage: 20,
         maxIncidenceAngle: 30,
       },
+      null,
     ],
 
-    ['name', 'collectionId', null, { ...defaultSearchParams }],
-    ['name', 'collectionId', [], { ...defaultSearchParams }],
-    ['name', null, null, { ...defaultSearchParams }],
-    [null, null, null, { ...defaultSearchParams }],
-  ])('checks if parameters are set correctly', async (name, collectionId, items, params) => {
-    const tpdp = new AirbusDataProvider();
-    const payload = tpdp.getOrderPayload(name, collectionId, items, params);
+    ['name', 'collectionId', null, { ...defaultSearchParams }, null],
+    ['name', 'collectionId', [], { ...defaultSearchParams }, null],
+    ['name', null, null, { ...defaultSearchParams }, null],
+    [null, null, null, { ...defaultSearchParams }, null],
+  ])(
+    'checks if parameters are set correctly',
+    async (name, collectionId, items, searchParams, orderParams) => {
+      const tpdp = new AirbusDataProvider();
+      const payload = tpdp.getOrderPayload(name, collectionId, items, searchParams, orderParams);
 
-    if (!!name) {
-      expect(payload.name).toBeDefined();
-      expect(payload.name).toStrictEqual(name);
-    } else {
-      expect(payload.name).toBeUndefined();
-    }
+      if (!!name) {
+        expect(payload.name).toBeDefined();
+        expect(payload.name).toStrictEqual(name);
+      } else {
+        expect(payload.name).toBeUndefined();
+      }
 
-    if (!!collectionId) {
-      expect(payload.collectionId).toBeDefined();
-      expect(payload.collectionId).toStrictEqual(collectionId);
-    } else {
-      expect(payload.collectionId).toBeUndefined();
-    }
+      if (!!collectionId) {
+        expect(payload.collectionId).toBeDefined();
+        expect(payload.collectionId).toStrictEqual(collectionId);
+      } else {
+        expect(payload.collectionId).toBeUndefined();
+      }
 
-    const { input } = payload;
+      const { input } = payload;
 
-    const dataObject = input.data[0];
-    const { products } = dataObject;
+      const dataObject = input.data[0];
+      const { products } = dataObject;
 
-    if (!!items && items.length) {
-      expect(products).toBeDefined();
-      expect(dataObject.products.length).toStrictEqual(items.length);
-      expect(dataObject.dataFilter).toBeUndefined();
-    } else {
-      expect(products).toBeUndefined();
-      checkSearchPayload(input, params);
-    }
-  });
+      if (!!items && items.length) {
+        expect(products).toBeDefined();
+        expect(dataObject.products.length).toStrictEqual(items.length);
+        expect(dataObject.dataFilter).toBeUndefined();
+      } else {
+        expect(products).toBeUndefined();
+        checkSearchPayload(input, searchParams);
+      }
+    },
+  );
 });

--- a/src/dataimport/__tests__/MaxarDataProvider.ts
+++ b/src/dataimport/__tests__/MaxarDataProvider.ts
@@ -181,9 +181,9 @@ describe('Test create order payload', () => {
       }
 
       if (orderParams?.productKernel) {
-        expect(input.productKernel).toEqual(orderParams.productKernel);
+        expect(dataObject.productKernel).toEqual(orderParams.productKernel);
       } else {
-        expect(input.productKernel).toBeUndefined();
+        expect(dataObject.productKernel).toBeUndefined();
       }
     },
   );

--- a/src/dataimport/__tests__/testUtils.PlanetDataProvider.ts
+++ b/src/dataimport/__tests__/testUtils.PlanetDataProvider.ts
@@ -2,7 +2,6 @@ import { TPDISearchParams, TPDProvider } from '../const';
 
 export function checkSearchPayload(requestData: any, params: TPDISearchParams): void {
   expect(requestData.provider).toStrictEqual(TPDProvider.PLANET);
-  expect(requestData.planetApiKey).toStrictEqual(params.planetApiKey);
 
   if (!!params.bbox) {
     expect(requestData.bounds.bbox).toStrictEqual([

--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -63,11 +63,15 @@ export type TPDISearchParams = {
   minSunElevation?: number;
   maxSunElevation?: number;
   constellation?: AirbusConstellation;
-  planetApiKey?: string;
   nativeFilter?: any;
   sensor?: MaxarSensor;
   productBundle?: PlanetProductBundle;
+};
+
+export type TPDIOrderParams = {
   harmonizeTo?: PlanetScopeHarmonization;
+  planetApiKey?: string;
+  productKernel?: ResamplingKernel;
 };
 
 type LinksType = {

--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -125,3 +125,9 @@ export enum PlanetScopeHarmonization {
   PS2 = 'PS2',
   NONE = 'NONE',
 }
+
+export enum ResamplingKernel {
+  CC = 'CC',
+  NN = 'NN',
+  MTF = 'MTF',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ import {
   TPDICollections,
   TPDISearchParams,
   TPDProvider,
+  ResamplingKernel,
 } from './dataimport/const';
 
 registerInitialAxiosInterceptors();
@@ -224,4 +225,5 @@ export {
   PlanetProductBundle,
   PlanetScopeHarmonization,
   MaxarSensor,
+  ResamplingKernel,
 };


### PR DESCRIPTION
When this feature (creating tpdi orders) was developed, orders didn't have any provider specific parameters so only search parameters were used. But soon after some parameters were added to orders (harmonizeTo) or has been removed from search to order (planetApiKey) and it became a bit of a mess as search parameters were abused to store order parameters. 

 I decided to split those two hence all the changes in sh-js