### PR TITLE
Feature/stitch wmts images

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -104,7 +104,7 @@ function parseUrl(
 }
 
 if (typeof window.URL.createObjectURL === 'undefined') {
-  window.URL.createObjectURL = (): string => 'kjkj';
+  window.URL.createObjectURL = () => `blob:https://mocked-create-object-url.com/${Math.random()}`;
   window.URL.revokeObjectURL = () => {};
 }
 

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,3 +1,4 @@
+import 'jest-canvas-mock';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
@@ -101,5 +102,23 @@ function parseUrl(
     params: params,
   };
 }
+
+if (typeof window.URL.createObjectURL === 'undefined') {
+  window.URL.createObjectURL = (): string => 'kjkj';
+  window.URL.revokeObjectURL = () => {};
+}
+
+document.createElement = (function(create) {
+  return function() {
+    const element: HTMLElement = create.apply(this, arguments);
+
+    if (element.tagName === 'IMG') {
+      setTimeout(() => {
+        element.onload(new Event('load'));
+      }, 100);
+    }
+    return element;
+  };
+})(document.createElement);
 
 export default undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5009,6 +5009,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "dev": true
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -8882,6 +8888,16 @@
         }
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
+      "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.1.0.tgz",
@@ -10822,6 +10838,23 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moo-color": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.2.tgz",
+      "integrity": "sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-config-prettier": "^4.2.0",
     "eslint-plugin-prettier": "^3.1.0",
     "jest": "^25.1.0",
+    "jest-canvas-mock": "^2.3.1",
     "node-fetch": "^2.6.0",
     "prettier": "^1.17.1",
     "rollup": "^0.67.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
 } from './layer/dataset';
 import { WmsLayer } from './layer/WmsLayer';
 import { WmtsLayer } from './layer/WmtsLayer';
+import { PlanetNicfiLayer } from './layer/PlanetNicfi';
 import { S1GRDAWSEULayer } from './layer/S1GRDAWSEULayer';
 import { S1GRDEOCloudLayer } from './layer/S1GRDEOCloudLayer';
 import { S2L2ALayer } from './layer/S2L2ALayer';
@@ -138,6 +139,7 @@ export {
   // layers:
   WmsLayer,
   WmtsLayer,
+  PlanetNicfiLayer,
   S1GRDAWSEULayer,
   S1GRDEOCloudLayer,
   S2L2ALayer,

--- a/src/layer/PlanetNicfi.ts
+++ b/src/layer/PlanetNicfi.ts
@@ -26,6 +26,7 @@ export class PlanetNicfiLayer extends WmtsLayer {
   protected baseUrl: string;
   protected layerId: string;
   protected resourceUrl: string;
+  protected matrixSet: string;
 
   public constructor({
     baseUrl,
@@ -39,6 +40,7 @@ export class PlanetNicfiLayer extends WmtsLayer {
     this.baseUrl = baseUrl;
     this.layerId = layerId;
     this.resourceUrl = resourceUrl;
+    this.matrixSet = 'GoogleMapsCompatible15'; //only matrixSet available for PlanetNicfi
   }
 
   public async findDatesUTC(

--- a/src/layer/WmtsLayer.ts
+++ b/src/layer/WmtsLayer.ts
@@ -10,7 +10,6 @@ import {
   bboxToXyzGrid,
   fetchLayersFromWmtsGetCapabilitiesXml,
   getMatrixSets,
-  MatrixSet,
   TileMatrix,
 } from './wmts.utils';
 import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
@@ -32,7 +31,6 @@ export class WmtsLayer extends AbstractLayer {
   protected layerId: string;
   protected resourceUrl: string;
   protected matrixSet: string;
-  protected matrixSets: MatrixSet[];
   protected tileMatrix: TileMatrix[];
 
   public constructor({

--- a/src/layer/__tests__/WmtsLayer.ts
+++ b/src/layer/__tests__/WmtsLayer.ts
@@ -4,7 +4,8 @@ import MockAdapter from 'axios-mock-adapter';
 import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmtsLayer, invalidateCaches } from '../../index';
 
 import '../../../jest-setup';
-import { bboxToXyz } from '../wmts.utils';
+import { bboxToXyzGrid } from '../wmts.utils';
+import { CRS_EPSG3857 } from '../../crs';
 
 const mockNetwork = new MockAdapter(axios);
 
@@ -21,10 +22,7 @@ test('WmtsLayer.getMap uses tileCoord instead of bbox', async () => {
     layerId,
     resourceUrl: baseTemplateUrl + `?api_key=${process.env.PLANET_API_KEY}`,
   });
-
   mockNetwork.reset();
-  mockNetwork.onAny().replyOnce(200, ''); // we don't care about the response, we will just inspect the request params
-
   const getMapParams = {
     bbox: bbox,
     fromTime: new Date(),
@@ -39,8 +37,8 @@ test('WmtsLayer.getMap uses tileCoord instead of bbox', async () => {
 
     format: MimeTypes.PNG,
   };
+  mockNetwork.onAny().replyOnce(200, '');
   await layer.getMap(getMapParams, ApiType.WMTS);
-
   expect(mockNetwork.history.get.length).toBe(1);
 
   const { url } = mockNetwork.history.get[0];
@@ -51,7 +49,13 @@ test('WmtsLayer.getMap uses tileCoord instead of bbox', async () => {
 });
 
 test('WmtsLayer.getMap uses bbox', async () => {
-  const bbox = new BBox(CRS_EPSG4326, 19, 20, 20, 21);
+  const bbox = new BBox(
+    CRS_EPSG3857,
+    1289034.0450012125,
+    1188748.6638910607,
+    1291480.029906338,
+    1191194.6487961877,
+  );
   const layerId = 'planet_medres_normalized_analytic_2019-06_2019-11_mosaic';
   const baseTemplateUrl = `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/{TileMatrix}/{TileCol}/{TileRow}.png`;
   const layer = new WmtsLayer({
@@ -61,24 +65,25 @@ test('WmtsLayer.getMap uses bbox', async () => {
   });
 
   mockNetwork.reset();
-  mockNetwork.onAny().replyOnce(200, ''); // we don't care about the response, we will just inspect the request params
-  const tileSize = 256;
   const getMapParams = {
     bbox: bbox,
     fromTime: new Date(),
     toTime: new Date(),
-    width: tileSize,
-    height: tileSize,
+    width: 256,
+    height: 256,
     format: MimeTypes.PNG,
   };
+
+  mockNetwork.onAny().replyOnce(200, ''); // we don't care about the response, we will just inspect the request params
+
   await layer.getMap(getMapParams, ApiType.WMTS);
 
   expect(mockNetwork.history.get.length).toBe(1);
 
   const { url } = mockNetwork.history.get[0];
-  const { x, y, z } = bboxToXyz(bbox, tileSize);
+  const { tiles } = bboxToXyzGrid(bbox, 256, 256, 256);
   expect(url).toHaveOrigin('https://tiles.planet.com');
   expect(url).toHaveBaseUrl(
-    `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/${z}/${x}/${y}.png`,
+    `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/${tiles[0].z}/${tiles[0].x}/${tiles[0].y}.png`,
   );
 });

--- a/src/layer/__tests__/WmtsLayer.ts
+++ b/src/layer/__tests__/WmtsLayer.ts
@@ -2,10 +2,9 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import { BBox, CRS_EPSG4326, ApiType, MimeTypes, WmtsLayer, invalidateCaches } from '../../index';
-
 import '../../../jest-setup';
-import { bboxToXyzGrid } from '../wmts.utils';
 import { CRS_EPSG3857 } from '../../crs';
+import { getCapabilitiesWmtsXMLResponse } from './fixtures.getCapabilitiesWMTS';
 
 const mockNetwork = new MockAdapter(axios);
 
@@ -21,6 +20,7 @@ test('WmtsLayer.getMap uses tileCoord instead of bbox', async () => {
     baseUrl: 'https://getCapabilities.com',
     layerId,
     resourceUrl: baseTemplateUrl + `?api_key=${process.env.PLANET_API_KEY}`,
+    matrixSet: 'GoogleMapsCompatible15',
   });
   mockNetwork.reset();
   const getMapParams = {
@@ -37,11 +37,12 @@ test('WmtsLayer.getMap uses tileCoord instead of bbox', async () => {
 
     format: MimeTypes.PNG,
   };
+  mockNetwork.onAny().replyOnce(200, getCapabilitiesWmtsXMLResponse); // updateLayerFromServiceIfNeeded response
   mockNetwork.onAny().replyOnce(200, '');
   await layer.getMap(getMapParams, ApiType.WMTS);
-  expect(mockNetwork.history.get.length).toBe(1);
+  expect(mockNetwork.history.get.length).toBe(2);
 
-  const { url } = mockNetwork.history.get[0];
+  const { url } = mockNetwork.history.get[1];
   expect(url).toHaveOrigin('https://tiles.planet.com');
   expect(url).toHaveBaseUrl(
     `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/${getMapParams.tileCoord.z}/${getMapParams.tileCoord.x}/${getMapParams.tileCoord.y}.png`,
@@ -56,12 +57,15 @@ test('WmtsLayer.getMap uses bbox', async () => {
     1291480.029906338,
     1191194.6487961877,
   );
+  const tileSize = 256;
+
   const layerId = 'planet_medres_normalized_analytic_2019-06_2019-11_mosaic';
   const baseTemplateUrl = `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/{TileMatrix}/{TileCol}/{TileRow}.png`;
   const layer = new WmtsLayer({
     baseUrl: 'https://getCapabilities.com',
     layerId,
     resourceUrl: baseTemplateUrl + `?api_key=${process.env.PLANET_API_KEY}`,
+    matrixSet: 'GoogleMapsCompatible15',
   });
 
   mockNetwork.reset();
@@ -69,21 +73,20 @@ test('WmtsLayer.getMap uses bbox', async () => {
     bbox: bbox,
     fromTime: new Date(),
     toTime: new Date(),
-    width: 256,
-    height: 256,
+    width: tileSize,
+    height: tileSize,
     format: MimeTypes.PNG,
   };
-
+  mockNetwork.onAny().replyOnce(200, getCapabilitiesWmtsXMLResponse); // updateLayerFromServiceIfNeeded response
   mockNetwork.onAny().replyOnce(200, ''); // we don't care about the response, we will just inspect the request params
 
   await layer.getMap(getMapParams, ApiType.WMTS);
 
-  expect(mockNetwork.history.get.length).toBe(1);
+  expect(mockNetwork.history.get.length).toBe(2);
 
-  const { url } = mockNetwork.history.get[0];
-  const { tiles } = bboxToXyzGrid(bbox, 256, 256, 256);
+  const { url } = mockNetwork.history.get[1];
   expect(url).toHaveOrigin('https://tiles.planet.com');
   expect(url).toHaveBaseUrl(
-    `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/${tiles[0].z}/${tiles[0].x}/${tiles[0].y}.png`,
+    `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_normalized_analytic_2019-06_2019-11_mosaic/gmap/14/8719/7705.png`,
   );
 });

--- a/src/layer/__tests__/wmts.utils.ts
+++ b/src/layer/__tests__/wmts.utils.ts
@@ -1,0 +1,131 @@
+import { BBox, CRS_EPSG3857, CRS_EPSG4326 } from '../..';
+import { bboxToXyzGrid } from '../wmts.utils';
+
+const tileMatrices256 = [...Array(20).keys()].map(zoom => ({
+  zoom: zoom,
+  tileWidth: 256,
+  tileHeight: 256,
+  matrixWidth: Math.pow(2, zoom),
+  matrixHeight: Math.pow(2, zoom),
+}));
+
+const tileMatrices512 = [...Array(19).keys()].map(zoom => ({
+  zoom: zoom + 1,
+  tileWidth: 512,
+  tileHeight: 512,
+  matrixWidth: Math.pow(2, zoom),
+  matrixHeight: Math.pow(2, zoom),
+}));
+
+const singleTile512Bbox = new BBox(
+  CRS_EPSG3857,
+  1487158.8223163893,
+  5009377.085697314,
+  1565430.3392804097,
+  5087648.602661333,
+);
+
+const rectangularBbox = new BBox(
+  CRS_EPSG4326,
+  11.7938232421875,
+  41.21998578493921,
+  13.150634765625002,
+  42.431565872579185,
+);
+
+const singleTile512Fixture = {
+  description: 'Test extact 512 tile bbox, should return single xyz tile',
+  bbox: singleTile512Bbox,
+  tileMatrices: tileMatrices512,
+  imageWidth: 512,
+  imageHeight: 512,
+  expectedResult: {
+    nativeHeight: 512,
+    nativeWidth: 512,
+    tiles: [
+      {
+        imageOffsetX: 0,
+        imageOffsetY: 0,
+        x: 275,
+        y: 191,
+        z: 10,
+      },
+    ],
+  },
+};
+
+const singleTile512Fixture256Tiles = {
+  description: 'Test extact 512 tile bbox, stitched with multpile 256 tiles',
+  bbox: singleTile512Bbox,
+  tileMatrices: tileMatrices256,
+  imageWidth: 512,
+  imageHeight: 512,
+  expectedResult: {
+    nativeHeight: 512,
+    nativeWidth: 512,
+    tiles: [
+      {
+        imageOffsetX: 0,
+        imageOffsetY: 0,
+        x: 550,
+        y: 382,
+        z: 10,
+      },
+      {
+        imageOffsetX: 0,
+        imageOffsetY: 256,
+        x: 550,
+        y: 383,
+        z: 10,
+      },
+      {
+        imageOffsetX: 256,
+        imageOffsetY: 0,
+        x: 551,
+        y: 382,
+        z: 10,
+      },
+      {
+        imageOffsetX: 256,
+        imageOffsetY: 256,
+        x: 551,
+        y: 383,
+        z: 10,
+      },
+    ],
+  },
+};
+
+const rectangularBboxFixture = {
+  description: 'Test rectangular bbox, should return multiple xyz tiles',
+  bbox: rectangularBbox,
+  tileMatrices: tileMatrices256,
+  imageWidth: 244,
+  imageHeight: 293,
+  expectedResult: {
+    nativeWidth: 247,
+    nativeHeight: 296.6024590163934,
+    tiles: [
+      { x: 136, y: 94, z: 8, imageOffsetX: -99, imageOffsetY: -158 },
+      { x: 136, y: 95, z: 8, imageOffsetX: -99, imageOffsetY: 98 },
+      { x: 137, y: 94, z: 8, imageOffsetX: 157, imageOffsetY: -158 },
+      { x: 137, y: 95, z: 8, imageOffsetX: 157, imageOffsetY: 98 },
+    ],
+  },
+};
+
+const cases = [
+  [singleTile512Fixture.description, singleTile512Fixture],
+  [singleTile512Fixture256Tiles.description, singleTile512Fixture256Tiles],
+  [rectangularBboxFixture.description, rectangularBboxFixture],
+];
+
+describe('test bboxToXyzGrid', () => {
+  test.each(cases)(
+    '%s',
+    (testDescription: string, { bbox, tileMatrices, imageWidth, imageHeight, expectedResult }: any) => {
+      const result = bboxToXyzGrid(bbox, imageWidth, imageHeight, tileMatrices);
+      expect(result).toEqual(expectedResult);
+    },
+  );
+});

--- a/src/layer/wmts.utils.ts
+++ b/src/layer/wmts.utils.ts
@@ -13,7 +13,9 @@ export type GetCapabilitiesWmtsXml = {
     'ows:ServiceIdentification': any[][];
     'ows:ServiceProvider': any[][];
     'ows:OperationsMetadata': any[][];
-    Contents: [{ Layer: GetCapabilitiesXmlWmtsLayer[] }];
+    Contents: [
+      { Layer: GetCapabilitiesXmlWmtsLayer[]; TileMatrixSet: GetCapabilitiesXmlWmtsTileMatrixSet[] },
+    ];
     ServiceMetadataURL: any[][];
   };
 };
@@ -29,7 +31,36 @@ export type GetCapabilitiesXmlWmtsLayer = {
   ResourceURL: any[];
 };
 
-type BBOX_TO_XYZ_IMAGE_GRID = {
+export type GetCapabilitiesXmlWmtsTileMatrixSet = {
+  TileMatrix: GetCapabilitiesXmlWmtsTileMatrix[];
+  'ows:Identifier': string[];
+  'ows:SupportedCRS': string[];
+};
+
+type GetCapabilitiesXmlWmtsTileMatrix = {
+  MatrixHeight: string[];
+  MatrixWidth: string[];
+  ScaleDenominator: string[];
+  TileHeight: string[];
+  TileWidth: string[];
+  TopLeftCorner: string[];
+  'ows:Identifier': string[];
+};
+
+export type TileMatrix = {
+  zoom: number;
+  tileWidth: number;
+  tileHeight: number;
+  matrixWidth: number;
+  matrixHeight: number;
+};
+
+export type MatrixSet = {
+  id: string;
+  tileMatrices: TileMatrix[];
+};
+
+export type BBOX_TO_XYZ_IMAGE_GRID = {
   nativeWidth: number;
   nativeHeight: number;
   tiles: { x: number; y: number; z: number; imageOffsetX: number; imageOffsetY: number }[];
@@ -42,50 +73,48 @@ function toWgs84(xy: number[]): number[] {
   ];
 }
 
-// Find the first zoom level where the requested imageWidth is lower than the pixel width of the bbox
 function bboxToWidthAndZoom(
   bbox: BBox,
   requestedImageWidth: number,
-  tileSize: number,
-): { zoom: number; mapWidth: number; bboxPixelWidth: number } {
+  tileMatrices: TileMatrix[],
+): { zoom: number; bboxPixelWidth: number; tileWidth: number; tileHeight: number } {
   if (bbox.crs === CRS_EPSG3857) {
     const topLeft = toWgs84([bbox.minX, bbox.minY]);
     const bottomRight = toWgs84([bbox.maxX, bbox.maxY]);
     bbox = new BBox(CRS_EPSG4326, topLeft[0], topLeft[1], bottomRight[0], bottomRight[1]);
   }
-  const degreeDiff = Math.abs(bbox.maxX - bbox.minX);
-  const pixelsPerDegree = tileSize / 360;
 
-  // Pixel width for the bbox at each zoom level between 0 and 19
-  let imageDimensionsAtZoom = [];
-  for (let z = 0; z < 20; z++) {
-    const mapWidth = tileSize * Math.pow(2, z);
-    imageDimensionsAtZoom.push({
-      zoom: z,
-      mapWidth,
-      bboxPixelWidth: Math.floor(((pixelsPerDegree * mapWidth) / tileSize) * degreeDiff),
-    });
+  // Find the first zoom level where the requested imageWidth is lower than the pixel width of the bbox
+  // or the last availble zoom level provided by the TileMatrixSet in getCapabilities
+  for (let [index, tileMatrix] of tileMatrices.entries()) {
+    const { matrixWidth, tileWidth, tileHeight, zoom } = tileMatrix;
+    const mapWidth = tileWidth * matrixWidth;
+    const degreeDiff = Math.abs(bbox.maxX - bbox.minX);
+    const pixelsPerDegree = tileWidth / 360;
+    const bboxPixelWidth = Math.floor(((pixelsPerDegree * mapWidth) / tileWidth) * degreeDiff);
+    if (requestedImageWidth <= bboxPixelWidth || index === tileMatrices.length - 1) {
+      return { zoom: zoom, bboxPixelWidth: bboxPixelWidth, tileWidth: tileWidth, tileHeight: tileHeight };
+    }
   }
-  return imageDimensionsAtZoom.find(dim => requestedImageWidth <= dim.bboxPixelWidth);
 }
 
 export function bboxToXyzGrid(
   bbox: BBox,
   imageWidth: number,
   imageHeight: number,
-  tileSize: number,
+  tileMatrices: TileMatrix[],
 ): BBOX_TO_XYZ_IMAGE_GRID {
   if (bbox.crs === CRS_EPSG3857) {
     const topLeft = toWgs84([bbox.minX, bbox.minY]);
     const bottomRight = toWgs84([bbox.maxX, bbox.maxY]);
     bbox = new BBox(CRS_EPSG4326, topLeft[0], topLeft[1], bottomRight[0], bottomRight[1]);
   }
-  const { zoom, bboxPixelWidth } = bboxToWidthAndZoom(bbox, imageWidth, tileSize);
+  const { zoom, bboxPixelWidth, tileWidth: tileSize } = bboxToWidthAndZoom(bbox, imageWidth, tileMatrices);
 
   const topLeft = [bbox.minX, bbox.maxY];
   const bottomRight = [bbox.maxX, bbox.minY];
-  const { pixelX: topLeftPixelX, pixelY: topLeftpixelY } = toPixel(topLeft, tileSize, zoom);
-  const { pixelX: bottomRightPixelX, pixelY: bottomRightPixelY } = toPixel(bottomRight, tileSize, zoom);
+  const { pixelX: topLeftPixelX, pixelY: topLeftpixelY } = toPixel(topLeft, tileMatrices, zoom);
+  const { pixelX: bottomRightPixelX, pixelY: bottomRightPixelY } = toPixel(bottomRight, tileMatrices, zoom);
 
   const xTiles = [Math.floor(topLeftPixelX / tileSize), Math.floor((bottomRightPixelX - 1) / tileSize)].sort(
     (a, b) => a - b,
@@ -121,9 +150,14 @@ export function bboxToXyzGrid(
   };
 }
 
-export function toPixel(coord: number[], tileSize: number, zoom: number): { pixelX: number; pixelY: number } {
+export function toPixel(
+  coord: number[],
+  tileMatrices: TileMatrix[],
+  zoom: number,
+): { pixelX: number; pixelY: number } {
   const [longitude, latitude] = coord;
-  const mapWidth = tileSize * Math.pow(2, zoom);
+  const tileMatrix = tileMatrices.find(matrix => matrix.zoom === zoom);
+  const mapWidth = tileMatrix.tileWidth * tileMatrix.matrixWidth;
   const sinLatitude = Math.min(Math.max(Math.sin(DEGREE_TO_RADIAN * latitude), -0.9999), 0.9999);
   const pixelX = Math.round(((longitude + 180) / 360) * mapWidth);
   const pixelY = Math.round(
@@ -164,4 +198,22 @@ export function getResourceUrl(xmlLayer: GetCapabilitiesXmlWmtsLayer): string | 
     }
   }
   return null;
+}
+
+export async function getMatrixSets(baseUrl: string, reqConfig: RequestConfiguration): Promise<MatrixSet[]> {
+  const parsedXml = ((await fetchGetCapabilitiesXml(
+    baseUrl,
+    OgcServiceTypes.WMTS,
+    reqConfig,
+  )) as unknown) as GetCapabilitiesWmtsXml;
+  return parsedXml.Capabilities.Contents[0].TileMatrixSet.map(tileMatrixSet => ({
+    id: tileMatrixSet['ows:Identifier'][0],
+    tileMatrices: tileMatrixSet.TileMatrix.map(tileMatrix => ({
+      zoom: Number(tileMatrix['ows:Identifier'][0]),
+      tileWidth: Number(tileMatrix.TileWidth[0]),
+      tileHeight: Number(tileMatrix.TileHeight[0]),
+      matrixWidth: Number(tileMatrix.MatrixWidth[0]),
+      matrixHeight: Number(tileMatrix.MatrixHeight[0]),
+    })),
+  }));
 }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -84,3 +84,17 @@ export async function validateCanvasDimensions(canvas: HTMLCanvasElement): Promi
   }
   return true;
 }
+
+export async function scaleCanvasImage(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): Promise<HTMLCanvasElement> {
+  const newSizeCanvas = document.createElement('canvas');
+  newSizeCanvas.width = width;
+  newSizeCanvas.height = height;
+  const newSizeCtx = newSizeCanvas.getContext('2d');
+  newSizeCtx.imageSmoothingEnabled = false;
+  newSizeCtx.drawImage(canvas, 0, 0, width, height);
+  return newSizeCanvas;
+}

--- a/stories/wmts.planet.stories.js
+++ b/stories/wmts.planet.stories.js
@@ -150,7 +150,6 @@ export const getMapWmtsLayersFactory = () => {
 
   const perform = async () => {
     const layer = (await LayersFactory.makeLayers(baseUrl, lId => layerId === lId))[0];
-    layer.matrixSet = 'GoogleMapsCompatible15';
 
     const getMapParams = {
       bbox: bbox,

--- a/stories/wmts.planet.stories.js
+++ b/stories/wmts.planet.stories.js
@@ -1,5 +1,4 @@
 import {
-  WmtsLayer,
   CRS_EPSG3857,
   BBox,
   MimeTypes,
@@ -7,6 +6,7 @@ import {
   LayersFactory,
   CRS_EPSG4326,
   S2L1CLayer,
+  PlanetNicfiLayer,
 } from '../dist/sentinelHub.esm';
 
 if (!process.env.PLANET_API_KEY) {
@@ -47,7 +47,7 @@ export const getMapBbox = () => {
   wrapperEl.innerHTML = '<h2>GetMap with bbox(WMTS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
+    const layer = new PlanetNicfiLayer({ baseUrl, layerId });
 
     const getMapParams = {
       bbox: bbox,
@@ -78,7 +78,7 @@ export const getMapBboxStitched = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
   wrapperEl.insertAdjacentElement('beforeend', s2Img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
+    const layer = new PlanetNicfiLayer({ baseUrl, layerId });
     const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
 
     const getMapParams = {
@@ -117,7 +117,7 @@ export const getMap = () => {
   wrapperEl.innerHTML = '<h2>GetMap (WMTS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
+    const layer = new PlanetNicfiLayer({ baseUrl, layerId });
 
     const getMapParams = {
       tileCoord: {

--- a/stories/wmts.planet.stories.js
+++ b/stories/wmts.planet.stories.js
@@ -47,7 +47,7 @@ export const getMapBbox = () => {
   wrapperEl.innerHTML = '<h2>GetMap with bbox(WMTS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId });
+    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
 
     const getMapParams = {
       bbox: bbox,
@@ -78,7 +78,7 @@ export const getMapBboxStitched = () => {
   wrapperEl.insertAdjacentElement('beforeend', img);
   wrapperEl.insertAdjacentElement('beforeend', s2Img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId });
+    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
     const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
 
     const getMapParams = {
@@ -117,7 +117,7 @@ export const getMap = () => {
   wrapperEl.innerHTML = '<h2>GetMap (WMTS)</h2>';
   wrapperEl.insertAdjacentElement('beforeend', img);
   const perform = async () => {
-    const layer = new WmtsLayer({ baseUrl, layerId });
+    const layer = new WmtsLayer({ baseUrl, layerId, matrixSet: 'GoogleMapsCompatible15' });
 
     const getMapParams = {
       tileCoord: {
@@ -130,6 +130,7 @@ export const getMap = () => {
       width: 256,
       height: 256,
       format: MimeTypes.JPEG,
+      matrixSet: 'GoogleMapsCompatible15',
     };
     const imageBlob = await layer.getMap(getMapParams, ApiType.WMTS);
     img.src = URL.createObjectURL(imageBlob);
@@ -149,6 +150,7 @@ export const getMapWmtsLayersFactory = () => {
 
   const perform = async () => {
     const layer = (await LayersFactory.makeLayers(baseUrl, lId => layerId === lId))[0];
+    layer.matrixSet = 'GoogleMapsCompatible15';
 
     const getMapParams = {
       bbox: bbox,

--- a/stories/wmts.stories.js
+++ b/stories/wmts.stories.js
@@ -1,0 +1,124 @@
+import { WmtsLayer, BBox, MimeTypes, ApiType, CRS_EPSG4326, S2L1CLayer } from '../dist/sentinelHub.esm';
+
+const notExactTileBbox = new BBox(
+  CRS_EPSG4326,
+  9.546533077955246,
+  -2.7491153895984772,
+  9.940667599439623,
+  -2.3553726144954044,
+);
+
+const rectangularBbox = new BBox(
+  CRS_EPSG4326,
+  21.649502366781235,
+  -33.649031907049206,
+  21.735161393880848,
+  -33.5284837550155,
+);
+
+const instanceId = process.env.INSTANCE_ID;
+const s2LayerId = process.env.S2L1C_LAYER_ID;
+
+export default {
+  title: 'WMTS',
+};
+
+export const getMapBbox = () => {
+  const img = document.createElement('img');
+  img.width = '512';
+  img.height = '512';
+
+  const s2Img = document.createElement('img');
+  s2Img.width = '512';
+  s2Img.height = '512';
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap with bbox(WMTS)</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+  wrapperEl.insertAdjacentElement('beforeend', s2Img);
+  const perform = async () => {
+    const layer = new WmtsLayer({
+      baseUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}`,
+      layerId: s2LayerId,
+      resourceUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}?REQUEST=GetTile&&showlogo=false&TILEMATRIXSET=PopularWebMercator256&LAYER=${s2LayerId}&TILEMATRIX={TileMatrix}&TILEROW={TileRow}&TILECOL={TileCol}&TIME=2019-04-17/2019-04-17&&format=image%2Fpng`,
+    });
+    const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
+
+    const getMapParams = {
+      bbox: notExactTileBbox,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.PNG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMTS);
+    img.src = URL.createObjectURL(imageBlob);
+
+    const getMapParamsS2 = {
+      bbox: notExactTileBbox,
+      fromTime: new Date(Date.UTC(2019, 4 - 1, 17, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2019, 4 - 1, 17, 23, 59, 59)),
+      width: 512,
+      height: 512,
+      format: MimeTypes.PNG,
+      showlogo: false,
+      preview: 2,
+    };
+    const s2ImageBlob = await layerS2L1C.getMap(getMapParamsS2, ApiType.WMS);
+    s2Img.src = URL.createObjectURL(s2ImageBlob);
+  };
+  perform().then(() => {});
+  return wrapperEl;
+};
+
+export const getMapBboxRectangular = () => {
+  const width = 474;
+  const height = 802;
+  const img = document.createElement('img');
+  img.width = width;
+  img.height = height;
+
+  const s2Img = document.createElement('img');
+  s2Img.width = width;
+  s2Img.height = height;
+
+  const wrapperEl = document.createElement('div');
+  wrapperEl.innerHTML = '<h2>GetMap bbox(WMTS) with different width and height</h2>';
+  wrapperEl.insertAdjacentElement('beforeend', img);
+  wrapperEl.insertAdjacentElement('beforeend', s2Img);
+  const perform = async () => {
+    const layer = new WmtsLayer({
+      baseUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}`,
+      layerId: s2LayerId,
+      resourceUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}?REQUEST=GetTile&&showlogo=false&TILEMATRIXSET=PopularWebMercator256&LAYER=${s2LayerId}&TILEMATRIX={TileMatrix}&TILEROW={TileRow}&TILECOL={TileCol}&TIME=2019-04-18/2019-04-18&&format=image%2Fpng`,
+    });
+    const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
+
+    const getMapParams = {
+      bbox: rectangularBbox,
+      fromTime: new Date(Date.UTC(2018, 11 - 1, 22, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2018, 12 - 1, 22, 23, 59, 59)),
+      width: width,
+      height: height,
+      format: MimeTypes.PNG,
+    };
+    const imageBlob = await layer.getMap(getMapParams, ApiType.WMTS);
+    img.src = URL.createObjectURL(imageBlob);
+
+    const getMapParamsS2 = {
+      bbox: rectangularBbox,
+      fromTime: new Date(Date.UTC(2019, 4 - 1, 18, 0, 0, 0)),
+      toTime: new Date(Date.UTC(2019, 4 - 1, 18, 23, 59, 59)),
+      width: width,
+      height: height,
+      format: MimeTypes.PNG,
+      showlogo: false,
+    };
+    const s2ImageBlob = await layerS2L1C.getMap(getMapParamsS2, ApiType.WMS);
+
+    s2Img.src = URL.createObjectURL(s2ImageBlob);
+  };
+  perform().then(() => {});
+  return wrapperEl;
+};

--- a/stories/wmts.stories.js
+++ b/stories/wmts.stories.js
@@ -41,6 +41,7 @@ export const getMapBbox = () => {
       baseUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}`,
       layerId: s2LayerId,
       resourceUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}?REQUEST=GetTile&&showlogo=false&TILEMATRIXSET=PopularWebMercator256&LAYER=${s2LayerId}&TILEMATRIX={TileMatrix}&TILEROW={TileRow}&TILECOL={TileCol}&TIME=2019-04-17/2019-04-17&&format=image%2Fpng`,
+      matrixSet: 'PopularWebMercator256',
     });
     const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
 
@@ -91,7 +92,8 @@ export const getMapBboxRectangular = () => {
     const layer = new WmtsLayer({
       baseUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}`,
       layerId: s2LayerId,
-      resourceUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}?REQUEST=GetTile&&showlogo=false&TILEMATRIXSET=PopularWebMercator256&LAYER=${s2LayerId}&TILEMATRIX={TileMatrix}&TILEROW={TileRow}&TILECOL={TileCol}&TIME=2019-04-18/2019-04-18&&format=image%2Fpng`,
+      resourceUrl: `https://services.sentinel-hub.com/ogc/wmts/${instanceId}?REQUEST=GetTile&&showlogo=false&TILEMATRIXSET=PopularWebMercator512&LAYER=${s2LayerId}&TILEMATRIX={TileMatrix}&TILEROW={TileRow}&TILECOL={TileCol}&TIME=2019-04-18/2019-04-18&&format=image%2Fpng`,
+      matrixSet: 'PopularWebMercator512',
     });
     const layerS2L1C = new S2L1CLayer({ instanceId, layerId: s2LayerId });
 


### PR DESCRIPTION
PR enables creating a single image from multiple WMTS tiles when the bbox from the `getMap` params require multiple tiles to be stitched . 

- Stitch images when bbox is not null, fetch single image when `bbox` is null and `tileCoords` are provided
- Introduce `matrixSet` to WMTS class, in order to get tile width, height,  zoom levels, and column and row count at each zoom
