### PR TITLE
fix types for `mimeFormat` parameter for `canvasToBlob()` function 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from './crs'
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from './auth';
 import {
   ApiType,
-  MimeType,
   MimeTypes,
   OrbitDirection,
   PreviewMode,
@@ -181,7 +180,6 @@ export {
   CRS_EPSG4326,
   CRS_EPSG3857,
   CRS_WGS84,
-  MimeType,
   MimeTypes,
   AcquisitionMode,
   Polarization,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { CRS_EPSG4326, CRS_EPSG3857, CRS_WGS84, SUPPORTED_CRS_OBJ } from './crs'
 import { setAuthToken, isAuthTokenSet, requestAuthToken } from './auth';
 import {
   ApiType,
+  MimeType,
   MimeTypes,
   OrbitDirection,
   PreviewMode,
@@ -180,6 +181,7 @@ export {
   CRS_EPSG4326,
   CRS_EPSG3857,
   CRS_WGS84,
+  MimeType,
   MimeTypes,
   AcquisitionMode,
   Polarization,

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import { MimeType, ImageProperties } from '../layer/const';
+import { MimeType, FormatJpegOrPng, MimeTypes, ImageProperties } from '../layer/const';
 
 export async function drawBlobOnCanvas(
   ctx: CanvasRenderingContext2D,
@@ -21,7 +21,13 @@ export async function drawBlobOnCanvas(
   }
 }
 
-export async function canvasToBlob(canvas: HTMLCanvasElement, mimeFormat: MimeType): Promise<Blob> {
+export async function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  mimeFormat: MimeType | FormatJpegOrPng,
+): Promise<Blob> {
+  if (mimeFormat === MimeTypes.JPEG_OR_PNG) {
+    return Promise.reject('This format is not supported');
+  }
   return await new Promise(resolve => canvas.toBlob(resolve, mimeFormat));
 }
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import { MimeType, FormatJpegOrPng, MimeTypes, ImageProperties } from '../layer/const';
+import { MimeType, ImageProperties } from '../layer/const';
 
 export async function drawBlobOnCanvas(
   ctx: CanvasRenderingContext2D,
@@ -21,13 +21,7 @@ export async function drawBlobOnCanvas(
   }
 }
 
-export async function canvasToBlob(
-  canvas: HTMLCanvasElement,
-  mimeFormat: MimeType | FormatJpegOrPng,
-): Promise<Blob> {
-  if (mimeFormat === MimeTypes.JPEG_OR_PNG) {
-    return Promise.reject('This format is not supported');
-  }
+export async function canvasToBlob(canvas: HTMLCanvasElement, mimeFormat: MimeType | string): Promise<Blob> {
   return await new Promise(resolve => canvas.toBlob(resolve, mimeFormat));
 }
 


### PR DESCRIPTION
~~Export `MimeType` so it can be used in `canvasToBlob` which accepts `MimeType` not (already exported) `MimeTypes`~~
This isn't the best solution because it clashes with the JS built-in type MimeType if you don't add alias for it in the import statement.

Thus I decided to add the `FormatJpegOrPng` as a possible type for `mimeFormat` for `canvasToBlob()` function so predefined values of `MimeTypes` can be used.
If `MimeType.JPEG_OR_PNG` is passed to `canvasToBlob()` an error is thrown.