### PR TITLE
Compatible collections for order

### DIFF
--- a/src/dataimport/TPDI.ts
+++ b/src/dataimport/TPDI.ts
@@ -221,7 +221,7 @@ export class TPDI {
         requestConfig,
       );
       if (data?.data) {
-        compatibleCollections = data.data;
+        compatibleCollections = data.data.map((c: Record<string, any>) => ({ id: c.id, name: c.name }));
       }
 
       return compatibleCollections;

--- a/src/dataimport/TPDI.ts
+++ b/src/dataimport/TPDI.ts
@@ -10,6 +10,7 @@ import {
   OrderSearchParams,
   OrderSearchResult,
   TPDIOrderParams,
+  TPDIOrderCompatibleCollection,
 } from './const';
 import { AirbusDataProvider } from './AirbusDataProvider';
 import { PlanetDataProvider } from './PlanetDataProvider';
@@ -197,6 +198,33 @@ export class TPDI {
       );
       const order: Order = response.data;
       return order;
+    }, reqConfig);
+  }
+
+  public static async getCompatibleCollections(
+    provider: TPDProvider,
+    params: TPDISearchParams,
+    reqConfig?: RequestConfiguration,
+  ): Promise<TPDIOrderCompatibleCollection[]> {
+    return await ensureTimeout(async innerReqConfig => {
+      const requestConfig: AxiosRequestConfig = createRequestConfig(innerReqConfig);
+      const tpdp = getThirdPartyDataProvider(provider);
+
+      const searchPayload = tpdp.getSearchPayload(params);
+
+      const payload = { input: searchPayload };
+      let compatibleCollections: TPDIOrderCompatibleCollection[];
+
+      const { data } = await axios.post(
+        `${TPDI_SERVICE_URL}/orders/searchcompatiblecollections/`,
+        payload,
+        requestConfig,
+      );
+      if (data?.data) {
+        compatibleCollections = data.data;
+      }
+
+      return compatibleCollections;
     }, reqConfig);
   }
 }

--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -103,6 +103,7 @@ export type TPDIOrderCompatibleCollection = {
   requiresMetadataUpdate: boolean;
   s3Bucket: string;
   userId: string;
+  additionalData?: Record<string, any>;
 };
 
 type LinksType = {
@@ -122,8 +123,8 @@ export type TPDSearchResult = {
 
 export type Quota = {
   collectionId: TPDICollections;
-  quotaSqkm: number;
-  quotaUsed: number;
+  quotaSqkm: number | null;
+  quotaUsed: number | null;
 };
 
 export enum OrderStatus {

--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -95,6 +95,16 @@ export type TPDIOrderParams = {
   productKernel?: ResamplingKernel;
 };
 
+export type TPDIOrderCompatibleCollection = {
+  id: string;
+  name: string;
+  created: string;
+  isConfigured: boolean;
+  requiresMetadataUpdate: boolean;
+  s3Bucket: string;
+  userId: string;
+};
+
 type LinksType = {
   currentToken: string;
   nextToken: string;

--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -98,12 +98,6 @@ export type TPDIOrderParams = {
 export type TPDIOrderCompatibleCollection = {
   id: string;
   name: string;
-  created: string;
-  isConfigured: boolean;
-  requiresMetadataUpdate: boolean;
-  s3Bucket: string;
-  userId: string;
-  additionalData?: Record<string, any>;
 };
 
 type LinksType = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ import {
   TPDISearchParams,
   TPDProvider,
   ResamplingKernel,
+  TPDIOrderCompatibleCollection,
 } from './dataimport/const';
 
 import { StatisticsProviderType } from './statistics/StatisticsProvider';
@@ -238,4 +239,5 @@ export {
   PlanetScopeHarmonization,
   MaxarSensor,
   ResamplingKernel,
+  TPDIOrderCompatibleCollection,
 };


### PR DESCRIPTION
>There is an not documented! as only for internal use endpoint that returns list of user's compatible collections. `api/v1/data_import/orders/searchcompatiblecollections` (you post your order detail and get back the list of user's compatible collections)
