### PR TITLE
Add custom responseType to request config

### DIFF
--- a/src/utils/cancelRequests.ts
+++ b/src/utils/cancelRequests.ts
@@ -8,6 +8,7 @@ export type RequestConfiguration = {
   timeout?: number | null;
   cancelToken?: CancelToken;
   cache?: CacheConfig;
+  responseType?: string;
   rewriteUrlFunc?: (url: string) => string;
 };
 
@@ -71,6 +72,9 @@ export const getAxiosReqParams = (
   }
   if (reqConfigWithDefault.rewriteUrlFunc) {
     axiosReqConfig.rewriteUrlFunc = reqConfigWithDefault.rewriteUrlFunc;
+  }
+  if (reqConfigWithDefault.responseType) {
+    axiosReqConfig.responseType = reqConfigWithDefault.responseType;
   }
   return axiosReqConfig;
 };


### PR DESCRIPTION
Related to https://git.sinergise.com/team-6/eobrowser3/-/issues/575

In case where `fetchGetCapabilitiesJson` failed, it returned a XML in the response and when the request was successful it returned a JSON. If `responseType === 'json'`, then the XML can not be parsed, by setting the `responseType: 'text'` and overriding the default `responseType: 'json'`, the XML can be parsed in the case of the request failing, and JSON can also be normally parsed when the request is successful.