### PR TITLE
Fix/use correct host for configuration service

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -30,7 +30,7 @@ import { Effects } from '../mapDataManipulation/const';
 import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
 import { getStatisticsProvider, StatisticsProviderType } from '../statistics/StatisticsProvider';
-import { fetchLayerParamsFromConfigurationService } from './utils';
+import { fetchLayerParamsFromConfigurationService, getConfigurationServiceHostFromBaseUrl } from './utils';
 interface ConstructorParameters {
   instanceId?: string | null;
   layerId?: string | null;
@@ -115,7 +115,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       throw new Error('This layer does not support Processing API (unknown dataset)');
     }
     const layersParams = await fetchLayerParamsFromConfigurationService(
-      this.dataset.shServiceHostname,
+      getConfigurationServiceHostFromBaseUrl(this.dataset.shServiceHostname),
       this.instanceId,
       reqConfig,
     );

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -115,7 +115,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       throw new Error('This layer does not support Processing API (unknown dataset)');
     }
     const layersParams = await fetchLayerParamsFromConfigurationService(
-      this.getShServiceHostname(),
+      this.dataset.shServiceHostname,
       this.instanceId,
       reqConfig,
     );

--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -114,7 +114,11 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
     if (!this.dataset) {
       throw new Error('This layer does not support Processing API (unknown dataset)');
     }
-    const layersParams = await fetchLayerParamsFromConfigurationService(this.instanceId, reqConfig);
+    const layersParams = await fetchLayerParamsFromConfigurationService(
+      this.getShServiceHostname(),
+      this.instanceId,
+      reqConfig,
+    );
 
     const layerParams = layersParams.find((l: any) => l.layerId === this.layerId);
     if (!layerParams) {

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -6,6 +6,7 @@ import {
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
   fetchLayerParamsFromConfigurationService,
+  getConfigurationServiceHostFromBaseUrl,
 } from './utils';
 import { ensureTimeout } from '../utils/ensureTimeout';
 import {
@@ -304,7 +305,11 @@ export class LayersFactory {
     // use configuration if possible
     if (authToken && preferGetCapabilities === false) {
       try {
-        const layers = await fetchLayerParamsFromConfigurationService(parseSHInstanceId(baseUrl), reqConfig);
+        const layers = await fetchLayerParamsFromConfigurationService(
+          getConfigurationServiceHostFromBaseUrl(baseUrl),
+          parseSHInstanceId(baseUrl),
+          reqConfig,
+        );
         layersInfos = layers.map((l: any) => ({
           ...l,
           dataset: LayersFactory.matchDatasetFromGetCapabilities(l.type, baseUrl),

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -1,5 +1,13 @@
 import { BBox } from '../bbox';
-import { GetMapParams, Interpolator, PreviewMode, ApiType, PaginatedTiles, MosaickingOrder } from './const';
+import {
+  GetMapParams,
+  Interpolator,
+  PreviewMode,
+  ApiType,
+  PaginatedTiles,
+  MosaickingOrder,
+  DEFAULT_SH_SERVICE_HOSTNAME,
+} from './const';
 import {
   createProcessingPayload,
   convertPreviewToString,
@@ -36,8 +44,6 @@ export type DataFusionLayerInfo = {
   upsampling?: Interpolator;
   downsampling?: Interpolator;
 };
-
-export const DEFAULT_SH_SERVICE_HOSTNAME = 'https://services.sentinel-hub.com/';
 
 export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
   protected layers: DataFusionLayerInfo[];

--- a/src/layer/__tests__/LayersFactory.ts
+++ b/src/layer/__tests__/LayersFactory.ts
@@ -7,6 +7,9 @@ import {
   DATASET_AWS_LOTL1,
   DATASET_S2L1C,
   DATASET_CDAS_S2L1C,
+  DATASET_S3OLCI,
+  DATASET_CDAS_S2L2A,
+  DATASET_CDAS_S3OLCI,
 } from '../dataset';
 import { LayersFactory } from '../LayersFactory';
 import { WmsLayer, setAuthToken, invalidateCaches, S2L1CCDASLayer } from '../../index';
@@ -171,6 +174,120 @@ describe('Test endpoints for getting layers parameters', () => {
 
     [
       {
+        baseUrl: `${DATASET_CDAS_S2L2A.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: undefined,
+        authToken: undefined,
+      },
+      [{ code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S2L2A.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: true,
+        authToken: undefined,
+      },
+      [{ code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S2L2A.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: false,
+        authToken: undefined,
+      },
+      [{ code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        //not authenticated
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S2L2A.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: false,
+        authToken: 'authToken',
+      },
+      [{ code: 200, data: [] }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/configuration/v1/wms/instances/${instanceId}/layers`;
+      },
+    ],
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S2L2A.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: false,
+        authToken: 'authToken',
+      },
+      [{ code: 401 }, { code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+
+    [
+      {
+        baseUrl: `${DATASET_S3OLCI.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: true,
+        authToken: undefined,
+      },
+      [{ code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://creodias.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+
+    [
+      {
+        baseUrl: `${DATASET_S3OLCI.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: false,
+        authToken: 'authToken',
+      },
+      [{ code: 200, data: [] }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://services.sentinel-hub.com/configuration/v1/wms/instances/${instanceId}/layers`;
+      },
+    ],
+
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S3OLCI.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: undefined,
+        authToken: undefined,
+      },
+      [{ code: 200, data: { layers: [] } }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+      },
+    ],
+
+    [
+      {
+        baseUrl: `${DATASET_CDAS_S3OLCI.shServiceHostname}ogc/wms/`,
+        instanceId: 'instanceId',
+        preferGetCapabilities: false,
+        authToken: 'authToken',
+      },
+      [{ code: 200, data: [] }],
+      function expectedEndpoint(instanceId: string): string {
+        return `https://sh.dataspace.copernicus.eu/configuration/v1/wms/instances/${instanceId}/layers`;
+      },
+    ],
+
+    [
+      {
         baseUrl: `${DATASET_AWS_LOTL1.shServiceHostname}ogc/wms/`,
         instanceId: 'instanceId',
         preferGetCapabilities: undefined,
@@ -265,7 +382,7 @@ describe('Test endpoints for getting layers parameters', () => {
         return `https://api.planet.com/basemaps/v1/mosaics/wmts?service=wmts&request=GetCapabilities&format=text%2Fxml`;
       },
     ],
-  ])('checks if correct endpoint is used', async (inputParams, responses, expectedEndpoint) => {
+  ])('checks if correct endpoint is used ', async (inputParams, responses, expectedEndpoint) => {
     const { baseUrl, instanceId, preferGetCapabilities, authToken } = inputParams;
 
     if (!!authToken) {

--- a/src/layer/__tests__/ProcessingDataFusionLayer.ts
+++ b/src/layer/__tests__/ProcessingDataFusionLayer.ts
@@ -15,9 +15,14 @@ import {
   Polarization,
   BYOCLayer,
 } from '../../index';
-import { DataFusionLayerInfo, DEFAULT_SH_SERVICE_HOSTNAME } from '../ProcessingDataFusionLayer';
+import { DataFusionLayerInfo } from '../ProcessingDataFusionLayer';
 import '../../../jest-setup';
-import { DEMInstanceTypeOrthorectification, LocationIdSHv3, SHV3_LOCATIONS_ROOT_URL } from '../const';
+import {
+  DEMInstanceTypeOrthorectification,
+  LocationIdSHv3,
+  SHV3_LOCATIONS_ROOT_URL,
+  DEFAULT_SH_SERVICE_HOSTNAME,
+} from '../const';
 import { constructFixtureGetMapRequest } from './fixtures.ProcessingDataFusionLayer';
 import { AcquisitionMode, Resolution } from '../S1GRDAWSEULayer';
 

--- a/src/layer/__tests__/S2L1CCDASLayer.ts
+++ b/src/layer/__tests__/S2L1CCDASLayer.ts
@@ -24,6 +24,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const SEARCH_INDEX_URL = 'https://sh.dataspace.copernicus.eu/index/v3/collections/S2L1C/searchIndex';
 
@@ -197,3 +198,14 @@ test.each([
     expect(layer.supportsApiType(ApiType.PROCESSING)).toBe(expectedResult);
   },
 );
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S2L1CCDASLayer, 'https://sh.dataspace.copernicus.eu');
+  });
+});

--- a/src/layer/__tests__/S2L1CLayer.ts
+++ b/src/layer/__tests__/S2L1CLayer.ts
@@ -24,6 +24,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const SEARCH_INDEX_URL = 'https://services.sentinel-hub.com/index/v3/collections/S2L1C/searchIndex';
 
@@ -193,3 +194,14 @@ test.each([
     expect(layer.supportsApiType(ApiType.PROCESSING)).toBe(expectedResult);
   },
 );
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S2L1CLayer, 'https://services.sentinel-hub.com');
+  });
+});

--- a/src/layer/__tests__/S2L2ACDASLayer.ts
+++ b/src/layer/__tests__/S2L2ACDASLayer.ts
@@ -24,6 +24,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const SEARCH_INDEX_URL = 'https://sh.dataspace.copernicus.eu/index/v3/collections/S2L2A/searchIndex';
 
@@ -182,5 +183,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S2L2ACDASLayer, 'https://sh.dataspace.copernicus.eu');
   });
 });

--- a/src/layer/__tests__/S2L2ACLayer.ts
+++ b/src/layer/__tests__/S2L2ACLayer.ts
@@ -24,6 +24,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const SEARCH_INDEX_URL = 'https://services.sentinel-hub.com/index/v3/collections/S2L2A/searchIndex';
 
@@ -178,5 +179,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S2L2ALayer, 'https://services.sentinel-hub.com');
   });
 });

--- a/src/layer/__tests__/S3OLCICDASLayer.ts
+++ b/src/layer/__tests__/S3OLCICDASLayer.ts
@@ -22,6 +22,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://sh.dataspace.copernicus.eu/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://sh.dataspace.copernicus.eu/index/v3/collections/S3OLCI/searchIndex';
@@ -160,5 +161,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S3OLCICDASLayer, 'https://sh.dataspace.copernicus.eu');
   });
 });

--- a/src/layer/__tests__/S3OLCILayer.ts
+++ b/src/layer/__tests__/S3OLCILayer.ts
@@ -22,6 +22,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://creodias.sentinel-hub.com/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://creodias.sentinel-hub.com/index/v3/collections/S3OLCI/searchIndex';
@@ -160,5 +161,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S3OLCILayer, 'https://services.sentinel-hub.com');
   });
 });

--- a/src/layer/__tests__/S3SLTRCDASLayer.ts
+++ b/src/layer/__tests__/S3SLTRCDASLayer.ts
@@ -23,6 +23,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://sh.dataspace.copernicus.eu/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://sh.dataspace.copernicus.eu/index/v3/collections/S3SLSTR/searchIndex';
@@ -186,5 +187,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S3SLSTRCDASLayer, 'https://sh.dataspace.copernicus.eu');
   });
 });

--- a/src/layer/__tests__/S3SLTRLayer.ts
+++ b/src/layer/__tests__/S3SLTRLayer.ts
@@ -23,6 +23,7 @@ import {
   constructFixtureFindDatesUTCSearchIndex,
   constructFixtureFindDatesUTCCatalog,
 } from './fixtures.findDatesUTC';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://creodias.sentinel-hub.com/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://creodias.sentinel-hub.com/index/v3/collections/S3SLSTR/searchIndex';
@@ -186,5 +187,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S3SLSTRLayer, 'https://services.sentinel-hub.com');
   });
 });

--- a/src/layer/__tests__/S5PL2CDASLayer.ts
+++ b/src/layer/__tests__/S5PL2CDASLayer.ts
@@ -24,6 +24,7 @@ import {
 } from './fixtures.findDatesUTC';
 
 import { ProductType } from '../S5PL2Layer';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://sh.dataspace.copernicus.eu/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://sh.dataspace.copernicus.eu/index/v3/collections/S5PL2/searchIndex';
@@ -173,5 +174,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S5PL2CDASLayer, 'https://sh.dataspace.copernicus.eu');
   });
 });

--- a/src/layer/__tests__/S5PL2Layer.ts
+++ b/src/layer/__tests__/S5PL2Layer.ts
@@ -25,6 +25,7 @@ import {
 } from './fixtures.findDatesUTC';
 
 import { ProductType } from '../S5PL2Layer';
+import { checkLayersParamsEndpoint } from './testUtils.layers';
 
 const CATALOG_URL = 'https://creodias.sentinel-hub.com/api/v1/catalog/1.0.0/search';
 const SEARCH_INDEX_URL = 'https://creodias.sentinel-hub.com/index/v3/collections/S5PL2/searchIndex';
@@ -174,5 +175,16 @@ describe('Test findDatesUTC using catalog', () => {
       layerId: 'LAYER_ID',
     });
     await checkResponseFindDatesUTC(constructFixtureFindDatesUTCCatalog(layer, {}));
+  });
+});
+
+describe('correct endpoint is used for layer params', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+
+  test('updateLayerFromServiceIfNeeded', async () => {
+    await checkLayersParamsEndpoint(mockNetwork, S5PL2Layer, 'https://services.sentinel-hub.com');
   });
 });

--- a/src/layer/__tests__/testUtils.layers.ts
+++ b/src/layer/__tests__/testUtils.layers.ts
@@ -1,0 +1,31 @@
+import MockAdapter from 'axios-mock-adapter';
+import { AbstractSentinelHubV3Layer } from '../AbstractSentinelHubV3Layer';
+
+export const checkLayersParamsEndpoint = async (
+  mockNetwork: MockAdapter,
+  layerClass: typeof AbstractSentinelHubV3Layer,
+  expectedEndpoint: string,
+): Promise<void> => {
+  const instanceId = 'INSTANCE_ID';
+  const layerId = 'LAYER_ID';
+
+  mockNetwork.onGet().reply(200, [
+    {
+      id: layerId,
+      styles: [
+        {
+          evalScript: '//',
+        },
+      ],
+    },
+  ]);
+
+  const layer = new layerClass({
+    instanceId,
+    layerId,
+  });
+  await layer.updateLayerFromServiceIfNeeded({});
+  expect(mockNetwork.history.get[0].url).toBe(
+    `${expectedEndpoint}/configuration/v1/wms/instances/${instanceId}/layers`,
+  );
+};

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -172,6 +172,8 @@ export const SHV3_LOCATIONS_ROOT_URL: Record<LocationIdSHv3, string> = {
   [LocationIdSHv3.gcpUsCentral1]: 'https://services-gcp-us-central1.sentinel-hub.com/',
 };
 
+export const DEFAULT_SH_SERVICE_HOSTNAME = 'https://services.sentinel-hub.com/';
+
 export type GetStatsParams = {
   fromTime: Date;
   toTime: Date;

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,7 +2,12 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify, parseUrl, stringifyUrl } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { OgcServiceTypes, SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import {
+  DEFAULT_SH_SERVICE_HOSTNAME,
+  OgcServiceTypes,
+  SH_SERVICE_HOSTNAMES_V1_OR_V2,
+  SH_SERVICE_HOSTNAMES_V3,
+} from './const';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_30MIN_MEMORY } from '../utils/cacheHandlers';
 import { GetCapabilitiesWmtsXml } from './wmts.utils';
@@ -147,7 +152,7 @@ export function getConfigurationServiceHostFromBaseUrl(baseUrl: string): string 
 
   // Note that for SH v3 service, the endpoint for fetching the list of layers is always
   // https://services.sentinel-hub.com/, even for creodias datasets:
-  return 'https://services.sentinel-hub.com/';
+  return DEFAULT_SH_SERVICE_HOSTNAME;
 }
 
 export async function fetchLayerParamsFromConfigurationService(
@@ -159,7 +164,7 @@ export async function fetchLayerParamsFromConfigurationService(
   if (!authToken) {
     throw new Error('Must be authenticated to fetch layer params');
   }
-  const configurationServiceHostName = shServiceHostName ?? 'https://services.sentinel-hub.com/';
+  const configurationServiceHostName = shServiceHostName ?? DEFAULT_SH_SERVICE_HOSTNAME;
   const url = `${configurationServiceHostName}configuration/v1/wms/instances/${instanceId}/layers`;
   const headers = {
     Authorization: `Bearer ${authToken}`,

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -152,12 +152,15 @@ export function getConfigurationServiceHostFromBaseUrl(baseUrl: string): string 
     host = baseUrl.substring(0, baseUrl.indexOf('/ogc/wms') + 1);
   }
 
+  // Copernicus datasets require different endpoint
   if (/dataspace.copernicus.eu/.test(host)) {
     return host;
   }
 
-  // Note that for SH v3 service, the endpoint for fetching the list of layers is always
-  // https://services.sentinel-hub.com/, even for creodias datasets:
+  // The endpoint for fetching the list of layers is typically
+  // https://services.sentinel-hub.com/, even for creodias datasets.
+  // However there is an exception for Copernicus datasets, which have a different
+  // a different endpoint for fetching the list of layers
   return DEFAULT_SH_SERVICE_HOSTNAME;
 }
 

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,13 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify, parseUrl, stringifyUrl } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import {
-  LocationIdSHv3,
-  OgcServiceTypes,
-  SHV3_LOCATIONS_ROOT_URL,
-  SH_SERVICE_HOSTNAMES_V1_OR_V2,
-  SH_SERVICE_HOSTNAMES_V3,
-} from './const';
+import { OgcServiceTypes, SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_30MIN_MEMORY } from '../utils/cacheHandlers';
 import { GetCapabilitiesWmtsXml } from './wmts.utils';

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,7 +2,13 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify, parseUrl, stringifyUrl } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { OgcServiceTypes, SH_SERVICE_HOSTNAMES_V1_OR_V2, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import {
+  LocationIdSHv3,
+  OgcServiceTypes,
+  SHV3_LOCATIONS_ROOT_URL,
+  SH_SERVICE_HOSTNAMES_V1_OR_V2,
+  SH_SERVICE_HOSTNAMES_V3,
+} from './const';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_30MIN_MEMORY } from '../utils/cacheHandlers';
 import { GetCapabilitiesWmtsXml } from './wmts.utils';
@@ -140,7 +146,18 @@ export function parseSHInstanceId(baseUrl: string): string {
   throw new Error(`Could not parse instanceId from URL: ${baseUrl}`);
 }
 
+export function getConfigurationServiceHostFromBaseUrl(baseUrl: string): string {
+  if (/dataspace.copernicus.eu/.test(baseUrl)) {
+    return 'https://sh.dataspace.copernicus.eu/';
+  }
+
+  // Note that for SH v3 service, the endpoint for fetching the list of layers is always
+  // https://services.sentinel-hub.com/, even for creodias datasets:
+  return 'https://services.sentinel-hub.com/';
+}
+
 export async function fetchLayerParamsFromConfigurationService(
+  shServiceHostName: string,
   instanceId: string,
   reqConfig: RequestConfiguration,
 ): Promise<any[]> {
@@ -148,9 +165,8 @@ export async function fetchLayerParamsFromConfigurationService(
   if (!authToken) {
     throw new Error('Must be authenticated to fetch layer params');
   }
-  // Note that for SH v3 service, the endpoint for fetching the list of layers is always
-  // https://services.sentinel-hub.com/, even for creodias datasets:
-  const url = `https://services.sentinel-hub.com/configuration/v1/wms/instances/${instanceId}/layers`;
+
+  const url = `${shServiceHostName}configuration/v1/wms/instances/${instanceId}/layers`;
   const headers = {
     Authorization: `Bearer ${authToken}`,
   };

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -159,8 +159,8 @@ export async function fetchLayerParamsFromConfigurationService(
   if (!authToken) {
     throw new Error('Must be authenticated to fetch layer params');
   }
-
-  const url = `${shServiceHostName}configuration/v1/wms/instances/${instanceId}/layers`;
+  const configurationServiceHostName = shServiceHostName ?? 'https://services.sentinel-hub.com/';
+  const url = `${configurationServiceHostName}configuration/v1/wms/instances/${instanceId}/layers`;
   const headers = {
     Authorization: `Bearer ${authToken}`,
   };

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -146,8 +146,14 @@ export function parseSHInstanceId(baseUrl: string): string {
 }
 
 export function getConfigurationServiceHostFromBaseUrl(baseUrl: string): string {
-  if (/dataspace.copernicus.eu/.test(baseUrl)) {
-    return 'https://sh.dataspace.copernicus.eu/';
+  let host = baseUrl;
+
+  if (/\ogc\/wms/.test(baseUrl)) {
+    host = baseUrl.substring(0, baseUrl.indexOf('/ogc/wms') + 1);
+  }
+
+  if (/dataspace.copernicus.eu/.test(host)) {
+    return host;
   }
 
   // Note that for SH v3 service, the endpoint for fetching the list of layers is always


### PR DESCRIPTION
```
  // Note that for SH v3 service, the endpoint for fetching the list of layers is always
  // https://services.sentinel-hub.com/, even for creodias datasets:
```
With CDSE  the assumption above is no longer correct. 
