### PR TITLE
Add mosaicking order to S1GRD constructor

### DIFF
--- a/src/layer/S1GRDAWSEULayer.ts
+++ b/src/layer/S1GRDAWSEULayer.ts
@@ -12,6 +12,7 @@ import {
   LinkType,
   DataProductId,
   FindTilesAdditionalParameters,
+  MosaickingOrder,
 } from './const';
 import { ProcessingPayload } from './processing';
 import { DATASET_AWSEU_S1GRD } from './dataset';
@@ -60,6 +61,7 @@ interface ConstructorParameters {
   description?: string | null;
   legendUrl?: string | null;
   acquisitionMode?: AcquisitionMode | null;
+  mosaickingOrder?: MosaickingOrder | null;
   polarization?: Polarization | null;
   resolution?: Resolution | null;
   orthorectify?: boolean | null;
@@ -85,6 +87,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
   public resolution: Resolution | null = null;
   public orbitDirection: OrbitDirection | null = null;
   public orthorectify: boolean | null = null;
+  public mosaickingOrder: MosaickingOrder | null = null;
   public demInstanceType: DEMInstanceTypeOrthorectification | null = null;
   public backscatterCoeff: BackscatterCoeff | null = BackscatterCoeff.GAMMA0_ELLIPSOID;
   public speckleFilter: SpeckleFilter | null;
@@ -106,6 +109,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     backscatterCoeff = BackscatterCoeff.GAMMA0_ELLIPSOID,
     orbitDirection = null,
     speckleFilter = null,
+    mosaickingOrder = null,
   }: ConstructorParameters) {
     super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description, legendUrl });
     this.acquisitionMode = acquisitionMode;
@@ -116,6 +120,7 @@ export class S1GRDAWSEULayer extends AbstractSentinelHubV3Layer {
     this.backscatterCoeff = backscatterCoeff;
     this.orbitDirection = orbitDirection;
     this.speckleFilter = speckleFilter;
+    this.mosaickingOrder = mosaickingOrder;
   }
 
   public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -8,6 +8,7 @@ import {
   OrbitDirection,
   LinkType,
   setAuthToken,
+  MosaickingOrder,
 } from '../../index';
 
 import {
@@ -40,6 +41,31 @@ test('timezone should NOT be UTC', () => {
   // run these tests in UTC timezone. Env var in package.json should take care of that, but we
   // check here just to be sure.
   expect(new Date().getTimezoneOffset()).not.toBe(0);
+});
+
+test('constructor with no mosaickingOrder parameter', () => {
+  const layer = new S1GRDAWSEULayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+  });
+  const expectedMosaickingOrder: null = null;
+  expect(layer.mosaickingOrder).toEqual(expectedMosaickingOrder);
+});
+
+test('constructor with mosaickingOrder parameter', () => {
+  const layer = new S1GRDAWSEULayer({
+    instanceId: 'INSTANCE_ID',
+    layerId: 'LAYER_ID',
+    acquisitionMode: AcquisitionMode.IW,
+    polarization: Polarization.DV,
+    resolution: Resolution.HIGH,
+    mosaickingOrder: MosaickingOrder.MOST_RECENT,
+  });
+  const expectedMosaickingOrder = MosaickingOrder.MOST_RECENT;
+  expect(layer.mosaickingOrder).toEqual(expectedMosaickingOrder);
 });
 
 test.each([

--- a/src/layer/__tests__/S1GRDAWSLayer.ts
+++ b/src/layer/__tests__/S1GRDAWSLayer.ts
@@ -51,8 +51,7 @@ test('constructor with no mosaickingOrder parameter', () => {
     polarization: Polarization.DV,
     resolution: Resolution.HIGH,
   });
-  const expectedMosaickingOrder: null = null;
-  expect(layer.mosaickingOrder).toEqual(expectedMosaickingOrder);
+  expect(layer.mosaickingOrder).toEqual(null);
 });
 
 test('constructor with mosaickingOrder parameter', () => {


### PR DESCRIPTION
https://git.sinergise.com/team-6/eobrowser3/-/issues/607

Constructor was missing the parameter `mosaickingOrder` so it was always set to null.