### PR TITLE
Support cdse byoc

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -30,7 +30,7 @@ import { Effects } from '../mapDataManipulation/const';
 import { runEffectFunctions } from '../mapDataManipulation/runEffectFunctions';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_NOCACHE } from '../utils/cacheHandlers';
 import { getStatisticsProvider, StatisticsProviderType } from '../statistics/StatisticsProvider';
-import { fetchLayerParamsFromConfigurationService, getConfigurationServiceHostFromBaseUrl } from './utils';
+import { fetchLayerParamsFromConfigurationService, getSHServiceRootUrl } from './utils';
 interface ConstructorParameters {
   instanceId?: string | null;
   layerId?: string | null;
@@ -115,7 +115,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       throw new Error('This layer does not support Processing API (unknown dataset)');
     }
     const layersParams = await fetchLayerParamsFromConfigurationService(
-      getConfigurationServiceHostFromBaseUrl(this.dataset.shServiceHostname),
+      this.getSHServiceRootUrl(),
       this.instanceId,
       reqConfig,
     );
@@ -678,5 +678,9 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
       maxCloudCoverPercent: null,
       datasetParameters: null,
     };
+  }
+
+  public getSHServiceRootUrl(): string {
+    return getSHServiceRootUrl(this.dataset.shServiceHostname);
   }
 }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -26,6 +26,7 @@ import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests
 import { ensureTimeout } from '../utils/ensureTimeout';
 import { CACHE_CONFIG_30MIN } from '../utils/cacheHandlers';
 import { StatisticsProviderType } from '../statistics/StatisticsProvider';
+import { getSHServiceRootUrl } from './utils';
 
 interface ConstructorParameters {
   instanceId?: string | null;
@@ -70,7 +71,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     this.collectionId = collectionId;
     this.locationId = locationId;
     this.subType = subType;
-    this.shServiceRootUrl = shServiceRootUrl;
+    this.shServiceRootUrl = getSHServiceRootUrl(shServiceRootUrl);
   }
 
   public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -17,6 +17,7 @@ import {
   BYOCBand,
   FindTilesAdditionalParameters,
   BYOCSubTypes,
+  SH_SERVICE_ROOT_URL,
 } from './const';
 import { DATASET_BYOC } from './dataset';
 import { AbstractSentinelHubV3Layer } from './AbstractSentinelHubV3Layer';
@@ -37,6 +38,7 @@ interface ConstructorParameters {
   collectionId?: string | null;
   locationId?: LocationIdSHv3 | null;
   subType?: BYOCSubTypes | null;
+  shServiceRootUrl?: string;
 }
 
 type BYOCFindTilesDatasetParameters = {
@@ -49,6 +51,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   public collectionId: string;
   public locationId: LocationIdSHv3;
   public subType: BYOCSubTypes;
+  public shServiceRootUrl: string;
 
   public constructor({
     instanceId = null,
@@ -61,11 +64,13 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
     collectionId = null,
     locationId = null,
     subType = null,
+    shServiceRootUrl = SH_SERVICE_ROOT_URL.default,
   }: ConstructorParameters) {
     super({ instanceId, layerId, evalscript, evalscriptUrl, dataProduct, title, description });
     this.collectionId = collectionId;
     this.locationId = locationId;
     this.subType = subType;
+    this.shServiceRootUrl = shServiceRootUrl;
   }
 
   public async updateLayerFromServiceIfNeeded(reqConfig?: RequestConfiguration): Promise<void> {
@@ -105,7 +110,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
 
       if (this.locationId === null) {
         if (this.subType !== BYOCSubTypes.ZARR) {
-          const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/${this.getTypeId()}`;
+          const url = `${this.getSHServiceRootUrl()}api/v1/metadata/collection/${this.getTypeId()}`;
           const headers = { Authorization: `Bearer ${getAuthToken()}` };
           const res = await axios.get(url, {
             responseType: 'json',
@@ -266,7 +271,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
         throw new Error('Fetching available bands for ZARR not supported.');
       }
 
-      const url = `https://services.sentinel-hub.com/api/v1/metadata/collection/${this.getTypeId()}`;
+      const url = `${this.getSHServiceRootUrl()}api/v1/metadata/collection/${this.getTypeId()}`;
       const headers = { Authorization: `Bearer ${getAuthToken()}` };
       const res = await axios.get(url, {
         responseType: 'json',
@@ -276,5 +281,9 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       return res.data.bands;
     }, reqConfig);
     return bandsResponseData;
+  }
+
+  public getSHServiceRootUrl(): string {
+    return this.shServiceRootUrl;
   }
 }

--- a/src/layer/LayersFactory.ts
+++ b/src/layer/LayersFactory.ts
@@ -5,7 +5,7 @@ import {
   fetchGetCapabilitiesJson,
   parseSHInstanceId,
   fetchLayerParamsFromConfigurationService,
-  getConfigurationServiceHostFromBaseUrl,
+  getSHServiceRootUrlFromBaseUrl,
   fetchGetCapabilitiesXml,
   GetCapabilitiesWmsXml,
   isWMSCapabilities,
@@ -242,6 +242,7 @@ export class LayersFactory {
         if (!SHLayerClass) {
           throw new Error(`Dataset ${dataset.id} is not defined in LayersFactory.LAYER_FROM_DATASET`);
         }
+        const shServiceRootUrl = getSHServiceRootUrlFromBaseUrl(baseUrl);
         return new SHLayerClass({
           instanceId: parseSHInstanceId(baseUrl),
           layerId,
@@ -255,6 +256,7 @@ export class LayersFactory {
           // We must pass the maxCloudCoverPercent (S-2) or others (S-1) from legacyGetMapFromParams to the Layer
           // otherwise the default values from layer definition on the service will be used.
           ...overrideConstructorParams,
+          shServiceRootUrl: shServiceRootUrl,
         });
       },
     );
@@ -274,7 +276,7 @@ export class LayersFactory {
     if (authToken && preferGetCapabilities === false) {
       try {
         const layers = await fetchLayerParamsFromConfigurationService(
-          getConfigurationServiceHostFromBaseUrl(baseUrl),
+          getSHServiceRootUrlFromBaseUrl(baseUrl),
           parseSHInstanceId(baseUrl),
           reqConfig,
         );

--- a/src/layer/ProcessingDataFusionLayer.ts
+++ b/src/layer/ProcessingDataFusionLayer.ts
@@ -6,7 +6,7 @@ import {
   ApiType,
   PaginatedTiles,
   MosaickingOrder,
-  DEFAULT_SH_SERVICE_HOSTNAME,
+  SH_SERVICE_ROOT_URL,
 } from './const';
 import {
   createProcessingPayload,
@@ -127,8 +127,16 @@ export class ProcessingDataFusionLayer extends AbstractSentinelHubV3Layer {
         )
       ) {
         shServiceHostname = bogusFirstLayer.getShServiceHostname();
+      }
+      //check if all layers use same root url and use it for request
+      else if (
+        this.layers.every(
+          layer => layer.layer.getSHServiceRootUrl() === bogusFirstLayer.getSHServiceRootUrl(),
+        )
+      ) {
+        shServiceHostname = bogusFirstLayer.getSHServiceRootUrl();
       } else {
-        shServiceHostname = DEFAULT_SH_SERVICE_HOSTNAME;
+        shServiceHostname = SH_SERVICE_ROOT_URL.default;
       }
 
       let blob = await processingGetMap(shServiceHostname, payload, innerReqConfig);

--- a/src/layer/__tests__/BYOCLayer.ts
+++ b/src/layer/__tests__/BYOCLayer.ts
@@ -237,7 +237,6 @@ describe.only('shServiceRootUrl', () => {
     mockNetwork.reset();
   });
   const mockedLayerId = 'LAYER_ID';
-  const mockedLayersResponse = [{ id: mockedLayerId, styles: [{}] }];
 
   test.each([
     [

--- a/src/layer/__tests__/BYOCLayer.ts
+++ b/src/layer/__tests__/BYOCLayer.ts
@@ -1,5 +1,5 @@
 import { BBox, CRS_EPSG4326, setAuthToken, LocationIdSHv3, BYOCLayer } from '../../index';
-import { SHV3_LOCATIONS_ROOT_URL, BYOCSubTypes } from '../const';
+import { SHV3_LOCATIONS_ROOT_URL, BYOCSubTypes, SH_SERVICE_ROOT_URL } from '../const';
 import { constructFixtureFindTilesSearchIndex, constructFixtureFindTilesCatalog } from './fixtures.BYOCLayer';
 
 import {
@@ -228,5 +228,63 @@ describe('Test updateLayerFromServiceIfNeeded for ZARR', () => {
       .replyOnce(200, mockedLayersResponse);
     await layer.updateLayerFromServiceIfNeeded();
     expect(layer.locationId).toEqual(LocationIdSHv3.creo);
+  });
+});
+
+describe.only('shServiceRootUrl', () => {
+  beforeEach(async () => {
+    setAuthToken(AUTH_TOKEN);
+    mockNetwork.reset();
+  });
+  const mockedLayerId = 'LAYER_ID';
+  const mockedLayersResponse = [{ id: mockedLayerId, styles: [{}] }];
+
+  test.each([
+    [
+      'default sh service url is used if not set',
+      {
+        instanceId: 'INSTANCE_ID',
+        layerId: mockedLayerId,
+        collectionId: 'mockCollectionId',
+        subType: BYOCSubTypes.BYOC,
+      },
+      SH_SERVICE_ROOT_URL.default,
+    ],
+    [
+      'default sh service url is used if set',
+      {
+        instanceId: 'INSTANCE_ID',
+        layerId: mockedLayerId,
+        collectionId: 'mockCollectionId',
+        subType: BYOCSubTypes.BYOC,
+        shServiceRootUrl: SH_SERVICE_ROOT_URL.default,
+      },
+      SH_SERVICE_ROOT_URL.default,
+    ],
+    [
+      'cdse sh service url is used if set',
+      {
+        instanceId: 'INSTANCE_ID',
+        layerId: mockedLayerId,
+        collectionId: 'mockCollectionId',
+        subType: BYOCSubTypes.BYOC,
+        shServiceRootUrl: SH_SERVICE_ROOT_URL.cdse,
+      },
+      SH_SERVICE_ROOT_URL.cdse,
+    ],
+    [
+      'default sh service url is used for unknown shServiceRootUrl',
+      {
+        instanceId: 'INSTANCE_ID',
+        layerId: mockedLayerId,
+        collectionId: 'mockCollectionId',
+        subType: BYOCSubTypes.BYOC,
+        shServiceRootUrl: 'random url',
+      },
+      SH_SERVICE_ROOT_URL.default,
+    ],
+  ])('%p', async (_title, layerParams, expected) => {
+    const layer = new BYOCLayer(layerParams);
+    expect(layer.getSHServiceRootUrl()).toBe(expected);
   });
 });

--- a/src/layer/__tests__/ProcessingDataFusionLayer.ts
+++ b/src/layer/__tests__/ProcessingDataFusionLayer.ts
@@ -21,7 +21,7 @@ import {
   DEMInstanceTypeOrthorectification,
   LocationIdSHv3,
   SHV3_LOCATIONS_ROOT_URL,
-  DEFAULT_SH_SERVICE_HOSTNAME,
+  SH_SERVICE_ROOT_URL,
 } from '../const';
 import { constructFixtureGetMapRequest } from './fixtures.ProcessingDataFusionLayer';
 import { AcquisitionMode, Resolution } from '../S1GRDAWSEULayer';
@@ -54,7 +54,7 @@ describe("Test data fusion uses correct URL depending on layers' combination", (
 
   test.each([
     [[shServicesLayer, shServicesLayer], shServicesLayer.dataset.shServiceHostname],
-    [[creodiasLayer, shServicesLayer, usWestLayer], DEFAULT_SH_SERVICE_HOSTNAME],
+    [[creodiasLayer, shServicesLayer, usWestLayer], SH_SERVICE_ROOT_URL.default],
     [[creodiasLayer, creodiasLayer], creodiasLayer.dataset.shServiceHostname],
     [[shServicesLayer, byocLayer], shServicesLayer.dataset.shServiceHostname],
     [
@@ -69,8 +69,8 @@ describe("Test data fusion uses correct URL depending on layers' combination", (
       ],
       SHV3_LOCATIONS_ROOT_URL[byocLayer.locationId],
     ],
-    [[byocLayer, shServicesLayer, creodiasLayer], DEFAULT_SH_SERVICE_HOSTNAME],
-    [[byocLayerMundi, byocLayer], DEFAULT_SH_SERVICE_HOSTNAME],
+    [[byocLayer, shServicesLayer, creodiasLayer], SH_SERVICE_ROOT_URL.default],
+    [[byocLayerMundi, byocLayer], SH_SERVICE_ROOT_URL.default],
     [
       [
         byocLayerMundi,

--- a/src/layer/__tests__/utils.ts
+++ b/src/layer/__tests__/utils.ts
@@ -1,5 +1,5 @@
-import { OgcServiceTypes } from '../const';
-import { createGetCapabilitiesXmlUrl } from '../utils';
+import { OgcServiceTypes, SH_SERVICE_ROOT_URL } from '../const';
+import { createGetCapabilitiesXmlUrl, getSHServiceRootUrlFromBaseUrl } from '../utils';
 
 const cases = [
   {
@@ -24,5 +24,21 @@ describe("'add' utility", () => {
   test.each(cases)('build getCapabilities url', ({ input, ogcServiceType, expected }) => {
     const url = createGetCapabilitiesXmlUrl(input, ogcServiceType);
     expect(url).toStrictEqual(expected);
+  });
+});
+
+describe('getSHServiceRootUrlFromBaseUrl', () => {
+  test.each([
+    ['https://services.sentinel-hub.com/ogc/wms/instanceId', SH_SERVICE_ROOT_URL.default],
+    ['https://services-uswest2.sentinel-hub.com/ogc/wms/instanceId', SH_SERVICE_ROOT_URL.default],
+    ['https://creodias.sentinel-hub.com/ogc/wms/instanceId', SH_SERVICE_ROOT_URL.default],
+    ['https://shservices.mundiwebservices.com/ogc/1wms/instanceId', SH_SERVICE_ROOT_URL.default],
+    ['https://sh.dataspace.copernicus.eu/wms/instance', SH_SERVICE_ROOT_URL.cdse],
+    ['', SH_SERVICE_ROOT_URL.default],
+    [null, SH_SERVICE_ROOT_URL.default],
+    [undefined, SH_SERVICE_ROOT_URL.default],
+    ['not url', SH_SERVICE_ROOT_URL.default],
+  ])('getSHServiceRootUrlFromBaseUrl %p', async (baseUrl, expected) => {
+    expect(getSHServiceRootUrlFromBaseUrl(baseUrl)).toBe(expected);
   });
 });

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -172,7 +172,10 @@ export const SHV3_LOCATIONS_ROOT_URL: Record<LocationIdSHv3, string> = {
   [LocationIdSHv3.cdse]: 'https://sh.dataspace.copernicus.eu/',
 };
 
-export const DEFAULT_SH_SERVICE_HOSTNAME = 'https://services.sentinel-hub.com/';
+export const SH_SERVICE_ROOT_URL = {
+  default: SHV3_LOCATIONS_ROOT_URL[LocationIdSHv3.awsEuCentral1],
+  cdse: SHV3_LOCATIONS_ROOT_URL[LocationIdSHv3.cdse],
+};
 
 export type GetStatsParams = {
   fromTime: Date;

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { stringify, parseUrl, stringifyUrl } from 'query-string';
 import { parseStringPromise } from 'xml2js';
 
-import { DEFAULT_SH_SERVICE_HOSTNAME, OgcServiceTypes, SH_SERVICE_HOSTNAMES_V3 } from './const';
+import { OgcServiceTypes, SH_SERVICE_HOSTNAMES_V3, SH_SERVICE_ROOT_URL } from './const';
 import { getAxiosReqParams, RequestConfiguration } from '../utils/cancelRequests';
 import { CACHE_CONFIG_30MIN, CACHE_CONFIG_30MIN_MEMORY } from '../utils/cacheHandlers';
 import { GetCapabilitiesWmtsXml } from './wmts.utils';
@@ -176,7 +176,7 @@ export async function fetchLayerParamsFromConfigurationService(
   if (!authToken) {
     throw new Error('Must be authenticated to fetch layer params');
   }
-  const configurationServiceHostName = shServiceHostName ?? DEFAULT_SH_SERVICE_HOSTNAME;
+  const configurationServiceHostName = shServiceHostName ?? SH_SERVICE_ROOT_URL.default;
   const url = `${configurationServiceHostName}configuration/v1/wms/instances/${instanceId}/layers`;
   const headers = {
     Authorization: `Bearer ${authToken}`,

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -148,23 +148,33 @@ export function parseSHInstanceId(baseUrl: string): string {
   throw new Error(`Could not parse instanceId from URL: ${baseUrl}`);
 }
 
-export function getConfigurationServiceHostFromBaseUrl(baseUrl: string): string {
+export function getSHServiceRootUrl(host: string): string {
+  const shServiceRootUrl = Object.values(SH_SERVICE_ROOT_URL).find(url => {
+    const regex = new RegExp(url);
+    if (regex.test(host)) {
+      return url;
+    }
+  });
+
+  if (shServiceRootUrl) {
+    return shServiceRootUrl;
+  }
+
+  // The endpoint for fetching the list of layers is typically
+  // https://services.sentinel-hub.com/, even for creodias datasets.
+  // However there is an exception for Copernicus datasets, which have
+  // a different endpoint for fetching the list of layers
+  return SH_SERVICE_ROOT_URL.default;
+}
+
+export function getSHServiceRootUrlFromBaseUrl(baseUrl: string): string {
   let host = baseUrl;
 
   if (/\ogc\/wms/.test(baseUrl)) {
     host = baseUrl.substring(0, baseUrl.indexOf('/ogc/wms') + 1);
   }
 
-  // Copernicus datasets require different endpoint
-  if (/dataspace.copernicus.eu/.test(host)) {
-    return host;
-  }
-
-  // The endpoint for fetching the list of layers is typically
-  // https://services.sentinel-hub.com/, even for creodias datasets.
-  // However there is an exception for Copernicus datasets, which have a different
-  // a different endpoint for fetching the list of layers
-  return DEFAULT_SH_SERVICE_HOSTNAME;
+  return getSHServiceRootUrl(host);
 }
 
 export async function fetchLayerParamsFromConfigurationService(


### PR DESCRIPTION
BYOC layers already support different deployment locations (`locationId`) so in theory adding new location `cdse` should be sufficient. However, BYOC layer needs to call `metadata/collections` service to get location if it is not provided. While this service is central (services.sentinel-hub.com) for all "sentinel-hub" deployments (collection on creodias or mundi also uses services.sentinel-hub.com to fetch collection info), it of course uses different endpoint for cdse deployment. So I had to introduce `shServiceUrl` (not the best name) which is used to replace hardcoded urls for  `metadata/collections` and `configuration` endpoints.

Other options that I considered and/or tried
- create BYOC_CDAS layer which extends BYOC layer and has fixed locationId and uses appropriate `shServiceHostName`. While this seems to be the easiest solution, I turned out it requires a lot of changes in eob.  


 

