### PR TITLE
tpdi switch to account quotas

### DIFF
--- a/src/dataimport/TPDI.ts
+++ b/src/dataimport/TPDI.ts
@@ -40,7 +40,7 @@ async function getQuotasInner(
     if (!!TDPICollectionId) {
       requestConfig.params = { collectionId: TDPICollectionId };
     }
-    const res = await axios.get(`${TPDI_SERVICE_URL}/quotas`, requestConfig);
+    const res = await axios.get(`${TPDI_SERVICE_URL}/accountquotas`, requestConfig);
     return res.data.data as Quota[];
   }, reqConfig);
 }

--- a/src/dataimport/__tests__/TPDI.ts
+++ b/src/dataimport/__tests__/TPDI.ts
@@ -42,7 +42,7 @@ describe('Test TPDI service enpoints', () => {
     await TPDI.getQuotas({});
     expect(mockNetwork.history.get.length).toBe(1);
     const request = mockNetwork.history.get[0];
-    expect(request.url).toBe(`${TPDI_SERVICE_URL}/quotas`);
+    expect(request.url).toBe(`${TPDI_SERVICE_URL}/accountquotas`);
   });
 
   it('uses correct endpoint to get orders', async () => {


### PR DESCRIPTION
Switch the endpoint used to get TPDI quotas. 
instead of GET https://services.sentinel-hub.com/api/v1/dataimport/quotas call GET https://services.sentinel-hub.com/api/v1/dataimport/accountquotas

[#1135](https://git.sinergise.com/team-6/eobrowser3/-/issues/1135)