### PR TITLE
Only include date in time without range format

### DIFF
--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -158,7 +158,7 @@ function getQueryParams(
   }
 
   if (!params.fromTime) {
-    queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z';
+    queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DD');
   } else {
     queryParams.time = `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
       .utc(params.toTime)


### PR DESCRIPTION
#261 

For WMS requests without time range, only date is is included. 
