### PR TITLE
Feature/handle date range with null

### DIFF
--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -10,9 +10,9 @@ import { StatisticalApiResponse } from '../statistics/const';
  */
 export type GetMapParams = {
   bbox: BBox;
-  /** Start of the time interval for which the images are fetched. We can not guarantee that BYOYCLayer has a sensingTime defined */
+  /** Start of the time interval for which the images are fetched. We can not guarantee that BYOCLayer has a sensingTime defined */
   fromTime: Date | null;
-  /** End of the time interval for which the images are fetched. We can not guarantee that BYOYCLayer has a sensingTime defined */
+  /** End of the time interval for which the images are fetched. We can not guarantee that BYOCLayer has a sensingTime defined */
   toTime: Date | null;
   format: MimeType | FormatJpegOrPng;
   resx?: string; // either resx + resy or width + height must be specified

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -10,10 +10,10 @@ import { StatisticalApiResponse } from '../statistics/const';
  */
 export type GetMapParams = {
   bbox: BBox;
-  /** Start of the time interval for which the images are fetched. If null, only `toTime` parameter will be used. */
+  /** Start of the time interval for which the images are fetched. We can not guarantee that BYOYCLayer has a sensingTime defined */
   fromTime: Date | null;
-  /** End of the time interval for which the images are fetched. If `fromTime` is null, only this parameter will be used to set time. */
-  toTime: Date;
+  /** End of the time interval for which the images are fetched. We can not guarantee that BYOYCLayer has a sensingTime defined */
+  toTime: Date | null;
   format: MimeType | FormatJpegOrPng;
   resx?: string; // either resx + resy or width + height must be specified
   resy?: string;

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -109,8 +109,8 @@ export function createProcessingPayload(
         {
           dataFilter: {
             timeRange: {
-              from: params.fromTime.toISOString(),
-              to: params.toTime.toISOString(),
+              from: params.fromTime?.toISOString(),
+              to: params.toTime?.toISOString(),
             },
             mosaickingOrder: mosaickingOrder ? mosaickingOrder : MosaickingOrder.MOST_RECENT,
           },

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -157,12 +157,16 @@ function getQueryParams(
     queryParams.format = params.format as MimeType;
   }
 
-  if (!params.fromTime) {
-    queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DD');
-  } else {
+  // time is an optional param, and sentinelhub will atleast return the latest image if time=none https://docs.sentinel-hub.com/api/latest/api/ogc/wms/
+  // set time range with fromTime and toTime
+  if (params.fromTime !== null && params.toTime !== null) {
     queryParams.time = `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
       .utc(params.toTime)
       .format('YYYY-MM-DDTHH:mm:ss') + 'Z'}`;
+  }
+  // Only toTime available. Requesting a single value for TIME parameter is deprecated
+  if (params.fromTime === null && params.toTime !== null) {
+    queryParams.time =  moment.utc(params.toTime).format('YYYY-MM-DD');
   }
 
   if (params.width && params.height) {

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -166,7 +166,7 @@ function getQueryParams(
   }
   // Only toTime available. Requesting a single value for TIME parameter is deprecated
   if (params.fromTime === null && params.toTime !== null) {
-    queryParams.time =  moment.utc(params.toTime).format('YYYY-MM-DD');
+    queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DD');
   }
 
   if (params.width && params.height) {

--- a/src/layer/wms.ts
+++ b/src/layer/wms.ts
@@ -157,14 +157,14 @@ function getQueryParams(
     queryParams.format = params.format as MimeType;
   }
 
-  // time is an optional param, and sentinelhub will atleast return the latest image if time=none https://docs.sentinel-hub.com/api/latest/api/ogc/wms/
+  // Time is an optional param on Sentinel hub. If it's not provided Sentinel hub will return latest available image. https://docs.sentinel-hub.com/api/latest/api/ogc/wms/
   // set time range with fromTime and toTime
   if (params.fromTime !== null && params.toTime !== null) {
     queryParams.time = `${moment.utc(params.fromTime).format('YYYY-MM-DDTHH:mm:ss') + 'Z'}/${moment
       .utc(params.toTime)
       .format('YYYY-MM-DDTHH:mm:ss') + 'Z'}`;
   }
-  // Only toTime available. Requesting a single value for TIME parameter is deprecated
+  // Other WMS providers may support a single value for TIME parameter, but Sentinel hub WMS service doesn't, so this should be handled in the application.
   if (params.fromTime === null && params.toTime !== null) {
     queryParams.time = moment.utc(params.toTime).format('YYYY-MM-DD');
   }


### PR DESCRIPTION
Creating a batch job with `cogOutput: true`  will result in the creation of a collection where the `sensingTime=null`. The resulting calls to the catalog api(getTiles) will then return `sensingTime: moment(null)`, it would have been ideal to change this to `sensingTime: dateTime === null ? null : moment(dateTime)`, but this might lead to braking changes.

This pull request does not aim at fixing the return values for `getTiles`, but rather adds support for requesting images where `fromTime` and `toTime` can be `null` in `BoycLayer`


 [Batch-api docs](https://docs.sentinel-hub.com/api/latest/reference/#tag/batch_process/operation/createNewBatchProcessingRequest)