### PR TITLE
Fix / remove biweekly and monthly subscription IDs for Planet ARPS

### DIFF
--- a/src/dataimport/const.ts
+++ b/src/dataimport/const.ts
@@ -79,8 +79,6 @@ export enum PlanetARPSType {
 
 export enum PlanetARPSId {
   PS_ARD_SR_DAILY = 'PS_ARD_SR_DAILY',
-  PS_ARD_SR_BIWEEKLY = 'PS_ARD_SR_BIWEEKLY',
-  PS_ARD_SR_MONTHLY = 'PS_ARD_SR_MONTHLY',
 }
 
 export enum PlanetPVType {


### PR DESCRIPTION
Planet ARPS biweekly and monthly subscriptions are not available. They might become available again - this can be reverted at that point.