### PR TITLE
call fetchEvalscriptUrlIfNeeded in BYOCLayer.getMap()

### DIFF
--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -134,6 +134,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
   public async getMap(params: GetMapParams, api: ApiType, reqConfig?: RequestConfiguration): Promise<Blob> {
     return await ensureTimeout(async (innerReqConfig) => {
       params = await this.decideJpegOrPng(params, innerReqConfig);
+      await this.fetchEvalscriptUrlIfNeeded(innerReqConfig);
       await this.updateLayerFromServiceIfNeeded(innerReqConfig);
       return await super.getMap(params, api, innerReqConfig);
     }, reqConfig);


### PR DESCRIPTION
Call `fetchEvalscriptUrlIfNeeded` in `BYOCLayer.getMap()`, same as in `AbstractSentinelHubV3Layer`, so that when only an `evalscriptUrl` is provided to the `BYOCLayer.getMap()`, it gets the evalscript automatically.