### PR TITLE
Location support fix

### DIFF
--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -114,10 +114,21 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
       }
 
       if (this.locationId === null) {
-        this.locationId =
-          (Object.entries(SHV3_LOCATIONS_ROOT_URL).find(
-            ([, url]) => url === this.shServiceRootUrl,
-          )?.[0] as LocationIdSHv3) ?? LocationIdSHv3.awsEuCentral1;
+        if (this.subType !== BYOCSubTypes.ZARR) {
+          const url = `${this.getSHServiceRootUrl()}api/v1/metadata/collection/${this.getTypeId()}`;
+          const headers = { Authorization: `Bearer ${getAuthToken()}` };
+          const res = await axios.get(url, {
+            responseType: 'json',
+            headers: headers,
+            ...getAxiosReqParams(innerReqConfig, CACHE_CONFIG_30MIN),
+          });
+
+          this.locationId = res.data.location.id;
+        } else {
+          // Obtaining location ID is currently not possible for ZARR.
+          // We hardcode AWS EU as the only currently supported location.
+          this.locationId = LocationIdSHv3.awsEuCentral1;
+        }
       }
     }, reqConfig);
   }

--- a/src/layer/BYOCLayer.ts
+++ b/src/layer/BYOCLayer.ts
@@ -115,7 +115,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
 
       if (this.locationId === null) {
         if (this.subType !== BYOCSubTypes.ZARR) {
-          const url = `${this.getSHServiceRootUrl()}api/v1/metadata/collection/${this.getTypeId()}`;
+          const url = `${this.getSHServiceRootUrl()}api/v1/byoc/global/?ids=${this.collectionId}`;
           const headers = { Authorization: `Bearer ${getAuthToken()}` };
           const res = await axios.get(url, {
             responseType: 'json',
@@ -123,7 +123,7 @@ export class BYOCLayer extends AbstractSentinelHubV3Layer {
             ...getAxiosReqParams(innerReqConfig, CACHE_CONFIG_30MIN),
           });
 
-          this.locationId = res.data.location.id;
+          this.locationId = res.data.data.find((item: any) => item.id === this.collectionId)?.location;
         } else {
           // Obtaining location ID is currently not possible for ZARR.
           // We hardcode AWS EU as the only currently supported location.

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -171,7 +171,7 @@ export const SHV3_LOCATIONS_ROOT_URL: Record<LocationIdSHv3, string> = {
   [LocationIdSHv3.awsUsWest2]: 'https://services-uswest2.sentinel-hub.com/',
   [LocationIdSHv3.creo]: 'https://creodias.sentinel-hub.com/',
   [LocationIdSHv3.mundi]: 'https://shservices.mundiwebservices.com/',
-  [LocationIdSHv3.gcpUsCentral1]: 'https://services-gcp-us-central1.sentinel-hub.com/',
+  [LocationIdSHv3.gcpUsCentral1]: 'https://services-gcp.sentinel-hub.com/',
   [LocationIdSHv3.cdse]: 'https://sh.dataspace.copernicus.eu/',
   [LocationIdSHv3.cdseOtc]: 'https://sh-otc.dataspace.copernicus.eu/',
 };


### PR DESCRIPTION
- re-enables reading location id for BYOC from the API
- updates GCP service location url

https://hello.planet.com/code/sentinel-hub/sentinel-frontend/pip-browser/-/issues/238