### PR TITLE
Fix Get Capabilities request

### DIFF
--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -128,7 +128,8 @@ export async function fetchGetCapabilitiesJson(
     ...getAxiosReqParams(reqConfig, CACHE_CONFIG_30MIN),
   };
   const res = await axios.get(url, axiosReqConfig);
-  return res.data.layers;
+  const resData = typeof res.data === 'string' ? JSON.parse(res.data) : res.data;
+  return resData.layers;
 }
 
 export async function fetchGetCapabilitiesJsonV1(


### PR DESCRIPTION
- Parse JSON when string is returned. This is a fallback for when incorrect response type is set.