### PR TITLE
OGC getCapabilities response update 

### DIFF
--- a/src/layer/__tests__/LayersFactory.ts
+++ b/src/layer/__tests__/LayersFactory.ts
@@ -118,7 +118,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -130,7 +130,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -143,7 +143,7 @@ describe('Test endpoints for getting layers parameters', () => {
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
         //not authenticated
-        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -167,7 +167,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 401 }, { code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://services.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
 
@@ -180,7 +180,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -192,7 +192,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -205,7 +205,7 @@ describe('Test endpoints for getting layers parameters', () => {
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
         //not authenticated
-        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -229,7 +229,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 401 }, { code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
 
@@ -242,7 +242,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://creodias.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://creodias.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
 
@@ -268,7 +268,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://sh.dataspace.copernicus.eu/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
 
@@ -294,7 +294,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://services-uswest2.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://services-uswest2.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [
@@ -306,7 +306,7 @@ describe('Test endpoints for getting layers parameters', () => {
       },
       [{ code: 200, data: { layers: [] } }],
       function expectedEndpoint(instanceId: string): string {
-        return `https://creodias.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson`;
+        return `https://creodias.sentinel-hub.com/ogc/wms/${instanceId}?request=GetCapabilities&format=application%2Fjson&endpoint_filter=false`;
       },
     ],
     [

--- a/src/layer/utils.ts
+++ b/src/layer/utils.ts
@@ -55,11 +55,23 @@ export type GetCapabilitiesXmlLayer = {
 };
 
 export function createGetCapabilitiesXmlUrl(baseUrl: string, ogcServiceType: OgcServiceTypes): string {
-  const defaultQueryParams = {
+  type DefaultQueryParams = {
+    service: OgcServiceTypes;
+    request: string;
+    format: string;
+    endpoint_filter?: string;
+  };
+
+  const defaultQueryParams: DefaultQueryParams = {
     service: ogcServiceType,
     request: 'GetCapabilities',
     format: 'text/xml',
   };
+
+  const urlObj = new URL(baseUrl);
+  if (SH_SERVICE_HOSTNAMES_V3.includes(`${urlObj.origin}/`)) {
+    defaultQueryParams.endpoint_filter = 'false';
+  }
 
   const { url, query } = parseUrl(baseUrl);
   return stringifyUrl({ url: url, query: { ...defaultQueryParams, ...query } }, { sort: false });
@@ -117,10 +129,22 @@ export async function fetchGetCapabilitiesJson(
   baseUrl: string,
   reqConfig: RequestConfiguration,
 ): Promise<any[]> {
-  const query = {
+  type QueryParams = {
+    request: string;
+    format: string;
+    endpoint_filter?: string;
+  };
+
+  const query: QueryParams = {
     request: 'GetCapabilities',
     format: 'application/json',
   };
+
+  const urlObj = new URL(baseUrl);
+  if (SH_SERVICE_HOSTNAMES_V3.includes(`${urlObj.origin}/`)) {
+    query.endpoint_filter = 'false';
+  }
+
   const queryString = stringify(query, { sort: false });
   const url = `${baseUrl}?${queryString}`;
   const axiosReqConfig: AxiosRequestConfig = {


### PR DESCRIPTION
Add `endpoint_filter=false` query param for OGC WMS `getCapabilities` request to keep same behaviour of `sh.js` despite change in default behaviour on SH WMS endpoint.

[internal issue](https://hello.planet.com/code/sentinel-hub/sentinel-frontend/pip-browser/-/issues/273)