### PR TITLE
use process api v1 also for advanced evalscripts

### DIFF
--- a/src/layer/AbstractSentinelHubV3Layer.ts
+++ b/src/layer/AbstractSentinelHubV3Layer.ts
@@ -233,12 +233,7 @@ export class AbstractSentinelHubV3Layer extends AbstractLayer {
         // allow subclasses to update payload with their own parameters:
         const updatedPayload = await this._updateProcessingGetMapPayload(payload, 0, innerReqConfig, params);
         const shServiceHostname = this.getShServiceHostname();
-        let blob = await processingGetMap(
-          shServiceHostname,
-          updatedPayload,
-          innerReqConfig,
-          Boolean(params.evalscriptId),
-        );
+        let blob = await processingGetMap(shServiceHostname, updatedPayload, innerReqConfig);
 
         // apply effects:
         // support deprecated GetMapParams.gain and .gamma parameters

--- a/src/layer/processing.ts
+++ b/src/layer/processing.ts
@@ -170,7 +170,6 @@ export async function processingGetMap(
   shServiceHostname: string,
   payload: ProcessingPayload,
   reqConfig: RequestConfiguration,
-  useV2?: boolean,
 ): Promise<Blob> {
   const authToken = reqConfig && reqConfig.authToken ? reqConfig.authToken : getAuthToken();
   if (!authToken) {
@@ -187,10 +186,6 @@ export async function processingGetMap(
     responseType: typeof window !== 'undefined' && window.Blob ? 'blob' : 'arraybuffer',
     ...getAxiosReqParams(reqConfig, CACHE_CONFIG_30MIN),
   };
-  const response = await axios.post(
-    `${shServiceHostname}api/${useV2 ? 'v2' : 'v1'}/process`,
-    payload,
-    requestConfig,
-  );
+  const response = await axios.post(`${shServiceHostname}api/v1/process`, payload, requestConfig);
   return response.data;
 }


### PR DESCRIPTION
Advanced evalscripts should work on both Process API V1 and V2.

part of  [internal issue](https://hello.planet.com/code/sentinel-hub/sentinel-frontend/pip-browser/-/issues/280)

related to https://github.com/sentinel-hub/sentinelhub-js/pull/306