### PR TITLE
feat: add image/webp to MimeType and MimeTypes

### DIFF
--- a/src/layer/AbstractLayer.ts
+++ b/src/layer/AbstractLayer.ts
@@ -135,6 +135,7 @@ export class AbstractLayer {
       if (
         params.format !== MimeTypes.JPEG &&
         params.format !== MimeTypes.PNG &&
+        params.format !== MimeTypes.WEBP &&
         params.format !== MimeTypes.JPEG_OR_PNG
       ) {
         throw new Error(
@@ -142,8 +143,10 @@ export class AbstractLayer {
             params.format +
             ' not supported, only ' +
             MimeTypes.PNG +
-            ' and ' +
+            ', ' +
             MimeTypes.JPEG +
+            ' and ' +
+            MimeTypes.WEBP +
             ' are allowed',
         );
       }

--- a/src/layer/__tests__/getHugeMap.ts
+++ b/src/layer/__tests__/getHugeMap.ts
@@ -15,6 +15,8 @@ test('getHugeMap should throw an error when format is not supported', async () =
   try {
     await layer.getHugeMap(getMapParams, ApiType.PROCESSING);
   } catch (e) {
-    expect(e.message).toBe('Format image/tiff not supported, only image/png and image/jpeg are allowed');
+    expect(e.message).toBe(
+      'Format image/tiff not supported, only image/png, image/jpeg and image/webp are allowed',
+    );
   }
 });

--- a/src/layer/const.ts
+++ b/src/layer/const.ts
@@ -129,6 +129,7 @@ export type MimeType =
   | 'text/xml'
   | 'image/png'
   | 'image/jpeg'
+  | 'image/webp'
   | 'image/tiff'
   | 'image/tiff;depth=8'
   | 'image/tiff;depth=16'
@@ -139,6 +140,7 @@ export type FormatJpegOrPng = 'JPEG_OR_PNG';
 export const MimeTypes: Record<string, MimeType | FormatJpegOrPng> = {
   JPEG: 'image/jpeg',
   PNG: 'image/png',
+  WEBP: 'image/webp',
   JPEG_OR_PNG: 'JPEG_OR_PNG',
 };
 


### PR DESCRIPTION
## Summary

Adds `image/webp` as a supported output format in sentinelhub-js.

  - Added `'image/webp'` to the `MimeType` union type in `src/layer/const.ts`
  - Added `WEBP: 'image/webp'` to the `MimeTypes` constant
  - Added `MimeTypes.WEBP` to the `getHugeMap()` format whitelist in `AbstractLayer.ts`

## Context

The Sentinel Hub Processing API already supports `image/webp` as an output format. WebP files are significantly smaller than PNG files, which improves tile load performance. This change exposes the format as a first-class constant, allowing consumers of this library to use `MimeTypes.WEBP`.

gitlab issue: https://hello.planet.com/code/solution-enablement/cdse-frontend/cdse/copernicus-browser/-/issues/854